### PR TITLE
chore: PR sync workflow for agents

### DIFF
--- a/.cursor/rules/git-pr-sync-before-advice.mdc
+++ b/.cursor/rules/git-pr-sync-before-advice.mdc
@@ -1,0 +1,39 @@
+---
+description: Refresh git/gh state before merge/PR advice or sharing PR URLs (avoid stale PR numbers)
+globs: ["**/*"]
+alwaysApply: true
+---
+
+# Git / GitHub PR state — sync before advice
+
+**Problem:** Chat context can still say “open PR #80” after #80 merged and #81 exists. The assistant has **no live GitHub view** unless commands run **in this session**.
+
+## When this applies
+
+- Before advising **merge**, **“what’s next”** after a PR, or **which PR** to open.
+- Before pasting or opening a **PR URL** or number after `gh pr create`.
+- When the user says they **just merged** — **do not** assume local `main` is current.
+
+## Minimum refresh (pick at least one)
+
+| Action | Command / script |
+|--------|------------------|
+| Update remote refs | `git fetch origin` |
+| Align local `main` | `git checkout main` → `git pull origin main` |
+| Verify a PR | `gh pr view <n> --json number,state,mergedAt,url` |
+| List PR for current branch | `gh pr list --head <branch-name> --json number,state,url` |
+
+Prefer repo automation when it already does fetch/rebase: **`.\scripts\commit-or-pr.ps1`** (see `.cursor/skills/token-aware-automation/SKILL.md` and `CONTRIBUTING.md` § PR state).
+
+## After creating a PR
+
+1. Run `gh pr view --json number,state,url` (or `gh pr list --head <branch>`).
+2. **Only then** share the link or say “PR #N” — avoids pointing at the **previous** merged PR.
+
+## GitHub lag
+
+Right after merge, `gh` may still show `OPEN` briefly. Re-run `gh pr view` or wait a few seconds; distinguish **UI lag** from **stale chat context**.
+
+## Human + agent habit
+
+Maintainers: after merging on GitHub, run **`git checkout main && git pull`**. Agents: **run a refresh command** before merge-related advice unless the user pasted fresh `gh`/`git` output in the same turn.

--- a/.cursor/skills/token-aware-automation/SKILL.md
+++ b/.cursor/skills/token-aware-automation/SKILL.md
@@ -60,3 +60,14 @@ Workflow that saves tokens (shorter form):
 - **User asks to commit / push / create PR:** use `preview-commit.ps1` then `commit-or-pr.ps1` (or `create-pr.ps1` for PR with body file); do not use ad-hoc `git add`/`git commit`/`git push` when the script covers the need.
 
 Avoid running raw `pytest`, `ruff`, `pre-commit`, or manual git commit/push when a script already does the same thing; the scripts are the single source of behaviour and keep sessions token-efficient.
