### PR TITLE
docs(dx): Docker smoke container hygiene (rule + skill + guides)

### DIFF
--- a/.cursor/rules/docker-local-smoke-cleanup.mdc
+++ b/.cursor/rules/docker-local-smoke-cleanup.mdc
@@ -1,0 +1,19 @@
+---
+description: Keep at most one or two local Data Boar containers; remove smoke-test leftovers unless A/B comparison needs them.
+globs: Dockerfile,deploy/**,docs/DOCKER_SETUP.md,docs/HOMELAB_VALIDATION.md,docs/deploy/**
+alwaysApply: false
+---
+
+# Local Docker smoke tests — container hygiene
+
+When creating or advising **local** `data_boar` / **data-boar** containers for smoke tests, builds, or lab validation:
+
+1. **Default:** prefer **one** long-lived container (e.g. `data-boar-audit` or compose project name from `deploy/docker-compose.yml`) matching [docs/DOCKER_SETUP.md](../../docs/DOCKER_SETUP.md).
+2. **Temporary / A–B only:** allow **at most two** named containers when comparing images or configs (e.g. `:latest` vs `:lab`, or two `docker run` variants). Use **clear names** (e.g. `data-boar-a`, `data-boar-b` or `data_boar:lab-a` tags), never anonymous piles of `docker run` without `--name`.
+3. **After success:** recommend `docker stop` + `docker rm` (or `docker compose … down`) for **throwaway** test containers; do **not** leave stopped containers “for later” unless the user explicitly wants a second slot for regression.
+4. **Discovery / cleanup commands** (operator or agent suggestions only; run in the user’s environment):
+   - `docker ps -a --filter "name=data-boar" --filter "name=data_boar"`
+   - Remove extras: `docker rm -f <old-container>` after confirming the user does not need them for A/B.
+5. **Do not** automate destructive `docker rm` without user confirmation; **do** document the recommended cleanup in PR/session notes when smoke tests were run.
+
+See also: [`.cursor/skills/docker-smoke-container-hygiene/SKILL.md`](../skills/docker-smoke-container-hygiene/SKILL.md), [docs/HOMELAB_VALIDATION.md](../../docs/HOMELAB_VALIDATION.md).

--- a/.cursor/skills/docker-smoke-container-hygiene/SKILL.md
+++ b/.cursor/skills/docker-smoke-container-hygiene/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: docker-smoke-container-hygiene
+description: >-
+  After local Data Boar Docker smoke tests, keep at most one or two named containers,
+  remove throwaway ones, and document cleanup. Use when creating containers, running
+  lab validation, or closing a session that used docker run/compose for data_boar.
+---
+
+# Docker smoke container hygiene (Data Boar)
+
+## When to use
+
+- You (or the operator) ran `docker build`, `docker run`, or `docker compose` for **Data Boar** (`data_boar` image, `data-boar-*` names).
+- The session is ending or you are about to open a PR after smoke verification.
+- Docker Desktop is accumulating stopped containers from repeated tests.
+
+## Instructions
+
+1. **Inventory** local Data Boar-related containers (name filter is enough for most cases):
+   - `docker ps -a` and look for `data-boar`, `data_boar`, or compose project service names from `deploy/`.
+2. **Retention policy**
+   - **Normal:** keep **one** container (or one compose stack) for day-to-day dev.
+   - **A/B or regression:** keep **at most two** intentionally named containers (e.g. different tags or configs). Anything else is **throwaway**.
+3. **Cleanup suggestion** (confirm with the operator before `rm -f`):
+   - Stop: `docker stop <name>`
+   - Remove: `docker rm <name>`  
+   - Compose: `docker compose -f deploy/docker-compose.yml … down` (add override file if used).
+4. **Document** in the session or PR description if smoke was run and **which** container name/tag was kept, so the next run does not spawn duplicates.
+5. **Agents:** do not delete containers autonomously; **propose** commands and remind the operator to keep only 1–2 instances unless A/B is required.
+
+## Rationale
+
+Stale containers confuse port mappings (`8088`), volume mounts, and Scout/quickview workflows; they also waste disk. A single explicit policy matches [docs/DOCKER_SETUP.md](../../../docs/DOCKER_SETUP.md) §7 and [docs/HOMELAB_VALIDATION.md](../../../docs/HOMELAB_VALIDATION.md).

--- a/docs/DOCKER_SETUP.md
+++ b/docs/DOCKER_SETUP.md
@@ -140,3 +140,25 @@ docker rm data-boar-audit
 ```
 
 Or with Compose: `docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.override.yml down`
+
+---
+
+## 7. Local smoke tests: container hygiene (keep it small)
+
+Repeated `docker run` / `docker build` during smoke tests or homelab checks can leave **many stopped containers** on Docker Desktop. That complicates ports, volumes, and knowing which image is “current.”
+
+**Policy (project convention):**
+
+1. Prefer **one** primary local container (e.g. `--name data-boar-audit`) or **one** Compose stack.
+2. Allow **at most two** named containers **only when** you need an explicit **A/B** (e.g. `fabioleitao/data_boar:latest` vs a locally built `data_boar:lab`). Use clear names; avoid ad-hoc unnamed containers.
+3. When a throwaway test is done, **stop and remove** extras: `docker rm -f <name>` (after confirming you do not need that instance).
+
+**List likely leftovers:**
+
+```powershell
+docker ps -a --filter "name=data-boar"
+```
+
+Agent/automation guidance for this workflow lives in **`.cursor/rules/docker-local-smoke-cleanup.mdc`** and **`.cursor/skills/docker-smoke-container-hygiene/SKILL.md`** (optional for contributors using Cursor).
+
+See also: [HOMELAB_VALIDATION.md](HOMELAB_VALIDATION.md) (lab baseline uses `docker run --rm` where possible).

--- a/docs/DOCKER_SETUP.pt_BR.md
+++ b/docs/DOCKER_SETUP.pt_BR.md
@@ -140,3 +140,25 @@ docker rm data-boar-audit
 ```
 
 Ou com Compose: `docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.override.yml down`
+
+---
+
+## 7. Smoke local: higiene de containers (manter poucos)
+
+Execuções repetidas de `docker run` / `docker build` em testes de smoke ou no homelab deixam **vários containers parados** no Docker Desktop. Isso atrapalha portas, volumes e saber qual imagem está “ativa”.
+
+**Convenção do projeto:**
+
+1. Preferir **um** container principal local (ex.: `--name data-boar-audit`) ou **uma** stack Compose.
+2. No máximo **dois** containers com nome **só** quando houver **A/B** explícito (ex.: `fabioleitao/data_boar:latest` vs `data_boar:lab` construída localmente). Evitar containers anônimos “soltos”.
+3. Ao terminar um teste descartável, **parar e remover** os extras: `docker rm -f <nome>` (após confirmar que essa instância não é mais necessária).
+
+**Listar candidatos a remoção:**
+
+```powershell
+docker ps -a --filter "name=data-boar"
+```
+
+Orientação para agentes/automação: **`.cursor/rules/docker-local-smoke-cleanup.mdc`** e **`.cursor/skills/docker-smoke-container-hygiene/SKILL.md`** (opcional para quem usa Cursor).
+
+Ver também: [HOMELAB_VALIDATION.pt_BR.md](HOMELAB_VALIDATION.pt_BR.md) (baseline do lab usa `docker run --rm` quando possível).

--- a/docs/HOMELAB_VALIDATION.md
+++ b/docs/HOMELAB_VALIDATION.md
@@ -16,6 +16,7 @@
 1. **Lab is for integration:** OS paths, Docker volumes, real DB ports, firewall, and “does this config actually run here?”
 1. **Synthetic by default:** hand-made `.txt` / `.csv` with **fake** CPF/email patterns (see project tests for valid-format examples—do not use real people’s data).
 1. **Real data only when allowed:** copies of non-production DBs, anonymised extracts, or documents you own/have permission to scan.
+1. **Docker container churn:** Prefer `docker run --rm` for one-shot checks. If you keep a named **Data Boar** container between runs, aim for **one** primary instance—or **two** only for explicit **A/B** (image or config). Remove throwaway containers when done so ports (`8088`) and volumes stay predictable. See [DOCKER_SETUP.md](DOCKER_SETUP.md) §7.
 
 ---
 

--- a/docs/HOMELAB_VALIDATION.pt_BR.md
+++ b/docs/HOMELAB_VALIDATION.pt_BR.md
@@ -16,6 +16,7 @@
 1. **Lab = integração:** caminhos, volumes Docker, portas de BD, firewall.
 1. **Sintético por omissão:** ficheiros `.txt` / `.csv` com padrões **falsos** (inspire-se nos testes do projeto, **não** use dados reais de terceiros).
 1. **Real só com permissão:** cópias não produtivas, anonimizadas ou documentos seus.
+1. **Containers Docker:** Prefira `docker run --rm` em checagens pontuais. Se mantiver um container **Data Boar** nomeado entre execuções, objetive **uma** instância principal—ou **duas** só para **A/B** explícito. Remova containers descartáveis ao fim para não confundir portas (`8088`) e volumes. Ver [DOCKER_SETUP.pt_BR.md](DOCKER_SETUP.pt_BR.md) §7.
 
 ---
 


### PR DESCRIPTION
## What
- **.cursor/rules/docker-local-smoke-cleanup.mdc** — at most 1-2 local Data Boar containers; A/B only when intentional.
- **.cursor/skills/docker-smoke-container-hygiene/SKILL.md** — post-smoke cleanup checklist for agents.
- **DOCKER_SETUP** + **HOMELAB_VALIDATION** (EN + pt-BR) — operator commands and policy.

Agents propose cleanup; no autonomous **docker rm** without user confirmation.

Made with [Cursor](https://cursor.com)