### PR TITLE
docs(ops): lab completão — SSHFS, WebDAV, iSCSI patterns

### DIFF
--- a/docs/ops/HOMELAB_VALIDATION.md
+++ b/docs/ops/HOMELAB_VALIDATION.md
@@ -8,6 +8,8 @@
 
 **Not legal advice.** For **real** personal data, use **lawful basis**, **minimisation**, and **read-only** technical accounts; prefer **synthetic** or **public sample** data when unsure.
 
+**Multi-host “completão” (full lab round):** This file is the **single-machine** baseline (clone, `check-all`, Docker smoke, synthetic FS). For **ordered E2E across several lab hosts**—Postgres/MariaDB stack, compressed fixtures, optional SMB/NFS/**SSHFS**/WebDAV/**iSCSI-backed** filesystem paths—follow **[LAB_SMOKE_MULTI_HOST.md](LAB_SMOKE_MULTI_HOST.md)** (host order, pass/fail checklist **A–M**, definition of *completão*). **PII / publishing:** do not put real mount lines, credentials, LAN addresses, or home paths in tracked docs or public issues; see [ADR 0018](../adr/0018-pii-anti-recurrence-guardrails-for-tracked-files-and-branch-history.md) and [ADR 0019](../adr/0019-pii-verification-cadence-and-manual-review-gate.md). Operator-specific evidence stays under **gitignored** `docs/private/homelab/`.
+
 **Related:** [deploy/DEPLOY.md](../deploy/DEPLOY.md) · [SONARQUBE_HOME_LAB.md](SONARQUBE_HOME_LAB.md) (optional quality server) · [OPERATOR_IT_REQUIREMENTS.md](OPERATOR_IT_REQUIREMENTS.md) · [TESTING.md](../TESTING.md) · [SECURITY.md](../SECURITY.md) · **Lab-op minimal stack (Podman + k3s):** [LAB_OP_MINIMAL_CONTAINER_STACK.md](LAB_OP_MINIMAL_CONTAINER_STACK.md) · **ThinkPad T14 + LMDE 7:** [LMDE7_T14_DEVELOPER_SETUP.pt_BR.md](LMDE7_T14_DEVELOPER_SETUP.pt_BR.md) · **Optional observability:** [PLAN_LAB_OP_OBSERVABILITY_STACK.md](../plans/PLAN_LAB_OP_OBSERVABILITY_STACK.md) · **Optional SIEM (Wazuh):** [LAB_OP_MINIMAL_CONTAINER_STACK.md](LAB_OP_MINIMAL_CONTAINER_STACK.md) §6
 
 ---
@@ -240,6 +242,7 @@ Keep a **dated note** (e.g. in **`docs/private/homelab/`** or a personal wiki): 
 
 ## See also
 
+- [LAB_SMOKE_MULTI_HOST.md](LAB_SMOKE_MULTI_HOST.md) — **multi-host** DB + filesystem lab, optional **SSHFS / WebDAV / iSCSI→FS**, checklist **A–M**, and what “**completão**” means vs this file’s §1 baseline.
 - [OS_COMPATIBILITY_TESTING_MATRIX.md](OS_COMPATIBILITY_TESTING_MATRIX.md) — **which Linux distros** to test (RHEL/Fedora/AlmaLinux, Arch/Manjaro/BigLinux, Gentoo, musl) prioritized by **production relevance** and **Python 3.12+** availability.
 - [LAB_OP_MINIMAL_CONTAINER_STACK.md](LAB_OP_MINIMAL_CONTAINER_STACK.md) §5 — **tower / Alpine / AlmaLinux**, multi-VM “cluster” simulation, **when** to prioritize **HA / horizontal scale** (vs **–1L** baseline).
 - [HOMELAB_LOCAL_REPOSITORIES.md](HOMELAB_LOCAL_REPOSITORIES.md) — **local Docker registry** and **apt repository** on Proxmox **after** the server is ready; enables **offline** validation, **faster** pulls, and **testing** `.deb` builds before public release.

--- a/docs/ops/HOMELAB_VALIDATION.pt_BR.md
+++ b/docs/ops/HOMELAB_VALIDATION.pt_BR.md
@@ -6,6 +6,8 @@
 
 **Não é aconselhamento jurídico.** Para dados **reais** de pessoas, exija **base legal**, **minimização** e contas técnicas **só leitura**; prefira dados **sintéticos** ou **amostras públicas** quando houver dúvida.
 
+**“Completão” multi-host (volta completa de laboratório):** Este arquivo é o **baseline** de **uma máquina** (clone, `check-all`, smoke Docker, FS sintético). Para **E2E ordenado em vários hosts**—pilha Postgres/MariaDB, arquivos comprimidos, SMB/NFS opcional, **SSHFS**, WebDAV, **filesystem sobre iSCSI** montado no SO—seguir **[LAB_SMOKE_MULTI_HOST.pt_BR.md](LAB_SMOKE_MULTI_HOST.pt_BR.md)** (ordem de hosts, checklist **A–M**, definição de *completão*). **PII / publicação:** não coloques linhas de montagem reais, credenciais, IPs de LAN ou caminhos de casa em docs rastreados ou issues públicas; ver [ADR 0018](../adr/0018-pii-anti-recurrence-guardrails-for-tracked-files-and-branch-history.md) e [ADR 0019](../adr/0019-pii-verification-cadence-and-manual-review-gate.md). Evidência operacional fica em **`docs/private/homelab/`** (gitignored).
+
 **Relacionado:** [deploy/DEPLOY.pt_BR.md](../deploy/DEPLOY.pt_BR.md) · [SONARQUBE_HOME_LAB.md](SONARQUBE_HOME_LAB.md) · [OPERATOR_IT_REQUIREMENTS.pt_BR.md](OPERATOR_IT_REQUIREMENTS.pt_BR.md) · [TESTING.pt_BR.md](../TESTING.pt_BR.md) · [SECURITY.pt_BR.md](../SECURITY.pt_BR.md) · **Lab-op — stack mínimo (Podman + k3s):** [LAB_OP_MINIMAL_CONTAINER_STACK.pt_BR.md](LAB_OP_MINIMAL_CONTAINER_STACK.pt_BR.md) ([EN](LAB_OP_MINIMAL_CONTAINER_STACK.md)) · **T14 + LMDE 7:** [LMDE7_T14_DEVELOPER_SETUP.pt_BR.md](LMDE7_T14_DEVELOPER_SETUP.pt_BR.md) · **Observabilidade opcional:** [PLAN_LAB_OP_OBSERVABILITY_STACK.pt_BR.md](../plans/PLAN_LAB_OP_OBSERVABILITY_STACK.pt_BR.md) · **SIEM (Wazuh):** mesmo doc LAB_OP §6
 
 ---
@@ -111,6 +113,7 @@ Nota datada em **`docs/private/homelab/`** (gitignored): **hostnames**, tag da i
 
 ## 12. Ver também
 
+- [LAB_SMOKE_MULTI_HOST.pt_BR.md](LAB_SMOKE_MULTI_HOST.pt_BR.md) — laboratório **multi-host** (BD + FS), opcional **SSHFS / WebDAV / iSCSI→FS**, checklist **A–M** e o que significa **“completão”** face ao baseline da §1 deste guia.
 - [OS_COMPATIBILITY_TESTING_MATRIX.pt_BR.md](OS_COMPATIBILITY_TESTING_MATRIX.pt_BR.md) — **quais distros** testar (RHEL/Fedora, Arch/Manjaro, Gentoo, musl) priorizadas por relevância em produção.
 - [LAB_OP_MINIMAL_CONTAINER_STACK.pt_BR.md](LAB_OP_MINIMAL_CONTAINER_STACK.pt_BR.md) §5 — torre / **Alpine** / **AlmaLinux**, simulação multi-VM, **quando** priorizar **HA / escala horizontal** (vs baseline **–1L**).
 - [HOMELAB_HOST_PACKAGE_INVENTORY.pt_BR.md](HOMELAB_HOST_PACKAGE_INVENTORY.pt_BR.md) — inventário de pacotes nos hosts (o repo não “vê” as suas máquinas).

--- a/docs/ops/LAB_SMOKE_MULTI_HOST.md
+++ b/docs/ops/LAB_SMOKE_MULTI_HOST.md
@@ -85,6 +85,41 @@ Data Boar reads **whatever path the process sees**. There is no separate “SMB 
 
 **Cross-host:** Other machines (latitude, mini-bt) can use **TCP** to the hub DB; they do **not** need the same cloud mounts unless you are testing **filesystem** on that host — then mount or copy fixtures locally.
 
+### 5.1 SSHFS (FUSE over SSH)
+
+When this works in your lab, it is a **valid** way to expose a **remote directory tree** as a local path—Data Boar then uses a normal **`filesystem`** target (it does not implement SSHFS itself).
+
+1. **Packages (typical Linux):** `sshfs` + FUSE (`fuse3` / `fuse` depending on distro). On **WSL2**, ensure FUSE/WinFsp pieces match your distro docs; treat failures as **environment** issues, not product bugs.
+1. **Mount (illustrative only—use your lab user/host and paths):**
+
+   ```bash
+   mkdir -p /mnt/lab-sshfs
+   sshfs USER@HOST:/remote/path /mnt/lab-sshfs -o reconnect,ServerAliveInterval=15,ServerAliveCountMax=3,ro
+   ```
+
+   Prefer **`-o ro`** for audit-style reads when the remote side allows it.
+1. **Config:** `type: filesystem`, `path:` under the mount (e.g. `/mnt/lab-sshfs/...`). Same scanning rules as any local tree; expect **higher latency** and occasional **stale handle** behaviour on flaky Wi‑Fi—`reconnect` and keep-alive options reduce drops.
+1. **Unmount:** `fusermount -u /mnt/lab-sshfs` (Linux) or your OS’s equivalent.
+1. **PII and publishing discipline:** Do **not** put real `USER@HOST`, keys, LAN IPs, or home paths into **tracked** Markdown, issues, or PR bodies. Guardrails: [ADR 0018](../adr/0018-pii-anti-recurrence-guardrails-for-tracked-files-and-branch-history.md), [ADR 0019](../adr/0019-pii-verification-cadence-and-manual-review-gate.md). Keep operator-specific mount lines in **gitignored** notes under `docs/private/homelab/` if you need a durable record.
+
+### 5.2 WebDAV — two integration patterns
+
+| Pattern | When | Data Boar side |
+| ------- | ---- | -------------- |
+| **A — Native connector** | You want to exercise **`webdavclient3`** / the share pipeline over **HTTPS** | `type: webdav`, `base_url`, credentials per [TECH_GUIDE.md](../TECH_GUIDE.md) / [USAGE.md](../USAGE.md); install **`.[shares]`** |
+| **B — OS mount** | You want the same **code path** as SMB/NFS (directory looks local) | Mount with **davfs2**, **rclone mount**, or similar, then **`type: filesystem`** on the mount point |
+
+Pick **one** pattern per test run so failures are easy to attribute (connector vs FUSE vs network).
+
+### 5.3 iSCSI / block devices / “LBA”
+
+- **iSCSI:** The product has **no** iSCSI initiator connector. The supported workflow is entirely **in the OS**: attach LUN → partition/format if needed → **mount a filesystem** → point a **`filesystem`** target at that mount.
+- **LBA (logical block addressing):** A disk/geometry detail **below** the filesystem. It does **not** appear in Data Boar YAML; only the **mounted path** matters for scans.
+
+### 5.4 Ordering (efficiency)
+
+Run **§5.1–5.3** optional checks **after** checklist **A–I** are green. Treat **J** and **K–M** as **optional** expansions of the same “completão” round—not a substitute for **`check-all`** or CI.
+
 ---
 
 ## 6. pi3b (ARM) — when to include
@@ -115,8 +150,13 @@ Use after **§1** host order. Tick when done on your lab sheet.
 | H | **pi3b:** `scan.max_workers: 1`; last in chain. | Completes or documents timeout/OOM for runbook. |
 | I | **Filesystem extras:** mount `tests/data/compressed` **and** `tests/data/homelab_synthetic` read-only; `scan_compressed: true`. | Findings in archives + text/CSV linkage files. |
 | J | **Shares (optional):** SMB/NFS/sshfs/cloud-local path in `filesystem` target after OS mount. | Same as any FS target — verify hydrated files (not cloud placeholders). |
+| K | **WebDAV connector (optional):** `type: webdav` against a lab server; credentials only in **private** / gitignored config. | Session completes; listing/download behaves per [TECH_GUIDE.md](../TECH_GUIDE.md); no credential echoes in logs you would paste publicly. |
+| L | **SSHFS (optional):** mount per **§5.1**, then `filesystem` target on the mount. | Scan completes or you document timeouts/latency limits for the runbook—**no** real hostnames/IPs in tracked docs. |
+| M | **iSCSI → FS (optional):** OS presents block device, mounted path, then `filesystem` target. | Proves **OS + storage** stack; same pass criteria as §2—**not** a separate product feature. |
 
 **Blocked today?** If LAB-OP logs show **diverging branches** or **disk full**, steps **A–B** must be done before meaningful host reports or fresh `uv sync` on those machines.
+
+**Definition — “completão”:** This checklist (**A–M** as applicable) plus repo **`.\scripts\check-all.ps1`** on the dev machine is the **full** manual lab round the project names in operator chatter—**not** “pytest only on one PC.” Skipping physical hosts is fine only when you explicitly record **why** (time, hardware down).
 
 ---
 

--- a/docs/ops/LAB_SMOKE_MULTI_HOST.pt_BR.md
+++ b/docs/ops/LAB_SMOKE_MULTI_HOST.pt_BR.md
@@ -85,6 +85,41 @@ O Data Boar lê **o path que o processo vê**. Não há conector SMB separado �
 
 **Entre hosts:** Outras máquinas (latitude, mini-bt) podem usar **TCP** para o BD no hub; **não** precisam das mesmas montagens de nuvem salvo que estejam a testar **filesystem** nesse host — aí montam ou copiam fixtures localmente.
 
+### 5.1 SSHFS (FUSE sobre SSH)
+
+Quando isto funciona no teu laboratório, é um modo **válido** de expor uma **árvore remota** como path local—o Data Boar usa depois um alvo **`filesystem`** normal (não implementa SSHFS por si).
+
+1. **Pacotes (Linux típico):** `sshfs` + FUSE (`fuse3` / `fuse` conforme a distro). Em **WSL2**, alinha FUSE/WinFsp à documentação da tua distro; falhas são **ambiente**, não bug do produto.
+1. **Montagem (só ilustrativo—usa usuário/host/paths do teu lab):**
+
+   ```bash
+   mkdir -p /mnt/lab-sshfs
+   sshfs USER@HOST:/caminho/remoto /mnt/lab-sshfs -o reconnect,ServerAliveInterval=15,ServerAliveCountMax=3,ro
+   ```
+
+   Preferir **`-o ro`** para leitura tipo auditoria quando o remoto permitir.
+1. **Config:** `type: filesystem`, `path:` por baixo do mount (ex.: `/mnt/lab-sshfs/...`). Mesmas regras que qualquer árvore local; espera **maior latência** e possíveis **handles** instáveis com Wi‑Fi fraco—`reconnect` e keep-alive ajudam.
+1. **Desmontar:** `fusermount -u /mnt/lab-sshfs` (Linux) ou equivalente no SO.
+1. **PII e publicação:** **Não** coloques `USER@HOST` reais, chaves, IPs de LAN ou caminhos de casa em Markdown **rastreado**, issues ou corpos de PR. Referências: [ADR 0018](../adr/0018-pii-anti-recurrence-guardrails-for-tracked-files-and-branch-history.md), [ADR 0019](../adr/0019-pii-verification-cadence-and-manual-review-gate.md). Notas operacionais com montagens reais ficam em **`docs/private/homelab/`** (gitignored).
+
+### 5.2 WebDAV — dois padrões de integração
+
+| Padrão | Quando | Lado Data Boar |
+| ------ | ------ | -------------- |
+| **A — Conector nativo** | Queres exercitar **`webdavclient3`** / o pipeline de shares por **HTTPS** | `type: webdav`, `base_url`, credenciais conforme [TECH_GUIDE.pt_BR.md](../TECH_GUIDE.pt_BR.md) / [USAGE.pt_BR.md](../USAGE.pt_BR.md); instalar **`.[shares]`** |
+| **B — Montagem no SO** | Queres o mesmo **caminho de código** que SMB/NFS (diretório parece local) | Montar com **davfs2**, **rclone mount**, ou similar, depois **`type: filesystem`** no ponto de montagem |
+
+Escolhe **um** padrão por corrida de teste para falhas serem fáceis de atribuir (conector vs FUSE vs rede).
+
+### 5.3 iSCSI / dispositivos de bloco / “LBA”
+
+- **iSCSI:** O produto **não** tem conector iniciador iSCSI. O fluxo suportado é **só no SO**: anexar LUN → particionar/formatar se preciso → **montar filesystem** → alvo **`filesystem`** nesse mount.
+- **LBA (endereçamento lógico de blocos):** Detalhe de disco/geometria **abaixo** do filesystem. **Não** entra no YAML do Data Boar; só importa o **path montado**.
+
+### 5.4 Ordem (eficiência)
+
+Corre os opcionais **§5.1–5.3** **depois** de **A–I** verdes. Trata **J** e **K–M** como **expansões opcionais** da mesma volta “completão”—não substituem **`check-all`** nem CI.
+
 ---
 
 ## 6. pi3b (ARM) — quando incluir
@@ -115,8 +150,13 @@ Usar depois da ordem de hosts da **§1**. Marcar na tua folha de laboratório.
 | H | **pi3b:** `scan.max_workers: 1`; último na cadeia. | Conclui ou documenta timeout/OOM para o runbook. |
 | I | **Filesystem extra:** montar `tests/data/compressed` **e** `tests/data/homelab_synthetic` só leitura; `scan_compressed: true`. | Findings em arquivos compactados + texto/CSV de ligação. |
 | J | **Compartilhamentos (opcional):** SMB/NFS/sshfs/pasta de nuvem local em alvo `filesystem` depois de montado no SO. | Igual a qualquer alvo FS — arquivos hidratados (não placeholders de nuvem). |
+| K | **Conector WebDAV (opcional):** `type: webdav` contra um servidor de lab; credenciais só em config **privada** / gitignored. | Sessão concluída; listagem/download conforme [TECH_GUIDE.pt_BR.md](../TECH_GUIDE.pt_BR.md); sem eco de credenciais em logs que vás colar publicamente. |
+| L | **SSHFS (opcional):** montagem conforme **§5.1**, depois alvo `filesystem` no mount. | Scan concluído ou documentas timeouts/limites de latência no runbook—**sem** hostnames/IPs reais em docs rastreados. |
+| M | **iSCSI → FS (opcional):** SO apresenta bloco, path montado, depois alvo `filesystem`. | Comprova **SO + storage**; mesmo critério que §2—**não** é feature separada do produto. |
 
 **Bloqueios atuais?** Se os logs LAB-OP mostrarem **ramos divergentes** ou **disco cheio**, os passos **A–B** são obrigatórios antes de relatórios de host úteis ou `uv sync` fresco nessas máquinas.
+
+**Definição — “completão”:** Esta checklist (**A–M** conforme aplicável) mais **`.\scripts\check-all.ps1`** na raiz no PC de desenvolvimento é a volta manual **completa** que o projeto menciona em conversa de operador—**não** “só pytest num PC.” Omitir hosts físicos só com **motivo** registado (tempo, hardware offline).
 
 ---
 


### PR DESCRIPTION
## Summary
- Expand **LAB_SMOKE_MULTI_HOST** with SSHFS (FUSE), WebDAV (connector vs OS mount), and iSCSI→filesystem notes; define **completão** vs single-host baseline.
- Add checklist rows **K–M**; cross-link **HOMELAB_VALIDATION** with ADR **0018**/**0019** PII discipline (no real mounts in tracked docs).

## Validation
- \.\scripts\check-all.ps1\ passed locally.

Made with [Cursor](https://cursor.com)