### PR TITLE
feat: add plans status dashboard automation and drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
+      - name: Check plans status dashboard is fresh
+        run: python scripts/plans-stats.py --check
+
       - name: Ruff check
         run: uv run ruff check .
       - name: Ruff format

--- a/docs/plans/PLANS_TODO.md
+++ b/docs/plans/PLANS_TODO.md
@@ -10,6 +10,32 @@ This document is the **single source of truth** for the project's plan status an
 
 **Policy:** When implementing a plan step, **update documentation** (USAGE, TECH_GUIDE, SECURITY, or dedicated docs) and **add or run tests** as the feature is implemented. After completing or adding to-dos, **update this file and the plan file** so progress is tracked in one place. All steps are intended to be **non-destructive**, **non-regression**, and **tested** before marking done.
 
+## Status taxonomy (horizon + urgency)
+
+Use these tags in headings to keep priorities explicit and machine-countable:
+
+- Horizons: `[H0]` must-do-now, `[H1]` short-term, `[H2]` medium-term, `[H3]` long-term/production-ready milestone, `[H4]` far horizon (post-lato/master's scenario), `[H5]` dream horizon (PhD thesis scenario).
+- Urgency: `[U0]` security/safety now, `[U1]` low-AI/high-gain soon, `[U2]` not critical next, `[U3]` backlog/catalogue.
+
+<!-- PLANS_STATUS_DASHBOARD:START -->
+## Status dashboard (auto-generated)
+
+Do not edit this block manually; refresh with `python scripts/plans-stats.py --write`.
+
+- **Status rows counted:** 87  (Done: 43 | Incomplete: 44)
+- **Incomplete breakdown:** Pending `⬜`=42, Tracked `🔄`=2, Under consideration=0, Backlog-marked rows=1
+
+| Horizon | Total rows | Done | Incomplete |
+| ------- | ----------: | ----: | ----------: |
+| `H0` | 19 | 16 | 3 |
+| `H1` | 0 | 0 | 0 |
+| `H2` | 0 | 0 | 0 |
+| `H3` | 68 | 27 | 41 |
+| `H4` | 0 | 0 | 0 |
+| `H5` | 0 | 0 | 0 |
+| `UNSPECIFIED` | 0 | 0 | 0 |
+<!-- PLANS_STATUS_DASHBOARD:END -->
+
 **Plan status:** Corporate compliance ✅ · Minor data detection ✅ · Aggregated identification ✅ · Sensitive categories ML/DL ✅ · Rate limiting ✅ · Web hardening ✅ · Logo and naming ✅ · **Security hardening** ✅ Done (Tier 1) · **Secrets/vault** ✅ Phase A done (Tier 1) · **Configurable timeouts** ✅ Done · **Commercial licensing (runtime + docs + issuer bootstrap)** ✅ Phase 1 in repo (see `docs/LICENSING_SPEC.md`, `core/licensing/`); operational hardening ⬜ Priority band A · **Version check & self-upgrade** ⬜ Not started · **Additional compliance samples** ✅ Done · **Compliance standards alignment (ISO/IEC 27701, FELCA)** ✅ Done (doc only) · **Additional detection techniques & FN reduction** 🔄 Slices 1–3 done (+ optional `fuzzy_column_match` / `FUZZY_COLUMN_MATCH`); next: plan §4 format hints / aggregated wording, etc. · **Compressed files** ✅ Done (steps 1–12; follow-ups 13–14 optional) · **Content type & cloaking detection** ✅ Core plan done (optional: man pages / OpenAPI examples) · **Data source versions & hardening** ⬜ Not started · **Strong crypto & controls validation** ⬜ Not started · **CNPJ alphanumeric format validation** ✅ Phase 4 done (Phase 5 checksum future) · **Selenium QA test suite** ⬜ Not started · **Synthetic data & confidence validation** ⬜ Not started · **Notifications (off-band + scan-complete)** ⬜ Not started · **Dashboard i18n** ⬜ Under consideration · **SAP connector** ⬜ Not started · **Additional data soup formats** ⬜ Backlog (catalogue)
 
 ### Commercial licensing — future reminder (partner / tiered SKUs)
@@ -77,7 +103,7 @@ The list below is ordered for the current billing cycle, with a focus on:
 - **AI-heavy** tasks where the agent’s help is most valuable.
 - **Manual-friendly** tasks that you can do largely by hand or with existing tooling.
 
-### Priority band A — Safety, security, IP exposure, profitability (sequence when critical)
+### H0/U0 Priority band A — Safety, security, IP exposure, profitability (sequence when critical)
 
 Complete **in order** when you need to reduce public artifact exposure or tighten commercial posture **before** burning tokens on large feature work. Most steps are **manual on GitHub/Docker Hub** + short doc updates; use the agent for checklists, scripts, and repo docs.
 
@@ -170,7 +196,7 @@ Tighten runtime defaults for the API host. Implemented: default `127.0.0.1`, opt
 - **pt-BR translation review:** When syncing EN → pt-BR, review for **naturalness** and meaning-equivalent wording; avoid overly literal transposition that can sound artificial. Schedule a pass over key docs (README.pt_BR, USAGE.pt_BR, DEPLOY.pt_BR, SENSITIVITY_DETECTION.pt_BR, etc.) when capacity allows.
 - **Legacy branches cleanup reminder:** When we have maintenance time, tidy `python2-lgpd-crawler-legacy-and-history-only` branches (verify no active work depends on them, then delete/close/retire them).
 
-### A. Near-term focus (current billing cycle)
+### H1/U1 A. Near-term focus (current billing cycle)
 
 0. **Home lab validation (order –1L)** *(manual, high gain for prod readiness)* — After Dependabot/Scout are under control, execute [HOMELAB_VALIDATION.md](../HOMELAB_VALIDATION.md) on a second machine; no feature code unless you document a gap. Prefer this **before** staking reputation on “it runs anywhere” demos.
 
@@ -198,7 +224,7 @@ Tighten runtime defaults for the API host. Implemented: default `127.0.0.1`, opt
    - Use AI for: notifications config shape, notifier interface, initial message templates for CI/script usage.
    - Do manually: notifier module, config parsing, basic docs and examples; later phases after reset.
 
-### B. Deferred to after billing reset (or if on-demand spend is enabled)
+### H2/U2 B. Deferred to after billing reset (or if on-demand spend is enabled)
 
 0. **Wabbix backlog (token-aware, non-blocking)** — **W-KPI:** release/CI KPI view. (W-CONTRACT already covered by existing contract tests for reports + OpenAPI responses.) Pick one small slice when maintenance is green.
 1. **Secrets vault – Phase B** – full vault implementation, re-import CLI/web, optional remove-from-config, and key management docs.
@@ -208,11 +234,14 @@ Tighten runtime defaults for the API host. Implemented: default `127.0.0.1`, opt
 5. **SAP connector** – research, connector module for HANA/OData/RFC, docs and tests.
 6. **Dashboard i18n** – routing and translation strategy decision, then implementation.
 
-### C. Backlog (catalogue)
+### H3/U3 C. Backlog (catalogue)
 
 **Additional data soup formats:** [PLAN_ADDITIONAL_DATA_SOUP_FORMATS.md](PLAN_ADDITIONAL_DATA_SOUP_FORMATS.md) – additional formats (epub, parquet, avro, dbf) and rich media / steganography containers (images, audio, video). Prioritise after compressed + content-type; stego as optional future phase.
 
 **Brand micro-copy reminder (dashBOARd):** Revisit whether/how to label the **web dashboard** with the recommended sub-brand nickname `dashBOARd` (while keeping the decision-maker pitch unchanged). Keep changes low-noise and professional: prefer page title/header parenthetical (and minimal doc mentions in technical overview / USAGE / TECH_GUIDE). If we apply it, also update version bump / release notes accordingly. Status: ✅ Implemented (nav + About); revisit on next minor bump if needed.
+
+- **H4/U3 far horizon (post-lato / master's scenario):** Master's degree path and related portfolio milestones can be tracked here when activated. Status: ⬜ Backlog.
+- **H5/U3 dream horizon (PhD thesis scenario):** PhD thesis-aligned research/roadmap items can be tracked here when activated. Status: ⬜ Backlog.
 
 ---
 

--- a/scripts/check-all.ps1
+++ b/scripts/check-all.ps1
@@ -14,6 +14,14 @@ Set-Location $repoRoot
 
 Write-Host "=== check-all: lint + tests ===" -ForegroundColor Cyan
 
+# Keep plan dashboard stats in sync before lint/tests.
+Write-Host "Refreshing plans status dashboard..." -ForegroundColor Yellow
+& python "$repoRoot\scripts\plans-stats.py" --write
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "check-all: FAILED to refresh plans dashboard." -ForegroundColor Red
+    exit $LASTEXITCODE
+}
+
 # Delegate to the existing script so we keep behaviour in one place.
 $argsList = @()
 if ($SkipPreCommit) {

--- a/scripts/plans-stats.py
+++ b/scripts/plans-stats.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""
+Generate and validate an auto-updated "Status dashboard" block in docs/plans/PLANS_TODO.md.
+
+Usage:
+  python scripts/plans-stats.py --write   # refresh block in-place
+  python scripts/plans-stats.py --check   # fail if block is stale
+  python scripts/plans-stats.py --stdout  # print block only
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+START = "<!-- PLANS_STATUS_DASHBOARD:START -->"
+END = "<!-- PLANS_STATUS_DASHBOARD:END -->"
+
+DEFAULT_PATH = Path("docs/plans/PLANS_TODO.md")
+HORIZONS = ("H0", "H1", "H2", "H3", "H4", "H5", "UNSPECIFIED")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Refresh/check PLANS_TODO status dashboard.")
+    p.add_argument("--path", default=str(DEFAULT_PATH), help="Path to PLANS_TODO.md")
+    mode = p.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--write", action="store_true", help="Write refreshed block in file")
+    mode.add_argument("--check", action="store_true", help="Check block is up-to-date")
+    mode.add_argument("--stdout", action="store_true", help="Print generated block")
+    return p.parse_args()
+
+
+def _extract_horizon(heading_line: str) -> str | None:
+    m = re.search(r"\b(H[0-5])\b", heading_line)
+    return m.group(1) if m else None
+
+
+def _is_status_row(line: str) -> bool:
+    if not line.startswith("|"):
+        return False
+    # Skip markdown separators.
+    if re.match(r"^\|\s*-+\s*\|", line):
+        return False
+    return any(token in line for token in ("✅", "⬜", "🔄", "Under consideration"))
+
+
+def compute_stats(text: str) -> dict:
+    current_horizon = "UNSPECIFIED"
+    done = 0
+    incomplete = 0
+    pending = 0
+    tracked = 0
+    under_consideration = 0
+    backlog = 0
+    total_rows = 0
+    by_h_total: dict[str, int] = defaultdict(int)
+    by_h_done: dict[str, int] = defaultdict(int)
+    by_h_incomplete: dict[str, int] = defaultdict(int)
+
+    for line in text.splitlines():
+        if line.startswith("#"):
+            h = _extract_horizon(line)
+            if h:
+                current_horizon = h
+        if not _is_status_row(line):
+            continue
+
+        total_rows += 1
+        by_h_total[current_horizon] += 1
+        row_done = "✅" in line
+        if row_done:
+            done += 1
+            by_h_done[current_horizon] += 1
+        else:
+            incomplete += 1
+            by_h_incomplete[current_horizon] += 1
+            if "⬜" in line:
+                pending += 1
+            if "🔄" in line:
+                tracked += 1
+            if "Under consideration" in line:
+                under_consideration += 1
+            if "Backlog" in line:
+                backlog += 1
+
+    # Ensure all horizons appear in output order.
+    for h in HORIZONS:
+        by_h_total[h] += 0
+        by_h_done[h] += 0
+        by_h_incomplete[h] += 0
+
+    return {
+        "total_rows": total_rows,
+        "done": done,
+        "incomplete": incomplete,
+        "pending": pending,
+        "tracked": tracked,
+        "under_consideration": under_consideration,
+        "backlog": backlog,
+        "by_h_total": dict(by_h_total),
+        "by_h_done": dict(by_h_done),
+        "by_h_incomplete": dict(by_h_incomplete),
+    }
+
+
+def render_dashboard(stats: dict) -> str:
+    lines: list[str] = []
+    lines.append(START)
+    lines.append("## Status dashboard (auto-generated)")
+    lines.append("")
+    lines.append(
+        "Do not edit this block manually; refresh with `python scripts/plans-stats.py --write`."
+    )
+    lines.append("")
+    lines.append(
+        f"- **Status rows counted:** {stats['total_rows']}  "
+        f"(Done: {stats['done']} | Incomplete: {stats['incomplete']})"
+    )
+    lines.append(
+        f"- **Incomplete breakdown:** Pending `⬜`={stats['pending']}, "
+        f"Tracked `🔄`={stats['tracked']}, "
+        f"Under consideration={stats['under_consideration']}, "
+        f"Backlog-marked rows={stats['backlog']}"
+    )
+    lines.append("")
+    lines.append("| Horizon | Total rows | Done | Incomplete |")
+    lines.append("| ------- | ----------: | ----: | ----------: |")
+    for h in HORIZONS:
+        lines.append(
+            f"| `{h}` | {stats['by_h_total'][h]} | {stats['by_h_done'][h]} | {stats['by_h_incomplete'][h]} |"
+        )
+    lines.append(END)
+    return "\n".join(lines)
+
+
+def replace_block(original: str, block: str) -> str:
+    if START in original and END in original:
+        pattern = re.compile(
+            re.escape(START) + r".*?" + re.escape(END), re.DOTALL | re.MULTILINE
+        )
+        return pattern.sub(block, original, count=1)
+    # Insert after the top intro paragraph chunk (before first --- separator), fallback prepend.
+    sep = "\n---\n"
+    idx = original.find(sep)
+    if idx != -1:
+        return original[:idx] + block + "\n\n" + original[idx:]
+    return block + "\n\n" + original
+
+
+def main() -> int:
+    args = parse_args()
+    path = Path(args.path)
+    if not path.exists():
+        print(f"plans-stats: file not found: {path}", file=sys.stderr)
+        return 2
+
+    original = path.read_text(encoding="utf-8")
+    stats = compute_stats(original)
+    block = render_dashboard(stats)
+    refreshed = replace_block(original, block)
+
+    if args.stdout:
+        print(block)
+        return 0
+    if args.write:
+        if refreshed != original:
+            path.write_text(refreshed, encoding="utf-8")
+            print(f"plans-stats: updated {path}")
+        else:
+            print(f"plans-stats: no changes ({path} already up-to-date)")
+        return 0
+    if args.check:
+        if refreshed != original:
+            print(
+                "plans-stats: dashboard is stale. Run: python scripts/plans-stats.py --write",
+                file=sys.stderr,
+            )
+            return 1
+        print("plans-stats: dashboard is up-to-date")
+        return 0
+
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- Add `scripts/plans-stats.py` to generate/check an auto-managed "Status dashboard" block in `docs/plans/PLANS_TODO.md`.
- Add horizon/urgency taxonomy tags (H0..H5 and U0..U3) in `PLANS_TODO.md`, including far-horizon and dream-horizon placeholders.
- Wire freshness checks into local gate (`scripts/check-all.ps1`) and CI (`.github/workflows/ci.yml`) to prevent dashboard drift.

## Test plan
- [x] `python scripts/plans-stats.py --write`
- [x] `python scripts/plans-stats.py --check`
- [x] `.\\scripts\\quick-test.ps1` (326 passed, 2 skipped)

Made with [Cursor](https://cursor.com)