### PR TITLE
Add timeouts configuration for data source connections

### DIFF
--- a/config/loader.py
+++ b/config/loader.py
@@ -216,6 +216,50 @@ def normalize_config(data: dict[str, Any]) -> dict[str, Any]:
         "grace_for_running_status": grace,
     }
 
+    # Timeouts for data source connections (global defaults; per-target overrides applied below)
+    timeout_cfg = data.get("timeouts") or {}
+    _connect = timeout_cfg.get("connect_seconds", 25)
+    _read = timeout_cfg.get("read_seconds", 90)
+    try:
+        _connect = max(1, int(_connect))
+    except (TypeError, ValueError):
+        _connect = 25
+    try:
+        _read = max(1, int(_read))
+    except (TypeError, ValueError):
+        _read = 90
+    out["timeouts"] = {"connect_seconds": _connect, "read_seconds": _read}
+
+    # Per-target timeout overrides: merge global timeouts with optional target.connect_timeout,
+    # target.read_timeout, or target.timeout (single value for both). Target overrides global when set.
+    global_connect = out["timeouts"]["connect_seconds"]
+    global_read = out["timeouts"]["read_seconds"]
+    for t in out.get("targets") or []:
+        if not isinstance(t, dict):
+            continue
+        target_connect = t.get("connect_timeout_seconds") or t.get("connect_timeout")
+        target_read = t.get("read_timeout_seconds") or t.get("read_timeout")
+        single = t.get("timeout")
+        if single is not None:
+            try:
+                single = max(1, int(single))
+            except (TypeError, ValueError):
+                single = None
+        if single is not None:
+            if target_connect is None:
+                target_connect = single
+            if target_read is None:
+                target_read = single
+        for _name, _val in (("connect_timeout_seconds", target_connect), ("read_timeout_seconds", target_read)):
+            if _val is not None:
+                try:
+                    _val = max(1, int(_val))
+                except (TypeError, ValueError):
+                    _val = global_connect if _name == "connect_timeout_seconds" else global_read
+            else:
+                _val = global_connect if _name == "connect_timeout_seconds" else global_read
+            t[_name] = _val
+
     # Parallel/sequential
     out["scan"] = data.get("scan", {})
     if "max_workers" not in out["scan"]:

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -21,6 +21,11 @@ scan:
   # Parallel targets: 1 = sequential (minimal), 2–4 for many DB/FS targets (I/O-bound; network/disk are the bottleneck)
   max_workers: 1
 
+# Optional: connection/read timeouts (seconds). Per-target overrides: connect_timeout, read_timeout, or timeout on each target (see docs/USAGE.md).
+# timeouts:
+#   connect_seconds: 25
+#   read_seconds: 90
+
 # Optional: ML/DL training terms for sensitivity detection (see docs/SENSITIVITY_DETECTION.md).
 # Uncomment and set paths, or use inline sensitivity_detection.ml_terms / dl_terms.
 # ml_patterns_file: /data/config/ml_terms.yaml

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -298,7 +298,7 @@ CLI uses the path you pass with `--config` (e.g. `config.yaml`). For the **web s
 ### Config file location and shape
 
 - **Location:** Any path; typical names: `config.yaml`, `config/config.json`. Legacy `config/config.json` with `databases` and `file_scan.directories` is normalized automatically.
-- **Root keys:** `targets`, `file_scan`, `report`, `api`, `sqlite_path`, `scan`, **`rate_limit`**, optional `ml_patterns_file`, `dl_patterns_file`, `regex_overrides_file`, `sensitivity_detection`, `learned_patterns`.
+- **Root keys:** `targets`, `file_scan`, `report`, `api`, `sqlite_path`, `scan`, **`rate_limit`**, **`timeouts`**, optional `ml_patterns_file`, `dl_patterns_file`, `regex_overrides_file`, `sensitivity_detection`, `learned_patterns`.
 
 ### Sensitivity detection: ML and DL training terms
 
@@ -342,6 +342,40 @@ rate_limit:
 
 - The CLI uses the same logic only to print **warnings** (it never exits with 429). This lets you keep existing scripts working while seeing when your policies would reject extra scans if called via API or dashboard.
 - Settings can also be overridden with environment variables: `RATE_LIMIT_ENABLED`, `RATE_LIMIT_MAX_CONCURRENT_SCANS`, `RATE_LIMIT_MIN_INTERVAL_SECONDS`, `RATE_LIMIT_GRACE_FOR_RUNNING_STATUS`.
