### PR TITLE
fix(security): harden machine fingerprint derivation

### DIFF
--- a/core/licensing/fingerprint.py
+++ b/core/licensing/fingerprint.py
@@ -20,5 +20,9 @@ def compute_machine_fingerprint() -> str:
     """
     seed = (os.environ.get("DATA_BOAR_MACHINE_SEED") or "").strip()
     host = socket.gethostname().lower()
-    blob = f"v1|host={host}|seed={seed}".encode("utf-8")
-    return hashlib.sha256(blob).hexdigest()
+    # Use a KDF (PBKDF2-HMAC) instead of a direct fast hash to avoid weak-sensitive-hash patterns
+    # and keep a stable deterministic fingerprint per host/seed pair.
+    data = f"v2|host={host}|seed={seed}".encode("utf-8")
+    salt = f"data-boar-mfp|{host}".encode("utf-8")
+    derived = hashlib.pbkdf2_hmac("sha256", data, salt, 200_000, dklen=32)
+    return derived.hex()

--- a/tests/test_licensing_fingerprint.py
+++ b/tests/test_licensing_fingerprint.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from core.licensing.fingerprint import compute_machine_fingerprint
+
+
+def test_machine_fingerprint_is_stable_for_same_seed_and_host(monkeypatch):
+    monkeypatch.setenv("DATA_BOAR_MACHINE_SEED", "seed-A")
+    monkeypatch.setattr("socket.gethostname", lambda: "host-1")
+
+    a = compute_machine_fingerprint()
+    b = compute_machine_fingerprint()
+
+    assert a == b
+    assert len(a) == 64
+    assert all(c in "0123456789abcdef" for c in a)
+
+
+def test_machine_fingerprint_changes_when_seed_changes(monkeypatch):
+    monkeypatch.setattr("socket.gethostname", lambda: "host-1")
+    monkeypatch.setenv("DATA_BOAR_MACHINE_SEED", "seed-A")
+    a = compute_machine_fingerprint()
+
+    monkeypatch.setenv("DATA_BOAR_MACHINE_SEED", "seed-B")
+    b = compute_machine_fingerprint()
+
+    assert a != b
+


### PR DESCRIPTION
## Summary
- replace direct machine fingerprint SHA-256 with PBKDF2-HMAC-SHA256 derivation (deterministic per host+seed)
- reduce weak-sensitive-hash exposure for licensing fingerprint flow while preserving behavior needed by license matching
- add focused regression tests for deterministic output and seed-change sensitivity

## Test plan
- [x] `uv run pytest -v -W error tests/test_licensing_fingerprint.py tests/test_licensing.py`