### PR TITLE
ci: pytest matrix 3.12+3.13; PYTHON_UPGRADE_PLAYBOOK (3.14 readiness)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,19 @@ on:
 
 jobs:
   test:
-    name: Test
+    name: Test (${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/docs/PYTHON_UPGRADE_PLAYBOOK.md
+++ b/docs/PYTHON_UPGRADE_PLAYBOOK.md
@@ -1,0 +1,92 @@
+# Python runtime upgrade playbook (3.12 → 3.13 → 3.14, Docker, CI)
+
+**Português (Brasil):** [PYTHON_UPGRADE_PLAYBOOK.pt_BR.md](PYTHON_UPGRADE_PLAYBOOK.pt_BR.md)
+
+**Purpose:** Stay **safe on 3.12** while **preparing** for newer CPython lines without breaking **wheels** (numpy, pandas, scipy, SQL drivers, ORM, etc.), **Docker** multi-stage paths, or **CI**.
+
+---
+
+## 1. Current contract (what must stay true)
+
+| Layer | Source of truth | Today |
+| ----- | ---------------- | ----- |
+| Declared range | `pyproject.toml` → `requires-python` | `>=3.12` |
+| Locked tree | `uv.lock` + `uv sync` | Resolved for 3.12/3.13 (per CI matrix after this playbook lands) |
+| Published image | `Dockerfile` **`FROM`** + **`COPY .../python3.XY/site-packages`** | Must match **one** Python minor end-to-end |
+| CI signal | `.github/workflows/ci.yml` | **Test** job should cover every **supported** minor you claim in SECURITY/CONTRIBUTING |
+
+**Catch:** Documentation may say “we support 3.12 and 3.13” while **only 3.12** ran in CI — then 3.13 regressions are **invisible** until someone runs locally or Docker fails.
+
+---
+
+## 2. Why 3.13 before 3.14?
+
+| | 3.13 | 3.14 |
+| --- | --- | --- |
+| **Wheel ecosystem** | Mature **cp313** wheels for most scientific/DB stack | **cp314** wheels still trailing; more **source builds** risk |
+| **Friction** | Lower: official `python:3.13-slim`, same pattern as 3.12 | Higher: watch PyPI for `cp314` on numpy/scipy/pandas/sklearn/psycopg2/oracledb/etc. |
+| **Security / CVEs** | Newer interpreter + Debian base refresh in slim images | Same idea, gated by dependency wheels |
+
+**Recommendation:** Treat **3.13** as the **next production target** for Docker + lockfile verification; treat **3.14** as **experimental** until `docker build` installs **only wheels** (or acceptable compile time) for your full `requirements.txt` / `uv.lock`.
+
+---
+
+## 3. Compatibility matrix to maintain
+
+| Check | 3.12 | 3.13 | 3.14 (prep) |
+| ----- | ---- | ---- | ----------- |
+| `uv sync` + `uv run pytest -v -W error` | CI | CI (matrix) | Manual or optional job |
+| `uv run ruff check` / format | CI | Same as 3.12 job (keep one) | N/A |
+| `pip-audit` / Dependabot | CI | Same | N/A |
+| **Docker** `docker build` | Default publish | Branch: change `FROM` + `python3.XY` paths | Branch only |
+| **Smoke:** container up, `/health`, idle scan | Homelab | Same image tag Family | Same |
+
+**Dockerfile edits when minor changes:** Replace **every** `python3.12` in `find`/`COPY` with `python3.13` (or `3.14`).
+
+---
+
+## 4. Preparing for 3.14 (sooner–later)
+
+1. **CI:** Keep **3.12 + 3.13** green; add an optional **`workflow_dispatch`** or **weekly** job on **3.14** that does `uv sync` + `pytest` (allow **failure** or **continue-on-error** until green).
+2. **Lockfile:** Run `uv lock` under **3.14** in a throwaway env **only after** `uv` reports a solvable tree; commit lock updates in a **dedicated PR**.
+3. **Wheel audit (manual):** Before bumping Docker `FROM`, run `pip install -r requirements.txt` in a **3.14** container and note any **“Building wheel for …”** that runs **>2–3 minutes** — that’s your regression risk.
+4. **`requires-python`:** Raise to `>=3.13` or `>=3.14` **only** when you **drop** 3.12 support — a **major** comms + release decision.
+
+---
+
+## 5. Local A/B Docker (time build + smoke)
+
+**Goal:** Compare **baseline** (`data_boar:py312`) vs **candidate** (`data_boar:py313`) without touching the default `latest` tag until satisfied.
+
+```powershell
+# From repo root — example for 3.13 candidate branch
+docker build -t data_boar:ab-py312 -f Dockerfile .
+# After editing Dockerfile to 3.13:
+docker build --no-cache -t data_boar:ab-py313 -f Dockerfile .
+
+docker images data_boar --format "{{.Tag}}\t{{.Size}}"
+```
+
+**Smoke (both):** same `config.yaml`, same volume, `docker run -p 8088:8088`, hit `/health`, optional `POST /scan` with `targets: []`.
+
+**If candidate fails or build explodes:** keep **3.12** `FROM` for **published** Hub images; keep the **branch** for retry next quarter.
+
+---
+
+## 6. What you might not be seeing
+
+- **Python upgrades ≠ automatic CVE cure:** Many findings are **Debian packages** (`apt`) or **PyPI** deps — refresh **base slim tag**, `apt-get upgrade` policy, and **Dependabot** anyway.
+- **`pylock.toml` (if present):** A `uv export --format pylock.toml` can show `requires-python` from the **export environment**; **`uv.lock` + `pyproject.toml`** are authoritative — don’t let a stray export contradict support policy.
+- **JFrog / private index:** If you mirror wheels, ensure **cp313** / **cp314** artifacts exist for pinned versions or resolution will fall back to PyPI or **sdist**.
+
+---
+
+## 7. Related docs
+
+- [TESTING.md](TESTING.md) · [DOCKER_SETUP.md](DOCKER_SETUP.md) · [HOMELAB_VALIDATION.md](HOMELAB_VALIDATION.md)
+- [SECURITY.md](SECURITY.md) — supported Python lines
+- [TECH_GUIDE.md](TECH_GUIDE.md) — local toolchains
+
+---
+
+*Last updated: CI matrix 3.12+3.13 for tests; playbook for 3.14 readiness.*

--- a/docs/PYTHON_UPGRADE_PLAYBOOK.pt_BR.md
+++ b/docs/PYTHON_UPGRADE_PLAYBOOK.pt_BR.md
@@ -1,0 +1,89 @@
+# Playbook de upgrade do runtime Python (3.12 → 3.13 → 3.14, Docker, CI)
+
+**English:** [PYTHON_UPGRADE_PLAYBOOK.md](PYTHON_UPGRADE_PLAYBOOK.md)
+
+**Objetivo:** Permanecer **seguro no 3.12** enquanto **prepara** linhas mais novas do CPython sem quebrar **wheels** (numpy, pandas, scipy, drivers SQL, ORM, etc.), caminhos **Docker** multi-stage ou **CI**.
+
+---
+
+## 1. Contrato atual (o que tem de continuar verdade)
+
+| Camada | Fonte da verdade | Hoje |
+| ------ | ------------------ | ---- |
+| Faixa declarada | `pyproject.toml` → `requires-python` | `>=3.12` |
+| Árvore fixada | `uv.lock` + `uv sync` | Resolvida para 3.12/3.13 (com matriz CI após este playbook) |
+| Imagem publicada | `Dockerfile` **`FROM`** + **`COPY .../python3.XY/site-packages`** | Tem de bater com **um** minor Python de ponta a ponta |
+| Sinal do CI | `.github/workflows/ci.yml` | Job **Test** deve cobrir todo **minor suportado** em SECURITY/CONTRIBUTING |
+
+**Armadilha:** A documentação pode dizer “suportamos 3.12 e 3.13” mas só o **3.12** rodava no CI — regressões no 3.12 ficam **invisíveis** até alguém rodar localmente ou o Docker falhar.
+
+---
+
+## 2. Por que 3.13 antes de 3.14?
+
+| | 3.13 | 3.14 |
+| --- | --- | --- |
+| **Ecossistema de wheels** | Wheels **cp313** maduros para boa parte do stack científico/BD | Wheels **cp314** ainda atrás; mais risco de **build a partir do fonte** |
+| **Atrito** | Menor: `python:3.13-slim` oficial, mesmo padrão do 3.12 | Maior: acompanhar PyPI para `cp314` em numpy/scipy/pandas/sklearn/psycopg2/oracledb/etc. |
+| **Segurança / CVE** | Interpretador mais novo + base Debian nas imagens slim | Mesma lógica, condicionada aos wheels das dependências |
+
+**Recomendação:** Tratar **3.13** como **próximo alvo** de produção em Docker + verificação do lockfile; **3.14** como **experimental** até `docker build` instalar **só wheels** (ou tempo de compilação aceitável) para o `requirements.txt` / `uv.lock` completos.
+
+---
+
+## 3. Matriz de compatibilidade a manter
+
+| Verificação | 3.12 | 3.13 | 3.14 (prep) |
+| ----------- | ---- | ---- | ----------- |
+| `uv sync` + `uv run pytest -v -W error` | CI | CI (matriz) | Manual ou job opcional |
+| `uv run ruff` | CI | Um job (ex.: 3.12) | N/A |
+| `pip-audit` | CI | Igual | N/A |
+| **Docker** `docker build` | Publicação padrão | Branch: alterar `FROM` + caminhos `python3.XY` | Só branch |
+| **Smoke:** container, `/health`, scan vazio | Homelab | Mesma família de tags | Idem |
+
+**Dockerfile:** ao mudar o minor, substituir **todos** os `python3.12` em `find`/`COPY` por `python3.13` (ou `3.14`).
+
+---
+
+## 4. Preparar 3.14 (cedo ou tarde)
+
+1. **CI:** Manter **3.12 + 3.13** verdes; job opcional **`workflow_dispatch`** ou **semanal** em **3.14** com `uv sync` + `pytest` (**continue-on-error** até ficar verde).
+2. **Lockfile:** `uv lock` em ambiente **3.14** só quando a árvore for resolvível; PR dedicado.
+3. **Auditoria de wheels:** antes de subir o `FROM`, notar compilações longas no `pip install`.
+4. **`requires-python`:** subir para `>=3.13` ou `>=3.14` **só** ao **abandonar** o 3.12 — decisão de release/comunicação.
+
+---
+
+## 5. Docker A/B local (tempo de build + smoke)
+
+Objetivo: comparar **`data_boar:py312`** vs **`data_boar:py313`** sem mudar `latest` até validar.
+
+```powershell
+docker build -t data_boar:ab-py312 -f Dockerfile .
+# Com Dockerfile em 3.13:
+docker build --no-cache -t data_boar:ab-py313 -f Dockerfile .
+```
+
+Smoke: mesmo `config.yaml`, volume, porta 8088, `/health`, scan opcional com `targets: []`.
+
+Se o candidato falhar: manter imagem publicada em **3.12**; branch para nova tentativa.
+
+---
+
+## 6. O que costuma passar despercebido
+
+- **Upgrade de Python ≠ CVE resolvido:** Muitos achados vêm de **pacotes Debian** ou **PyPI** — atualizar **tag slim**, política de `apt` e **Dependabot** na mesma.
+- **`pylock.toml`:** export pode mostrar `requires-python` do **ambiente**; **fonte:** `uv.lock` + `pyproject.toml`.
+- **Mirror (JFrog / privado):** garantir artefactos **cp313** / **cp314** para versões fixadas.
+
+---
+
+## 7. Documentos relacionados
+
+- [TESTING.pt_BR.md](TESTING.pt_BR.md) · [DOCKER_SETUP.pt_BR.md](DOCKER_SETUP.pt_BR.md) · [HOMELAB_VALIDATION.pt_BR.md](HOMELAB_VALIDATION.pt_BR.md)
+- [SECURITY.pt_BR.md](../SECURITY.pt_BR.md)
+- [TECH_GUIDE.pt_BR.md](TECH_GUIDE.pt_BR.md)
+
+---
+
+*Última atualização: matriz CI 3.12+3.13 nos testes; playbook para readiness 3.14.*

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,7 @@ Deploy assets (Compose, Kubernetes, config examples) remain in the [deploy/](../
 | Topic                   | English                                                  | Português (pt-BR)                                                    |
 | ---------------         | -----------------------------                            | ------------------------------------                                 |
 | Testing                 | [TESTING.md](TESTING.md)                                 | [TESTING.pt_BR.md](TESTING.pt_BR.md)                                 |
+| Python upgrade (3.12→3.13→3.14, Docker A/B, matrix) | [PYTHON_UPGRADE_PLAYBOOK.md](PYTHON_UPGRADE_PLAYBOOK.md) | [PYTHON_UPGRADE_PLAYBOOK.pt_BR.md](PYTHON_UPGRADE_PLAYBOOK.pt_BR.md) |
 | SonarQube (home lab, Docker, CI / IDE / MCP) | [SONARQUBE_HOME_LAB.md](SONARQUBE_HOME_LAB.md)             | [SONARQUBE_HOME_LAB.pt_BR.md](SONARQUBE_HOME_LAB.pt_BR.md)             |
 | Home lab (deploy smoke, synthetic/real targets) | [HOMELAB_VALIDATION.md](HOMELAB_VALIDATION.md)       | [HOMELAB_VALIDATION.pt_BR.md](HOMELAB_VALIDATION.pt_BR.md)             |
 | Topology                | [TOPOLOGY.md](TOPOLOGY.md)                               | [TOPOLOGY.pt_BR.md](TOPOLOGY.pt_BR.md)                               |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -24,6 +24,8 @@ uv run pytest -v -W error -k "session_id"
 
 **Requirements:** Python 3.12+, dependencies installed (`uv sync --group dev` or `pip install -e .` plus dev tools). The **dev** group includes **`rapidfuzz`** so fuzzy-column tests run; core runtime does not require it unless you enable `sensitivity_detection.fuzzy_column_match` (optional extra **`detection-fuzzy`**). No external services are required; tests use temporary configs and in-memory or temporary SQLite where needed.
 
+**Supported minors:** CI runs **pytest** on **Python 3.12 and 3.13** (see `.github/workflows/ci.yml`). For Docker base bumps and a 3.14 readiness checklist, see [PYTHON_UPGRADE_PLAYBOOK.md](PYTHON_UPGRADE_PLAYBOOK.md).
+
 ## Test modules overview
 
 | Module                                | Purpose                                                                                                                                                                                                                                                          |

--- a/docs/TESTING.pt_BR.md
+++ b/docs/TESTING.pt_BR.md
@@ -24,6 +24,8 @@ uv run pytest -v -W error -k "session_id"
 
 **Requisitos:** Python 3.12+, dependências instaladas (`uv sync` ou `pip install -e .`). Nenhum serviço externo é necessário; os testes usam configs temporários e SQLite em memória ou temporário quando preciso.
 
+**Versões menores suportadas:** o CI executa **pytest** em **Python 3.12 e 3.13** (veja `.github/workflows/ci.yml`). Para bumps da imagem Docker e checklist de readiness 3.14, veja [PYTHON_UPGRADE_PLAYBOOK.pt_BR.md](PYTHON_UPGRADE_PLAYBOOK.pt_BR.md).
+
 ## Visão geral dos módulos de teste
 
 | Módulo                                | Objetivo                                                                                                                                                                                                                                                          |


### PR DESCRIPTION
## What
- **CI:** \	est\ job matrix **Python 3.12 and 3.13** (\ail-fast: false\) so we match SECURITY/CONTRIBUTING support claims.
- **Docs:** \PYTHON_UPGRADE_PLAYBOOK\ (EN + pt-BR): 3.13 before 3.14, Docker \python3.XY\ paths, A/B smoke, wheels/JFrog caveats, optional future 3.14 job.
- **TESTING** + index links.

Verify both matrix legs pass before merging.

Made with [Cursor](https://cursor.com)