### PR TITLE
docs: add Python upgrade playbook under plans

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,7 @@ Deploy assets (Compose, Kubernetes, config examples) remain in the [deploy/](../
 
 - [ops/README.md](ops/README.md) — Operator runbooks index (this folder) and **link-audit checklist** for doc moves.
 - [plans/PLANS_TODO.md](plans/PLANS_TODO.md) — Plan status and current app state (single source of truth for open-plan to-dos). *Plan files are EN-only for history; operator runbooks under ops/ are EN + pt-BR.*
+- [plans/PYTHON_UPGRADE_PLAYBOOK.md](plans/PYTHON_UPGRADE_PLAYBOOK.md) — Python runtime upgrade sequencing (3.12→3.13→…), Docker, CI, and wheels; [pt-BR companion](plans/PYTHON_UPGRADE_PLAYBOOK.pt_BR.md).
 - External evolution reviews are mapped into plan history (internal; not a public doc surface).
 - [releases/](releases/) — Release notes (e.g. 1.6.3, 1.6.2, 1.6.1, 1.6.0, 1.5.4, 1.5.3, 1.4.3).
 - [plans/completed/](plans/completed/) — Archived completed plans and the implementation checklist ([NEXT_STEPS.md](plans/completed/NEXT_STEPS.md)), all items Done.

--- a/docs/README.pt_BR.md
+++ b/docs/README.pt_BR.md
@@ -83,6 +83,7 @@ Os artefatos de deploy (Compose, Kubernetes, exemplos de config) ficam na pasta 
 
 - [ops/README.md](ops/README.md) — Índice dos runbooks do operador e **checklist de auditoria de links** após mover docs.
 - [plans/PLANS_TODO.md](plans/PLANS_TODO.md) — Status dos planos e estado atual da aplicação (fonte única de verdade para os to-dos dos planos abertos). *Arquivos de plano são apenas em inglês para histórico; runbooks em ops/ são EN + pt-BR.*
+- [plans/PYTHON_UPGRADE_PLAYBOOK.md](plans/PYTHON_UPGRADE_PLAYBOOK.md) — Sequenciamento de upgrade do runtime Python (3.12→3.13→…), Docker, CI e wheels; [guia em pt-BR](plans/PYTHON_UPGRADE_PLAYBOOK.pt_BR.md).
 - Revisões externas de evolução são mapeadas no histórico dos planos (conteúdo interno; não é uma superfície pública de documentação).
 - [releases/](releases/) — Notas de release (ex.: 1.6.3, 1.6.2, 1.6.1, 1.6.0, 1.5.4, 1.4.3).
 - [plans/completed/](plans/completed/) — Planos concluídos arquivados e o checklist de implementação ([NEXT_STEPS.md](plans/completed/NEXT_STEPS.md)), todos os itens Feitos.

--- a/docs/plans/PYTHON_UPGRADE_PLAYBOOK.md
+++ b/docs/plans/PYTHON_UPGRADE_PLAYBOOK.md
@@ -1,0 +1,95 @@
+# Python runtime upgrade playbook (3.12 → 3.13 → 3.14, Docker, CI)
+
+**Location:** This is a **planned / ops meta** document (upgrade path and matrix), kept under **`docs/plans/`** with other readiness and sequencing guides—not only day-to-day HOWTOs under **`docs/`**.
+
+**Português (Brasil):** [PYTHON_UPGRADE_PLAYBOOK.pt_BR.md](PYTHON_UPGRADE_PLAYBOOK.pt_BR.md)
+
+**Purpose:** Stay **safe on 3.12** while **preparing** for newer CPython lines without breaking **wheels** numpy/pandas/scipy, SQL drivers, ORM, **Docker** multi-stage paths, or **CI**.
+
+---
+
+## 1. Current contract (what must stay true)
+
+| Layer | Source of truth | Today |
+| ----- | ---------------- | ----- |
+| Declared range | `pyproject.toml` → `requires-python` | `>=3.12` |
+| Locked tree | `uv.lock` + `uv sync` | Resolved for 3.12/3.13 (CI test matrix on `main`) |
+| Published image | `Dockerfile` **`FROM`** + **`COPY .../python3.XY/site-packages`** | Must match **one** Python minor end-to-end |
+| CI signal | `.github/workflows/ci.yml` | **Test** job should cover every **supported** minor you claim in SECURITY/CONTRIBUTING |
+
+**Catch:** Claiming **3.13** without CI on 3.13 hides regressions until Docker or local runs fail.
+
+---
+
+## 2. Why 3.13 before 3.14?
+
+| | 3.13 | 3.14 |
+| --- | --- | --- |
+| **Wheel ecosystem** | Mature **cp313** wheels for most scientific/DB stack | **cp314** wheels still trailing; more **source builds** risk |
+| **Friction** | Lower: official `python:3.13-slim`, same pattern as 3.12 | Higher: watch PyPI for `cp314` on numpy/scipy/pandas/sklearn/psycopg2/oracledb/etc. |
+| **Security / CVEs** | Newer interpreter + Debian base refresh in slim images | Same idea, gated by dependency wheels |
+
+**Recommendation:** Treat **3.13** as the **next production target** for Docker + lockfile verification; treat **3.14** as **experimental** until `docker build` installs **only wheels** (or acceptable compile time) for your full `requirements.txt` / `uv.lock`.
+
+---
+
+## 3. Compatibility matrix to maintain
+
+| Check | 3.12 | 3.13 | 3.14 (prep) |
+| ----- | ---- | ---- | ----------- |
+| `uv sync` + `uv run pytest -v -W error` | CI | CI (matrix) | Manual or optional job |
+| `uv run ruff check` / format | CI | Same as 3.12 job (keep one) | N/A |
+| `pip-audit` / Dependabot | CI | Same | N/A |
+| **Docker** `docker build` | Default publish | Branch: change `FROM` + `python3.XY` paths | Branch only |
+| **Smoke:** container up, `/health`, idle scan | Homelab | Same image tag family | Same |
+
+**Dockerfile edits when minor changes:** Replace **every** `python3.12` in `find`/`COPY` with `python3.13` (or `3.14`).
+
+---
+
+## 4. Preparing for 3.14 (sooner–later)
+
+1. **CI:** Keep **3.12 + 3.13** green; add an optional **`workflow_dispatch`** or **weekly** job on **3.14** that does `uv sync` + `pytest` (allow **failure** or **continue-on-error** until green).
+2. **Lockfile:** Run `uv lock` under **3.14** in a throwaway env **only after** `uv` reports a solvable tree; commit lock updates in a **dedicated PR**.
+3. **Wheel audit (manual):** Before bumping Docker `FROM`, run `pip install -r requirements.txt` in a **3.14** container and note any **“Building wheel for …”** that runs **>2–3 minutes** — that’s your regression risk.
+4. **`requires-python`:** Raise to `>=3.13` or `>=3.14` **only** when you **drop** 3.12 support — a **major** comms + release decision.
+
+---
+
+## 5. Local A/B Docker (time build + smoke)
+
+**Goal:** Compare **baseline** (`data_boar:py312`) vs **candidate** (`data_boar:py313`) without touching the default `latest` tag until satisfied.
+
+```powershell
+# From repo root — example for 3.13 candidate branch
+docker build -t data_boar:ab-py312 -f Dockerfile .
+# After editing Dockerfile to 3.13:
+docker build --no-cache -t data_boar:ab-py313 -f Dockerfile .
+
+docker images data_boar --format "{{.Tag}}\t{{.Size}}"
+```
+
+**Smoke (both):** same `config.yaml`, same volume, `docker run -p 8088:8088`, hit `/health`, optional `POST /scan` with `targets: []`.
+
+**If candidate fails or build explodes:** keep **3.12** `FROM` for **published** Hub images; keep the **branch** for retry next quarter.
+
+---
+
+## 6. What you might not be seeing
+
+- **Python upgrades ≠ automatic CVE cure:** Many findings are **Debian packages** (`apt`) or **PyPI** deps — refresh **base slim tag**, `apt-get upgrade` policy, and **Dependabot** anyway.
+- **`pylock.toml` (if present):** A `uv export --format pylock.toml` can show `requires-python` from the **export environment**; **`uv.lock` + `pyproject.toml`** are authoritative — don’t let a stray export contradict support policy.
+- **JFrog / private index:** If you mirror wheels, ensure **cp313** / **cp314** artifacts exist for pinned versions or resolution will fall back to PyPI or **sdist**.
+
+---
+
+## 7. Related docs
+
+- [TESTING.md](../TESTING.md) · [DOCKER_SETUP.md](../DOCKER_SETUP.md) · [HOMELAB_VALIDATION.md](../ops/HOMELAB_VALIDATION.md)
+- [SECURITY.md](../SECURITY.md) — supported Python lines
+- [TECH_GUIDE.md](../TECH_GUIDE.md) — local toolchains
+- [PLAN_READINESS_AND_OPERATIONS.md](PLAN_READINESS_AND_OPERATIONS.md) · [PLANS_TODO.md](PLANS_TODO.md)
+
+---
+
+*Last updated: playbook relocated to `docs/plans/`; CI matrix 3.12+3.13 for tests.*

--- a/docs/plans/PYTHON_UPGRADE_PLAYBOOK.pt_BR.md
+++ b/docs/plans/PYTHON_UPGRADE_PLAYBOOK.pt_BR.md
@@ -1,0 +1,92 @@
+# Playbook de upgrade do runtime Python (3.12 → 3.13 → 3.14, Docker, CI)
+
+**Localização:** Documento **meta / operação planejada** (trilha de upgrade e matriz). Fica em **`docs/plans/`**, junto de readiness e sequenciamento—não só HOWTOs cotidianos em **`docs/`**.
+
+**English:** [PYTHON_UPGRADE_PLAYBOOK.md](PYTHON_UPGRADE_PLAYBOOK.md)
+
+**Objetivo:** Permanecer **seguro no 3.12** enquanto **prepara** linhas mais novas do CPython sem quebrar **wheels**, drivers SQL, ORM, caminhos **Docker** multi-stage ou **CI**.
+
+---
+
+## 1. Contrato atual (o que tem de continuar verdade)
+
+| Camada | Fonte da verdade | Hoje |
+| ------ | ------------------ | ---- |
+| Faixa declarada | `pyproject.toml` → `requires-python` | `>=3.12` |
+| Árvore fixada | `uv.lock` + `uv sync` | Resolvida para 3.12/3.13 (matriz de testes no CI em `main`) |
+| Imagem publicada | `Dockerfile` **`FROM`** + **`COPY .../python3.XY/site-packages`** | Tem de bater com **um** minor Python de ponta a ponta |
+| Sinal do CI | `.github/workflows/ci.yml` | Job **Test** deve cobrir todo **minor suportado** em SECURITY/CONTRIBUTING |
+
+**Armadilha:** Declarar **3.13** sem CI no 3.13 esconde regressões até o Docker ou o local falhar.
+
+---
+
+## 2. Por que 3.13 antes de 3.14?
+
+| | 3.13 | 3.14 |
+| --- | --- | --- |
+| **Ecossistema de wheels** | Wheels **cp313** maduros para boa parte do stack científico/BD | Wheels **cp314** ainda atrás; mais risco de **build a partir do fonte** |
+| **Atrito** | Menor: `python:3.13-slim` oficial, mesmo padrão do 3.12 | Maior: acompanhar PyPI para `cp314` em numpy/scipy/pandas/sklearn/psycopg2/oracledb/etc. |
+| **Segurança / CVE** | Interpretador mais novo + base Debian nas imagens slim | Mesma lógica, condicionada aos wheels das dependências |
+
+**Recomendação:** Tratar **3.13** como **próximo alvo** de produção em Docker + verificação do lockfile; **3.14** como **experimental** até `docker build` instalar **só wheels** (ou tempo de compilação aceitável) para o `requirements.txt` / `uv.lock` completos.
+
+---
+
+## 3. Matriz de compatibilidade a manter
+
+| Verificação | 3.12 | 3.13 | 3.14 (prep) |
+| ----------- | ---- | ---- | ----------- |
+| `uv sync` + `uv run pytest -v -W error` | CI | CI (matriz) | Manual ou job opcional |
+| `uv run ruff` | CI | Um job (ex.: 3.12) | N/A |
+| `pip-audit` | CI | Igual | N/A |
+| **Docker** `docker build` | Publicação padrão | Branch: alterar `FROM` + caminhos `python3.XY` | Só branch |
+| **Smoke:** container, `/health`, scan vazio | Homelab | Mesma família de tags | Idem |
+
+**Dockerfile:** ao mudar o minor, substituir **todos** os `python3.12` em `find`/`COPY` por `python3.13` (ou `3.14`).
+
+---
+
+## 4. Preparar 3.14 (cedo ou tarde)
+
+1. **CI:** Manter **3.12 + 3.13** verdes; job opcional **`workflow_dispatch`** ou **semanal** em **3.14** com `uv sync` + `pytest` (**continue-on-error** até ficar verde).
+2. **Lockfile:** `uv lock` em ambiente **3.14** só quando a árvore for resolvível; PR dedicado.
+3. **Auditoria de wheels:** antes de subir o `FROM`, notar compilações longas no `pip install`.
+4. **`requires-python`:** subir para `>=3.13` ou `>=3.14` **só** ao **abandonar** o 3.12 — decisão de release/comunicação.
+
+---
+
+## 5. Docker A/B local (tempo de build + smoke)
+
+Objetivo: comparar **`data_boar:py312`** vs **`data_boar:py313`** sem mudar `latest` até validar.
+
+```powershell
+docker build -t data_boar:ab-py312 -f Dockerfile .
+# Com Dockerfile em 3.13:
+docker build --no-cache -t data_boar:ab-py313 -f Dockerfile .
+```
+
+Smoke: mesmo `config.yaml`, volume, porta 8088, `/health`, scan opcional com `targets: []`.
+
+Se o candidato falhar: manter imagem publicada em **3.12**; branch para nova tentativa.
+
+---
+
+## 6. O que costuma passar despercebido
+
+- **Upgrade de Python ≠ CVE resolvido:** Muitos achados vêm de **pacotes Debian** ou **PyPI** — atualizar **tag slim**, política de `apt` e **Dependabot** na mesma.
+- **`pylock.toml`:** export pode mostrar `requires-python` do **ambiente**; **fonte:** `uv.lock` + `pyproject.toml`.
+- **Mirror (JFrog / privado):** garantir artefactos **cp313** / **cp314** para versões fixadas.
+
+---
+
+## 7. Documentos relacionados
+
+- [TESTING.pt_BR.md](../TESTING.pt_BR.md) · [DOCKER_SETUP.pt_BR.md](../DOCKER_SETUP.pt_BR.md) · [HOMELAB_VALIDATION.pt_BR.md](../ops/HOMELAB_VALIDATION.pt_BR.md)
+- [SECURITY.pt_BR.md](../SECURITY.pt_BR.md)
+- [TECH_GUIDE.pt_BR.md](../TECH_GUIDE.pt_BR.md)
+- [PLAN_READINESS_AND_OPERATIONS.md](PLAN_READINESS_AND_OPERATIONS.md) · [PLANS_TODO.md](PLANS_TODO.md)
+
+---
+
+*Última atualização: playbook em `docs/plans/`; matriz CI 3.12+3.13 nos testes.*


### PR DESCRIPTION
## Summary
- Add \docs/plans/PYTHON_UPGRADE_PLAYBOOK.md\ + \.pt_BR.md\ (canonical under \plans/\).
- Link from \docs/README.md\ / \README.pt_BR.md\ internal index.

## Tests
\\\ash
uv run pytest tests/test_docs_markdown.py tests/test_markdown_lint.py
\\\
15 passed.

Made with [Cursor](https://cursor.com)