### PR TITLE
chore(docker): harden wheel upgrade verification in image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,10 @@ WORKDIR /app
 COPY requirements.txt /app/requirements.txt
 
 # Upgrade pip/wheel in builder before deps (Scout: pip<25.3, wheel<=0.46.1 had CVEs; image inherits site-packages).
-RUN pip install --no-cache-dir --upgrade "pip>=25.3" "wheel>=0.46.2" && \
+# Remove any stale wheel metadata first, then assert effective runtime version.
+RUN pip uninstall -y wheel || true && \
+    pip install --no-cache-dir --upgrade "pip>=25.3" "wheel>=0.46.2" && \
+    python -c "import wheel; import sys; sys.exit(0 if tuple(map(int, wheel.__version__.split('.'))) >= (0,46,2) else 1)" && \
     pip install --no-cache-dir -r /app/requirements.txt && \
     find /usr/local/lib/python3.12/site-packages -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null; \
     find /usr/local/lib/python3.12/site-packages -name "*.pyc" -delete 2>/dev/null; true
@@ -42,7 +45,9 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 
 # Re-assert pip/wheel in the runtime layer so Docker Scout does not flag stale tooling copied from
 # older builder caches (CVEs on wheel<=0.46.1, pip<25.3). App deps already live under site-packages.
-RUN pip install --no-cache-dir --upgrade "pip>=25.3" "wheel>=0.46.2"
+RUN pip uninstall -y wheel || true && \
+    pip install --no-cache-dir --upgrade "pip>=25.3" "wheel>=0.46.2" && \
+    python -c "import wheel; import sys; sys.exit(0 if tuple(map(int, wheel.__version__.split('.'))) >= (0,46,2) else 1)"
 
 # Copy application code
 COPY . .


### PR DESCRIPTION
## Summary
- Harden Docker build/runtime wheel handling by removing stale wheel metadata before reinstall.
- Reinstall and assert `wheel>=0.46.2` in both builder and runtime layers.
- Keep scope Docker-only (single-file PR) to avoid accidental format-only churn from check-all autoformat.

## Validation executed
- Build: `docker build -t data_boar:maint-69 c:/Users/fabio/Documents/dev/python3-lgpd-crawler-clean`
- Scout quickview: `data_boar:maint-69` -> `0C / 1H / 1M / 31L`
- Scout cves: JWT high removed; remaining high is `wheel 0.45.1` in Scout package view.
- Gate: `./scripts/check-all.ps1 -SkipPreCommit` passed in clean worktree (326 passed, 2 skipped).
- Smoke: container started and `/health` returned 200 on port 8099.

## Notes
- `check-all` autoformatted unrelated files in the clean worktree; they are intentionally excluded from this PR.

Made with [Cursor](https://cursor.com)