### PR TITLE
style: apply ruff formatting to synced files

### DIFF
--- a/connectors/filesystem_connector.py
+++ b/connectors/filesystem_connector.py
@@ -329,9 +329,7 @@ def _scan_sqlite_file_as_db(
                     except Exception:
                         pass
                     sample = " ".join(sample_parts)
-                    res = scanner.scan_column(
-                        cname, sample, connector_data_type=ctype
-                    )
+                    res = scanner.scan_column(cname, sample, connector_data_type=ctype)
                     if res["sensitivity_level"] == "LOW":
                         continue
                     findings.append(

--- a/connectors/sql_connector.py
+++ b/connectors/sql_connector.py
@@ -241,9 +241,7 @@ class SQLConnector:
     ) -> None:
         """Sample column, run detection, optionally full-scan for minor; save finding and log."""
         sample = self.sample(schema, table, cname)
-        res = self.scanner.scan_column(
-            cname, sample, connector_data_type=ctype
-        )
+        res = self.scanner.scan_column(cname, sample, connector_data_type=ctype)
         res = augment_low_id_like_for_persist(res, cname, self.detection_config)
         if (
             res["sensitivity_level"] == "LOW"

--- a/core/detector.py
+++ b/core/detector.py
@@ -659,11 +659,17 @@ def _format_length_suggests_id_column(column_name: str, char_len: int) -> bool:
     Conservative: 9 (SSN-style), 11 (CPF digits), 14 (CNPJ digits) with name hints to limit FPs.
     """
     col = (column_name or "").lower()
-    if char_len == 9 and ("ssn" in col or "social_sec" in col or "social security" in col):
+    if char_len == 9 and (
+        "ssn" in col or "social_sec" in col or "social security" in col
+    ):
         return True
-    if char_len == 11 and ("cpf" in col or column_name_suggests_identifier_review(column_name)):
+    if char_len == 11 and (
+        "cpf" in col or column_name_suggests_identifier_review(column_name)
+    ):
         return True
-    if char_len == 14 and ("cnpj" in col or column_name_suggests_identifier_review(column_name)):
+    if char_len == 14 and (
+        "cnpj" in col or column_name_suggests_identifier_review(column_name)
+    ):
         return True
     return False
 

--- a/scripts/kpi-export.py
+++ b/scripts/kpi-export.py
@@ -62,7 +62,9 @@ def _compute_ci_pass_rate(prs: list[dict[str, Any]]) -> tuple[int, int, int]:
     for pr in prs:
         checks = pr.get("statusCheckRollup") or []
         # Conservative: if no checks are attached, count as non-passing.
-        if checks and all((c.get("conclusion") or "").upper() == "SUCCESS" for c in checks):
+        if checks and all(
+            (c.get("conclusion") or "").upper() == "SUCCESS" for c in checks
+        ):
             passed += 1
     pct = int(round((passed / total) * 100))
     return passed, total, pct
@@ -78,7 +80,9 @@ def _compute_dependabot_latency(prs: list[dict[str, Any]]) -> tuple[str, str]:
             merged_days.append(_business_days(created, merged))
         elif created and not merged:
             open_count += 1
-    avg = "-" if not merged_days else str(int(round(sum(merged_days) / len(merged_days))))
+    avg = (
+        "-" if not merged_days else str(int(round(sum(merged_days) / len(merged_days))))
+    )
     p95 = "-"
     if merged_days:
         ordered = sorted(merged_days)
@@ -113,7 +117,9 @@ def _render_block(
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Export W-KPI markdown snapshot.")
-    parser.add_argument("--limit-prs", type=int, default=10, help="Merged PR sample size")
+    parser.add_argument(
+        "--limit-prs", type=int, default=10, help="Merged PR sample size"
+    )
     parser.add_argument(
         "--out",
         type=str,
@@ -154,7 +160,9 @@ def main() -> int:
     ci_passed, ci_total, ci_pct = _compute_ci_pass_rate(merged_prs or [])
     dep_latency, dep_open = _compute_dependabot_latency(dependabot_prs or [])
     generated_utc = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
-    block = _render_block(ci_passed, ci_total, ci_pct, dep_latency, dep_open, generated_utc)
+    block = _render_block(
+        ci_passed, ci_total, ci_pct, dep_latency, dep_open, generated_utc
+    )
 
     if args.out:
         out_path = Path(args.out)
@@ -172,4 +180,3 @@ if __name__ == "__main__":
     except RuntimeError as exc:
         print(f"kpi-export: {exc}", file=sys.stderr)
         raise SystemExit(2)
-

--- a/scripts/plans-stats.py
+++ b/scripts/plans-stats.py
@@ -24,10 +24,14 @@ HORIZONS = ("H0", "H1", "H2", "H3", "H4", "H5", "UNSPECIFIED")
 
 
 def parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(description="Refresh/check PLANS_TODO status dashboard.")
+    p = argparse.ArgumentParser(
+        description="Refresh/check PLANS_TODO status dashboard."
+    )
     p.add_argument("--path", default=str(DEFAULT_PATH), help="Path to PLANS_TODO.md")
     mode = p.add_mutually_exclusive_group(required=True)
-    mode.add_argument("--write", action="store_true", help="Write refreshed block in file")
+    mode.add_argument(
+        "--write", action="store_true", help="Write refreshed block in file"
+    )
     mode.add_argument("--check", action="store_true", help="Check block is up-to-date")
     mode.add_argument("--stdout", action="store_true", help="Print generated block")
     return p.parse_args()
@@ -187,4 +191,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/tests/test_aggregated_identification.py
+++ b/tests/test_aggregated_identification.py
@@ -365,7 +365,8 @@ def test_report_contains_aggregated_sheet_and_recommendation(tmp_path):
             assert len(df_agg) >= 2
             assert (
                 "Sample / coverage note" in str(df_agg.iloc[0].get("Target", ""))
-                or "sampled scanning" in str(df_agg.iloc[0].get("Explanation", "")).lower()
+                or "sampled scanning"
+                in str(df_agg.iloc[0].get("Explanation", "")).lower()
             )
             assert (
                 "Target" in df_agg.columns

--- a/tests/test_format_length_hint.py
+++ b/tests/test_format_length_hint.py
@@ -21,23 +21,13 @@ class TestParseDeclaredCharLength(unittest.TestCase):
 
 class TestFormatLengthSuggestsId(unittest.TestCase):
     def test_cpf_and_id_suffix(self):
-        self.assertTrue(
-            _format_length_suggests_id_column("user_cpf", 11)
-        )
-        self.assertTrue(
-            _format_length_suggests_id_column("external_id", 11)
-        )
-        self.assertFalse(
-            _format_length_suggests_id_column("description", 11)
-        )
+        self.assertTrue(_format_length_suggests_id_column("user_cpf", 11))
+        self.assertTrue(_format_length_suggests_id_column("external_id", 11))
+        self.assertFalse(_format_length_suggests_id_column("description", 11))
 
     def test_cnpj(self):
-        self.assertTrue(
-            _format_length_suggests_id_column("company_cnpj", 14)
-        )
-        self.assertTrue(
-            _format_length_suggests_id_column("tax_registration_id", 14)
-        )
+        self.assertTrue(_format_length_suggests_id_column("company_cnpj", 14))
+        self.assertTrue(_format_length_suggests_id_column("tax_registration_id", 14))
 
     def test_ssn(self):
         self.assertTrue(_format_length_suggests_id_column("employee_ssn", 9))
@@ -61,9 +51,7 @@ class TestDetectorFormatHintIntegration(unittest.TestCase):
         self.assertEqual(pat, "GENERAL")
 
     def test_enabled_low_to_medium(self):
-        d = SensitivityDetector(
-            detection_config={"connector_format_id_hint": True}
-        )
+        d = SensitivityDetector(detection_config={"connector_format_id_hint": True})
         level, pat, norm, conf = d.analyze(
             "external_id",
             _neutral_sample_text(),

--- a/tests/test_fuzzy_column_match.py
+++ b/tests/test_fuzzy_column_match.py
@@ -130,12 +130,14 @@ def test_analyze_default_matches_explicit_fuzzy_false():
     d0 = SensitivityDetector(detection_config={})
     d1 = SensitivityDetector(detection_config={"fuzzy_column_match": False})
     for col, sample in cases:
-        assert d0.analyze(col, sample) == d1.analyze(
-            col, sample
-        ), f"mismatch for {col!r}"
+        assert d0.analyze(col, sample) == d1.analyze(col, sample), (
+            f"mismatch for {col!r}"
+        )
 
 
-def test_analyze_fuzzy_true_without_rapidfuzz_same_as_false_when_library_missing(monkeypatch):
+def test_analyze_fuzzy_true_without_rapidfuzz_same_as_false_when_library_missing(
+    monkeypatch,
+):
     """
     If rapidfuzz import fails, fuzzy_column_match: true must not change outcomes vs false.
     """
@@ -154,7 +156,10 @@ def test_analyze_fuzzy_true_without_rapidfuzz_same_as_false_when_library_missing
         detection_config={"fuzzy_column_match": True, "medium_confidence_threshold": 40}
     )
     d_off = SensitivityDetector(
-        detection_config={"fuzzy_column_match": False, "medium_confidence_threshold": 40}
+        detection_config={
+            "fuzzy_column_match": False,
+            "medium_confidence_threshold": 40,
+        }
     )
     assert d_on.analyze(col, sample) == d_off.analyze(col, sample)
 


### PR DESCRIPTION
## Summary
- Apply Ruff formatting normalization to 8 files that drifted from mixed local automation runs.
- Keep this PR style-only (no behavior changes).
- Goal: clean/sync local and remote trees so maintenance/publish flows stay deterministic.

## Validation
- [x] `./scripts/check-all.ps1` passed (ruff + full pytest)
- [x] Scope is lint-only formatting

Made with [Cursor](https://cursor.com)