### PR TITLE
fix(security): PBKDF2 for config scope digest (CodeQL weak-sensitive-data-hashing)

### DIFF
--- a/core/engine.py
+++ b/core/engine.py
@@ -11,8 +11,16 @@ from typing import Any
 
 def _compute_config_scope_hash(config: dict[str, Any]) -> str:
     """
-    Compute a non-reversible SHA-256 hash of the scan scope (target names, types, file_scan.extensions only).
-    Used for audit evidence of what was in scope; no secrets or credentials are included.
+    Compute a non-reversible digest of the scan scope (target names, types, file_scan.extensions only).
+
+    **Why PBKDF2, not SHA-256 / BLAKE2:** CodeQL ``py/weak-sensitive-data-hashing`` treats
+    configuration-derived strings (including target ``name``) as potentially sensitive and flags
+    *fast* digests (MD5/SHA/BLAKE2, etc.) as unsafe “password hashing.” This value is **not** a
+    password store—it is audit metadata only—but we use **PBKDF2-HMAC-SHA256** with a fixed salt
+    and high iteration count so the query suite is satisfied without changing semantics beyond the
+    digest function.
+
+    No secrets or credentials are included in the scope material.
     """
     parts: list[str] = []
     for t in config.get("targets", []):
@@ -24,7 +32,10 @@ def _compute_config_scope_hash(config: dict[str, Any]) -> str:
     if exts:
         parts.append("extensions:" + ",".join(sorted(str(e) for e in exts)))
     blob = "\n".join(sorted(parts)).encode("utf-8")
-    return hashlib.sha256(blob).hexdigest()
+    # Fixed application salt (not secret); iteration count is the work factor for CodeQL / KDF posture.
+    salt = b"data-boar|config-scope|v1"
+    derived = hashlib.pbkdf2_hmac("sha256", blob, salt, 120_000, dklen=32)
+    return derived.hex()
 
 
 # Import connectors so they register themselves

--- a/tests/test_config_scope_hash.py
+++ b/tests/test_config_scope_hash.py
@@ -1,0 +1,20 @@
+"""Tests for scan config scope digest (audit metadata; PBKDF2 for CodeQL weak-sensitive-hash posture)."""
+
+from core.engine import _compute_config_scope_hash
+
+
+def test_config_scope_hash_stable_for_same_scope():
+    cfg = {
+        "targets": [{"name": "db_a", "type": "database"}],
+        "file_scan": {"extensions": [".csv", ".txt"]},
+    }
+    a = _compute_config_scope_hash(cfg)
+    b = _compute_config_scope_hash(cfg)
+    assert a == b
+    assert len(a) == 64
+
+
+def test_config_scope_hash_changes_when_scope_changes():
+    base = {"targets": [{"name": "x", "type": "y"}], "file_scan": {}}
+    other = {"targets": [{"name": "x", "type": "z"}], "file_scan": {}}
+    assert _compute_config_scope_hash(base) != _compute_config_scope_hash(other)


### PR DESCRIPTION
## What
Replaces fast digests on scan-scope material with **PBKDF2-HMAC-SHA256** (fixed app salt, 120k iterations). CodeQL **py/weak-sensitive-data-hashing** flags BLAKE2b/SHA-256 on this path because config-derived fields are tainted as sensitive.

## Test
`uv run pytest tests/test_config_scope_hash.py -q`

Made with [Cursor](https://cursor.com)