+
+## PR state / number freshness (before merge advice or sharing links)
+
+The assistant **does not** have live GitHub state between messages. Before advising **merge**, **post-merge next steps**, or pasting a **PR URL/number** (especially right after `gh pr create`):
+
+1. Run **`git fetch origin`**, and on **`main`**: **`git pull origin main`** (or show `git status -sb`), **or**
+2. Run **`gh pr view <n> --json state,mergedAt,url`** or **`gh pr list --head <branch>`**.
+
+After **`gh pr create`**, run **`gh pr view --json number,state,url`** before sharing the link so you cite the **new** PR, not a previously merged one. GitHub may lag briefly after merge — re-query if needed.
+
+**Project rule:** `.cursor/rules/git-pr-sync-before-advice.mdc` (always apply). **Human-readable:** `CONTRIBUTING.md` § *PR state and agent advice*, **`AGENTS.md`**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent / assistant notes (Cursor, Copilot, etc.)
+
+- **Git & PR state:** The model does **not** see GitHub or your local repo unless a command runs in-session. Before advising **merge**, **next steps after a PR**, or sharing a **PR number/URL**, refresh state (`git fetch`, `git pull` on `main`, and/or `gh pr view`). See **`.cursor/rules/git-pr-sync-before-advice.mdc`** (always applied) and **`CONTRIBUTING.md`** → *PR state and agent advice*.
+- **Automation:** Prefer **`scripts/check-all.ps1`**, **`scripts/commit-or-pr.ps1`**, and related helpers — **``.cursor/skills/token-aware-automation/SKILL.md`**.
+- **Plans:** Single source of truth for backlog sequencing is **`docs/plans/PLANS_TODO.md`** (English-only history); operator runbooks live under **`docs/ops/`** (EN + pt-BR).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,17 @@ Thank you for considering contributing. This document covers local setup, workfl
 - **Security:** Do not post exploit details publicly. Use the [Security issue](.github/ISSUE_TEMPLATE/security.md) template (high-level only) or the process in [SECURITY.md](SECURITY.md).
 - **Pull requests:** Use the [PR template](.github/PULL_REQUEST_TEMPLATE.md). Ensure tests pass (`uv run pytest -v -W error`; see [docs/TESTING.md](docs/TESTING.md)), the lint job passes (`uv run ruff check .`), and that docs/README are updated when behaviour or setup changes.
 
+### PR state and agent advice (sync before citing PR numbers)
+
+AI assistants and humans should **not** assume a PR is still open or that local `main` matches GitHub **without a fresh check** — chat context can reference an **already merged** PR (e.g. #80) while the next one (#81) is already merged.
+
+- **Minimum:** `git fetch origin` and, on `main`, `git pull origin main` (or at least `git status -sb`) before advising “merge PR #N” or “what’s next” after a merge.
+- **GitHub CLI:** `gh pr view <n> --json state,mergedAt,url` or `gh pr list --head <your-branch>`.
+- **Automation:** `.\scripts\commit-or-pr.ps1` includes fetch/rebase patterns for PR flows; prefer it over ad-hoc git when possible.
+- **After `gh pr create`:** Run `gh pr view --json number,state,url` (or `gh pr list --head <branch>`) **before** sharing the URL so the number matches the **new** PR, not a previous one.
+
+Cursor encodes this in **`.cursor/rules/git-pr-sync-before-advice.mdc`**. See also **[AGENTS.md](AGENTS.md)**. Brief GitHub lag after merge is possible; re-query `gh` if unsure.
+
 ### Reducing merge conflicts
 
 - **Merge or rebase `main` into your branch before opening a PR.** Run `git fetch origin main` then `git merge origin/main` (or `git rebase origin/main`) and fix any conflicts locally. That way the PR stays mergeable and reviewers see a clean diff.

--- a/CONTRIBUTING.pt_BR.md
+++ b/CONTRIBUTING.pt_BR.md
@@ -46,6 +46,17 @@ Obrigado por considerar contribuir. Este documento cobre a configuração local,
 - **Segurança:** Não publique detalhes de exploração em público. Use o modelo [Security issue](.github/ISSUE_TEMPLATE/security.md) (apenas em alto nível) ou o processo em [SECURITY.md](SECURITY.md) ([pt-BR](SECURITY.pt_BR.md)).
 - **Pull requests:** Use o [modelo de PR](.github/PULL_REQUEST_TEMPLATE.md). Garanta que os testes passem (`uv run pytest -v -W error`; veja [docs/TESTING.md](docs/TESTING.md) ([pt-BR](docs/TESTING.pt_BR.md))) e que docs/README sejam atualizados quando o comportamento ou a configuração mudar.
 
+### Estado do PR e conselhos ao assistente (sincronizar antes de citar número)
+
+Assistentes de IA e humanos **não** devem assumir que um PR ainda está aberto ou que o `main` local bate com o GitHub **sem verificar** — o contexto do chat pode citar um PR **já mergeado** (ex.: #80) enquanto o seguinte (#81) também já foi mergeado.
+
+- **Mínimo:** `git fetch origin` e, no `main`, `git pull origin main` (ou pelo menos `git status -sb`) antes de aconselhar “faça merge do PR #N” ou “o que vem depois” do merge.
+- **GitHub CLI:** `gh pr view <n> --json state,mergedAt,url` ou `gh pr list --head <sua-branch>`.
+- **Automação:** `.\scripts\commit-or-pr.ps1` inclui fetch/rebase nos fluxos de PR; prefira-o ao git manual quando couber.
+- **Depois de `gh pr create`:** Execute `gh pr view --json number,state,url` (ou `gh pr list --head <branch>`) **antes** de compartilhar o URL para o número bater com o PR **novo**, não o anterior.
+
+O Cursor registra isso em **`.cursor/rules/git-pr-sync-before-advice.mdc`**. Veja também **[AGENTS.md](AGENTS.md)**. Pode haver um pequeno atraso do GitHub após o merge; consulte o `gh` de novo se houver dúvida.
+
 ### Reduzir conflitos de merge
 
 - **Faça merge ou rebase de `main` na sua branch antes de abrir um PR.** Execute `git fetch origin main` e depois `git merge origin/main` (ou `git rebase origin/main`) e resolva conflitos localmente. Assim o PR permanece integrável e os revisores veem um diff limpo.


### PR DESCRIPTION
## Summary
Document and enforce refreshing \git\/\gh\ state before merge advice or sharing PR numbers/URLs.

## Changes
- \.cursor/rules/git-pr-sync-before-advice.mdc\ (always apply)
- \AGENTS.md\
- \CONTRIBUTING.md\ / \CONTRIBUTING.pt_BR.md\ — new subsection
- \.cursor/skills/token-aware-automation/SKILL.md\ — PR freshness section

## Tests
\\\
uv run pytest tests/test_markdown_lint.py tests/test_docs_markdown.py
\\\
15 passed.

Made with [Cursor](https://cursor.com)