### PR TITLE
docs(branding): align security and usage wording with Data Boar

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ This document describes which versions of the application are supported, which d
 
 ## Supported versions
 
-- **Application:** `python3-lgpd-crawler` – current development targets **Python 3.12+**.
+- **Application (brand):** **Data Boar**. Package/distribution identifier remains `python3-lgpd-crawler` for compatibility. Current development targets **Python 3.12+**.
 - We aim to support the latest stable minor versions of Python 3.12 and 3.13 on Linux, macOS and Windows.
 - Older Python versions (< 3.12) are not tested and should be considered unsupported.
 

--- a/SECURITY.pt_BR.md
+++ b/SECURITY.pt_BR.md
@@ -6,7 +6,7 @@ Este documento descreve quais versões da aplicação são suportadas, qual linh
 
 ## Versões suportadas
 
-- **Aplicação:** `python3-lgpd-crawler` — o desenvolvimento atual tem como alvo **Python 3.12+**.
+- **Aplicação (marca):** **Data Boar**. O identificador do pacote/distribuição permanece `python3-lgpd-crawler` por compatibilidade. O desenvolvimento atual tem como alvo **Python 3.12+**.
 - Objetivamos suportar as últimas versões estáveis minor do Python 3.12 e 3.13 em Linux, macOS e Windows.
 - Versões antigas do Python (< 3.12) não são testadas e devem ser consideradas não suportadas.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # How to Use Data Boar (LGPD Audit Application)
 
-**Data Boar** is the application name (based on lgpd_crawler technology; engine: python3-lgpd-crawler). This guide covers **command-line arguments and outcomes**, **deploying and using the web API**, **configuration (targets and credentials)**, and **downloading reports** (current and previous sessions). Operators can use it to learn how to run, configure, and navigate the app.
+**Data Boar** is the application name (based on lgpd_crawler technology; package/distribution id: `python3-lgpd-crawler`). This guide covers **command-line arguments and outcomes**, **deploying and using the web API**, **configuration (targets and credentials)**, and **downloading reports** (current and previous sessions). Operators can use it to learn how to run, configure, and navigate the app.
 
 **Português (Brasil):** [USAGE.pt_BR.md](USAGE.pt_BR.md)
 

--- a/docs/USAGE.pt_BR.md
+++ b/docs/USAGE.pt_BR.md
@@ -1,6 +1,6 @@
 # Como usar o Data Boar (aplicação de auditoria LGPD) — pt-BR
 
-**Data Boar** é o nome da aplicação (baseado na tecnologia lgpd_crawler; motor: python3-lgpd-crawler). Este documento complementa o `docs/USAGE.md` em inglês e descreve, em português, como:
+**Data Boar** é o nome da aplicação (baseado na tecnologia lgpd_crawler; id de pacote/distribuição: `python3-lgpd-crawler`). Este documento complementa o `docs/USAGE.md` em inglês e descreve, em português, como:
 
 - Executar a aplicação via **CLI** e **API web**;
 - Entender os parâmetros (`--config`, `--web`, `--port`, `--tenant`, `--technician`);

--- a/docs/data_boar.1
+++ b/docs/data_boar.1
@@ -1,4 +1,4 @@
-.\" data_boar.1 - man page for Data Boar (application; engine: python3-lgpd-crawler)
+.\" data_boar.1 - man page for Data Boar (application; package id: python3-lgpd-crawler)
 .\" View as: man data_boar or man lgpd_crawler (symlink for compatibility)
 .TH DATA_BOAR 1 "March 2026" "Data Boar 1.6.3" "User Commands"
 .SH NAME

--- a/docs/data_boar.5
+++ b/docs/data_boar.5
@@ -1,4 +1,4 @@
-.\" data_boar.5 - file formats and configuration for Data Boar (engine: python3-lgpd-crawler)
+.\" data_boar.5 - file formats and configuration for Data Boar (package id: python3-lgpd-crawler)
 .\" View as: man 5 data_boar or man 5 lgpd_crawler (symlink for compatibility)
 .TH DATA_BOAR 5 "March 2026" "Data Boar 1.6.3" "File Formats"
 .SH NAME


### PR DESCRIPTION
## Summary
- align user-facing branding wording to Data Boar in security and usage docs
- keep `python3-lgpd-crawler` references where needed as package/distribution identifier for compatibility
- no code/runtime behavior changes (docs/manpage wording only)

## Test plan
- [x] `uv run pytest -v -W error tests/test_markdown_lint.py`