### PR TITLE
chore(maintenance): Dependabot #61 + Docker base pin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # -----------------------------------------------------------------------------
 # Stage 1: build Python extensions and install dependencies
 # -----------------------------------------------------------------------------
-FROM python:3.12-slim AS builder
+FROM python:3.12.13-slim AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential gcc g++ pkg-config \
@@ -24,7 +24,7 @@ RUN pip install --no-cache-dir --upgrade "pip>=25.3" "wheel>=0.46.2" && \
 # -----------------------------------------------------------------------------
 # Stage 2: minimal runtime (no build tools, only runtime libs + app)
 # -----------------------------------------------------------------------------
-FROM python:3.12-slim
+FROM python:3.12.13-slim
 
 LABEL org.opencontainers.image.description="LGPD/GDPR/CCPA audit. Default: web API and frontend on port 8088. Override command for CLI one-shot."
 

--- a/tools/license-studio/go.mod
+++ b/tools/license-studio/go.mod
@@ -2,4 +2,4 @@ module studio.local/shard
 
 go 1.22
 
-require github.com/golang-jwt/jwt/v5 v5.2.1
+require github.com/golang-jwt/jwt/v5 v5.2.2

--- a/tools/license-studio/go.sum
+++ b/tools/license-studio/go.sum
@@ -1,2 +1,2 @@
-github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
-github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=


### PR DESCRIPTION
## Summary
- Apply Dependabot PR #61 update for `tools/license-studio`: `github.com/golang-jwt/jwt/v5` from `5.2.1` to `5.2.2` (`go.mod` + `go.sum`).
- Include optional Docker maintenance slice by pinning both stages in `Dockerfile` from `python:3.12-slim` to `python:3.12.13-slim`.
- Keep scope focused on maintenance without app behavior changes.

## Test plan
- [x] `./scripts/quick-test.ps1` (326 passed, 2 skipped)
- [x] Diff reviewed: only `Dockerfile`, `tools/license-studio/go.mod`, `tools/license-studio/go.sum`
- [ ] Optional after merge: run `docker scout quickview fabioleitao/data_boar:latest` again after next image rebuild/push

Made with [Cursor](https://cursor.com)