### PR TITLE
feat(ops): KPI export helper + report decouple micro-slice

### DIFF
--- a/docs/plans/PLAN_READINESS_AND_OPERATIONS.md
+++ b/docs/plans/PLAN_READINESS_AND_OPERATIONS.md
@@ -94,7 +94,7 @@ Notes:
 
 - Data sources: GitHub PR list/checks + Dependabot alerts/PR timestamps.
 - Keep a small markdown note per release cycle in `docs/releases/X.Y.Z.md` with the latest KPI snapshot.
-- If manual collection starts to drift, automate with a lightweight script in a later slice.
+- Lightweight export script available: `python scripts/kpi-export.py --limit-prs 10` (stdout) or `--out docs/releases/kpi_snapshot.md`.
 
 ---
 

--- a/report/generator.py
+++ b/report/generator.py
@@ -847,6 +847,41 @@ def _enrich_failures(fail_rows: list[dict]) -> list[dict]:
     ]
 
 
+def _aggregated_identification_recommendation_row() -> dict:
+    """Recommendation row for aggregated identification risk (cross-category re-identification)."""
+    return {
+        _REC_DATA_PATTERN: "AGGREGATED_IDENTIFICATION",
+        _REC_BASE_LEGAL: "LGPD Art. 5 (dado pessoal); GDPR Recital 26 (identifiability – combination of data may identify individuals)",
+        _REC_RISCO: (
+            "Dados de múltiplas colunas ou fontes (ex.: gênero, cargo, saúde, endereço, telefone) na mesma tabela/arquivo "
+            "podem permitir identificação ou reidentificação de pessoas. "
+            "A detecção baseia-se em amostras de escaneamento (não no universo completo); tratar como caso especial para DPO e compliance."
+        ),
+        _REC_RECOMENDACAO: (
+            "Avaliar controles de acesso e limitação de finalidade; considerar anonimização ou pseudonimização; "
+            "documentar base legal para o tratamento combinado (LGPD Art. 5; GDPR Recital 26). "
+            "Confirmar manualmente com base nos dados reais, especialmente quando sample_limit for baixo."
+        ),
+        _REC_PRIORIDADE: "ALTA",
+        _REC_RELEVANTE_PARA: "DPO, Compliance, Segurança da Informação",
+    }
+
+
+def _minor_crossref_recommendation_row() -> dict:
+    """Recommendation row when DOB_POSSIBLE_MINOR is cross-referenced with identifier/health findings."""
+    return {
+        _REC_DATA_PATTERN: "DOB_POSSIBLE_MINOR (high confidence – cross-ref)",
+        _REC_BASE_LEGAL: "LGPD Art. 14 (dados de crianças/adolescentes); GDPR Art. 8 (consentimento em serviços da sociedade da informação)",
+        _REC_RISCO: "Mesma tabela/arquivo contém data de nascimento sugerindo menor e dados identificadores ou de saúde; tratar como alta prioridade para DPO.",
+        _REC_RECOMENDACAO: (
+            "Caso especial – dados de menores: confirmar base legal e consentimento (titular ou responsável, conforme a idade e a lei aplicável); "
+            "restringir acesso e retenção ao estritamente necessário; priorizar anonimização ou pseudonimização."
+        ),
+        _REC_PRIORIDADE: _REC_PRIORITY_CRITICA,
+        _REC_RELEVANTE_PARA: "DPO, Compliance, Área jurídica, Segurança da Informação",
+    }
+
+
 def _write_excel_sheets(
     writer: Any,
     session_id: str,
@@ -929,40 +964,9 @@ def _write_excel_sheets(
         recommendation_overrides=overrides if overrides else None,
     )
     if agg_rows:
-        recs.insert(
-            0,
-            {
-                _REC_DATA_PATTERN: "AGGREGATED_IDENTIFICATION",
-                _REC_BASE_LEGAL: "LGPD Art. 5 (dado pessoal); GDPR Recital 26 (identifiability – combination of data may identify individuals)",
-                _REC_RISCO: (
-                    "Dados de múltiplas colunas ou fontes (ex.: gênero, cargo, saúde, endereço, telefone) na mesma tabela/arquivo "
-                    "podem permitir identificação ou reidentificação de pessoas. "
-                    "A detecção baseia-se em amostras de escaneamento (não no universo completo); tratar como caso especial para DPO e compliance."
-                ),
-                _REC_RECOMENDACAO: (
-                    "Avaliar controles de acesso e limitação de finalidade; considerar anonimização ou pseudonimização; "
-                    "documentar base legal para o tratamento combinado (LGPD Art. 5; GDPR Recital 26). "
-                    "Confirmar manualmente com base nos dados reais, especialmente quando sample_limit for baixo."
-                ),
-                _REC_PRIORIDADE: "ALTA",
-                _REC_RELEVANTE_PARA: "DPO, Compliance, Segurança da Informação",
-            },
-        )
+        recs.insert(0, _aggregated_identification_recommendation_row())
     if db_high_keys or fs_high_keys:
-        recs.insert(
-            0,
-            {
-                _REC_DATA_PATTERN: "DOB_POSSIBLE_MINOR (high confidence – cross-ref)",
-                _REC_BASE_LEGAL: "LGPD Art. 14 (dados de crianças/adolescentes); GDPR Art. 8 (consentimento em serviços da sociedade da informação)",
-                _REC_RISCO: "Mesma tabela/arquivo contém data de nascimento sugerindo menor e dados identificadores ou de saúde; tratar como alta prioridade para DPO.",
-                _REC_RECOMENDACAO: (
-                    "Caso especial – dados de menores: confirmar base legal e consentimento (titular ou responsável, conforme a idade e a lei aplicável); "
-                    "restringir acesso e retenção ao estritamente necessário; priorizar anonimização ou pseudonimização."
-                ),
-                _REC_PRIORIDADE: _REC_PRIORITY_CRITICA,
-                _REC_RELEVANTE_PARA: "DPO, Compliance, Área jurídica, Segurança da Informação",
-            },
-        )
+        recs.insert(0, _minor_crossref_recommendation_row())
     pd.DataFrame(recs).to_excel(writer, sheet_name="Recommendations", index=False)
     praise = _praise_rows(db_rows_for_sheets, fs_rows_for_sheets)
     if praise:

--- a/scripts/kpi-export.py
+++ b/scripts/kpi-export.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+Export a small W-KPI markdown snapshot from GitHub data.
+
+Token-aware scope:
+- KPI 1 (auto): CI pass rate across last N merged PRs to main.
+- KPI 2 (semi-auto): Dependabot response latency summary from merged/open Dependabot PRs.
+
+Requires GitHub CLI auth (`gh auth status`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _run_gh_json(args: list[str]) -> Any:
+    proc = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError((proc.stderr or proc.stdout).strip() or "gh call failed")
+    return json.loads(proc.stdout or "null")
+
+
+def _as_dt(value: str | None) -> dt.datetime | None:
+    if not value:
+        return None
+    try:
+        return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _business_days(start: dt.datetime, end: dt.datetime) -> int:
+    if end < start:
+        return 0
+    day = start.date()
+    end_day = end.date()
+    count = 0
+    while day <= end_day:
+        if day.weekday() < 5:
+            count += 1
+        day += dt.timedelta(days=1)
+    return max(0, count - 1)
+
+
+def _compute_ci_pass_rate(prs: list[dict[str, Any]]) -> tuple[int, int, int]:
+    total = len(prs)
+    if total == 0:
+        return 0, 0, 0
+    passed = 0
+    for pr in prs:
+        checks = pr.get("statusCheckRollup") or []
+        # Conservative: if no checks are attached, count as non-passing.
+        if checks and all((c.get("conclusion") or "").upper() == "SUCCESS" for c in checks):
+            passed += 1
+    pct = int(round((passed / total) * 100))
+    return passed, total, pct
+
+
+def _compute_dependabot_latency(prs: list[dict[str, Any]]) -> tuple[str, str]:
+    merged_days: list[int] = []
+    open_count = 0
+    for pr in prs:
+        created = _as_dt(pr.get("createdAt"))
+        merged = _as_dt(pr.get("mergedAt"))
+        if created and merged:
+            merged_days.append(_business_days(created, merged))
+        elif created and not merged:
+            open_count += 1
+    avg = "-" if not merged_days else str(int(round(sum(merged_days) / len(merged_days))))
+    p95 = "-"
+    if merged_days:
+        ordered = sorted(merged_days)
+        idx = max(0, min(len(ordered) - 1, int(round(0.95 * (len(ordered) - 1)))))
+        p95 = str(ordered[idx])
+    return f"{avg} bd (p95: {p95})", str(open_count)
+
+
+def _render_block(
+    ci_passed: int,
+    ci_total: int,
+    ci_pct: int,
+    dep_latency: str,
+    dep_open: str,
+    generated_utc: str,
+) -> str:
+    return "\n".join(
+        [
+            "### W-KPI snapshot (auto export)",
+            "",
+            f"- Generated at (UTC): `{generated_utc}`",
+            "",
+            "| KPI | Current value | Target | Source |",
+            "| --- | --- | --- | --- |",
+            f"| CI pass rate (last merged PRs) | `{ci_passed}/{ci_total}` (`{ci_pct}%`) | `>= 90%` | `gh pr list --state merged --json statusCheckRollup` |",
+            f"| Dependabot response latency (merged) | `{dep_latency}` | `<= 5 business days` | `gh pr list --author app/dependabot` |",
+            f"| Dependabot open PRs | `{dep_open}` | `0-2` (context-dependent) | `gh pr list --state open --author app/dependabot` |",
+            "",
+        ]
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Export W-KPI markdown snapshot.")
+    parser.add_argument("--limit-prs", type=int, default=10, help="Merged PR sample size")
+    parser.add_argument(
+        "--out",
+        type=str,
+        default="",
+        help="Optional output markdown path; prints to stdout when omitted",
+    )
+    args = parser.parse_args()
+
+    merged_prs = _run_gh_json(
+        [
+            "pr",
+            "list",
+            "--state",
+            "merged",
+            "--base",
+            "main",
+            "--limit",
+            str(max(1, args.limit_prs)),
+            "--json",
+            "number,mergedAt,statusCheckRollup",
+        ]
+    )
+    dependabot_prs = _run_gh_json(
+        [
+            "pr",
+            "list",
+            "--state",
+            "all",
+            "--search",
+            "author:app/dependabot",
+            "--limit",
+            "30",
+            "--json",
+            "state,createdAt,mergedAt",
+        ]
+    )
+
+    ci_passed, ci_total, ci_pct = _compute_ci_pass_rate(merged_prs or [])
+    dep_latency, dep_open = _compute_dependabot_latency(dependabot_prs or [])
+    generated_utc = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    block = _render_block(ci_passed, ci_total, ci_pct, dep_latency, dep_open, generated_utc)
+
+    if args.out:
+        out_path = Path(args.out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(block, encoding="utf-8")
+        print(f"kpi-export: wrote {out_path}")
+        return 0
+    print(block)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except RuntimeError as exc:
+        print(f"kpi-export: {exc}", file=sys.stderr)
+        raise SystemExit(2)
+


### PR DESCRIPTION
## Summary
- Add `scripts/kpi-export.py` to export a token-aware W-KPI markdown snapshot from GitHub CLI data.
- Update readiness plan notes to reference the new KPI export helper for optional automation follow-up.
- Apply W-DECOUPLE micro-refactor in `report/generator.py` by extracting recommendation-row helper builders (no intended behavior change).

## Docker step 2 results (already executed)
- Rebuilt image: `docker build -t data_boar:maint-67 .`
- Scout quickview: `docker scout quickview data_boar:maint-67`
- Result: `0C / 2H / 1M / 31L`, base `python:3.12.13-slim`, suggested update `python:3.14.3-slim`.

## Test plan
- [x] `python scripts/kpi-export.py --limit-prs 10`
- [x] `uv run pytest -q tests/test_report_recommendations.py tests/test_report_trends.py`

Made with [Cursor](https://cursor.com)