+
+### Timeouts for data source connections
+
+You can configure connection and read timeouts (in seconds) used when opening and reading from databases, APIs, or other targets. Global defaults apply to all targets; individual targets can override them.
+
+```yaml
+timeouts:
+  connect_seconds: 25   # default: 25 — max time to establish a connection
+  read_seconds: 90      # default: 90 — max time to wait for read/response
+```
+
+- **Per-target overrides:** On any target you can set `connect_timeout`, `read_timeout`, or a single `timeout` (used for both connect and read when the other is not set). Target values override the global timeouts when present. Values are in seconds and are clamped to at least 1.
+
+Example (global defaults plus one slower target):
+
+```yaml
+timeouts:
+  connect_seconds: 25
+  read_seconds: 90
+
+targets:
+  - name: fast-db
+    type: database
+    # uses 25 / 90
+  - name: slow-api
+    type: api
+    connect_timeout: 60
+    read_timeout: 120
+  - name: legacy
+    type: database
+    timeout: 45   # 45 for both connect and read
+```
+
+Connectors use the merged values (global or per-target) when opening connections and performing I/O; see the config schema and connector documentation for details.
 
 ### API and security (CSP, headers)
 

--- a/docs/USAGE.pt_BR.md
+++ b/docs/USAGE.pt_BR.md
@@ -236,6 +236,7 @@ Esse endpoint procura, entre os arquivos `audit_YYYYMMDD.log` disponíveis (do m
 - `api` – porta da API; opcionalmente `require_api_key`, `api_key` ou `api_key_from_env` para exigir chave de API (cabeçalho X-API-Key ou Authorization: Bearer); GET /health permanece público. Ver [SECURITY.md](../SECURITY.md).
 - `sqlite_path` – caminho do banco SQLite com resultados.
 - `scan` – `max_workers` para paralelismo.
+- `timeouts` – timeouts globais para conexões (ex.: `connect_seconds`, `read_seconds`); cada alvo pode sobrescrever com `connect_timeout`, `read_timeout` ou `timeout`. Ver abaixo.
 - `api.workers` – número de workers uvicorn (padrão 1; 2+ para mais requisições concorrentes).
 - Opcionais: `ml_patterns_file`, `dl_patterns_file`, `regex_overrides_file`, `sensitivity_detection` (termos ML/DL inline), `learned_patterns` (export de termos classificados).
 
@@ -271,6 +272,40 @@ rate_limit:
 
 - A CLI usa a mesma lógica apenas para imprimir **avisos** (não muda o código de saída), de forma a manter scripts existentes funcionando enquanto você enxerga quando sua política bloquearia chamadas via API/dashboard.
 - É possível sobrescrever os valores via variáveis de ambiente: `RATE_LIMIT_ENABLED`, `RATE_LIMIT_MAX_CONCURRENT_SCANS`, `RATE_LIMIT_MIN_INTERVAL_SECONDS`, `RATE_LIMIT_GRACE_FOR_RUNNING_STATUS`.
+
+### Timeouts para conexões com fontes de dados
+
+É possível configurar timeouts de conexão e de leitura (em segundos) usados ao abrir e ler bancos, APIs ou outros alvos. Os padrões globais valem para todos os alvos; cada alvo pode sobrescrevê-los.
+
+```yaml
+timeouts:
+  connect_seconds: 25   # padrão 25 — tempo máximo para estabelecer conexão
+  read_seconds: 90      # padrão 90 — tempo máximo de espera para leitura/resposta
+```
+
+- **Sobrescrita por alvo:** Em qualquer alvo você pode definir `connect_timeout`, `read_timeout` ou um único `timeout` (usado para connect e read quando o outro não for definido). Os valores do alvo sobrescrevem os timeouts globais quando presentes. Valores em segundos; mínimo 1.
+
+Exemplo (padrões globais e um alvo mais lento):
+
+```yaml
+timeouts:
+  connect_seconds: 25
+  read_seconds: 90
+
+targets:
+  - name: fast-db
+    type: database
+    # usa 25 / 90
+  - name: slow-api
+    type: api
+    connect_timeout: 60
+    read_timeout: 120
+  - name: legacy
+    type: database
+    timeout: 45   # 45 para connect e read
+```
+
+Os conectores usam os valores mesclados (global ou por alvo) ao abrir conexões e fazer I/O; veja o esquema do config e a documentação dos conectores.
 
 ### API e segurança (CSP, cabeçalhos)
 


### PR DESCRIPTION
Introduce global timeout settings for connection and read operations in the configuration. Allow per-target overrides for connect and read timeouts, enhancing flexibility in managing data source connections. Update documentation to reflect the new timeout options and provide examples for clarity.

## Description
Brief description of the change and why it is needed.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [x] Refactor / maintenance
- [ ] Other (describe):

## Checklist
- [x] Tests pass locally (`uv run pytest`).
- [x] Lint passes (`uv run ruff check .`) and no new linter/format issues.
- [x] Docs/README updated if behaviour or setup changed.
- [x] Security-sensitive changes: considered impact and SECURITY.md (e.g. dependency changes, config, auth).

## Related issues
Fixes (issue number) (if applicable).
