### PR TITLE
docs(ops): OPERATOR_TODAY_MODE_2026-04-22 (EN + pt-BR)

### DIFF
--- a/docs/ops/today-mode/OPERATOR_TODAY_MODE_2026-04-22.md
+++ b/docs/ops/today-mode/OPERATOR_TODAY_MODE_2026-04-22.md
@@ -1,0 +1,42 @@
+# Operator today mode — 2026-04-22 (post PR #213: README pitch, plans hub, compliance mirrors)
+
+**Português (Brasil):** [OPERATOR_TODAY_MODE_2026-04-22.pt_BR.md](OPERATOR_TODAY_MODE_2026-04-22.pt_BR.md)
+
+**Theme:** **`main`** should include **PR #213** (README stakeholder pitch + deck vocabulary, **ADR 0035**, plans hub/todo wording, **COMPLIANCE** / **GLOSSARY** / **TECH_GUIDE** / **TESTING** touch-ups, **`test_readme_stakeholder_pitch_contract`**). **First:** **`git fetch origin`** · **`git checkout main`** · **`git pull origin main`** — confirm tip of **`origin/main`** and clean **`git status`**. **Then:** pick the next **`PLANS_TODO.md`** row or a small **`feature`** slice; run **`.\scripts\check-all.ps1`** before any new PR. **Stacked private:** sync if **`docs/private/`** changed — **`.\scripts\private-git-sync.ps1`**.
+
+---
+
+## Block 0 — Morning reality check (10–15 min)
+
+Run **`carryover-sweep`** or **`.\scripts\operator-day-ritual.ps1 -Mode Morning`**. Then:
+
+1. Confirm **no open PR** supersedes doc README pitch work ( **`gh pr list --state open`** ).
+2. Optional quick doc guard: **`uv run pytest tests/test_readme_stakeholder_pitch_contract.py tests/test_docs_pt_br_locale.py -q`**
+
+**Rolling queue:** [CARRYOVER.md](CARRYOVER.md) · **Published truth:** [PUBLISHED_SYNC.md](PUBLISHED_SYNC.md)
+
+### Social / editorial (private hub) — ~2 min
+
+- [ ] Skim **`docs/private/social_drafts/editorial/SOCIAL_HUB.md`** for **Alvo** matching **2026-04-22** — [SOCIAL_PUBLISH_AND_TODAY_MODE.md](SOCIAL_PUBLISH_AND_TODAY_MODE.md).
+
+---
+
+## Carryover — from prior EOD
+
+- [ ] **`main`** fast-forwarded after **#213** merge — no stray **`docs/readme-stakeholder-pitch-restore`** work left unpulled unless you open a follow-up branch.
+- [ ] **Private git:** ritual may have flagged pending lines — commit/push private repo when appropriate (no secrets in public PRs).
+
+---
+
+## End of day
+
+- **`eod-sync`** or **`.\scripts\operator-day-ritual.ps1 -Mode Eod`**
+- Skim **`OPERATOR_TODAY_MODE_2026-04-23.md`** next (create from this file if needed)
+
+---
+
+## Quick references
+
+- **`docs/adr/0035-readme-stakeholder-pitch-vs-deck-vocabulary.md`** — pitch vs deck wording
+- **`docs/plans/PLANS_TODO.md`** · **`docs/plans/PLANS_HUB.md`**
+- Session keywords: **`eod-sync`**, **`carryover-sweep`**, **`pmo-view`**

--- a/docs/ops/today-mode/OPERATOR_TODAY_MODE_2026-04-22.pt_BR.md
+++ b/docs/ops/today-mode/OPERATOR_TODAY_MODE_2026-04-22.pt_BR.md
@@ -1,0 +1,42 @@
+# Modo hoje do operador — 2026-04-22 (pós PR #213: pitch README, hub de planos, espelhos de compliance)
+
+**English:** [OPERATOR_TODAY_MODE_2026-04-22.md](OPERATOR_TODAY_MODE_2026-04-22.md)
+
+**Tema:** o **`main`** deve incluir o **PR #213** (pitch README + vocabulário do deck, **ADR 0035**, ajustes de hub/todo nos planos, toques em **COMPLIANCE** / **GLOSSARY** / **TECH_GUIDE** / **TESTING**, teste **`test_readme_stakeholder_pitch_contract`**). **Primeiro:** **`git fetch origin`** · **`git checkout main`** · **`git pull origin main`** — confirmar merge recente e **`git status`** limpo. **Depois:** próxima linha do **`PLANS_TODO.md`** ou fatia **`feature`** pequena; rodar **`.\scripts\check-all.ps1`** antes de novo PR. **Privado empilhado:** se **`docs/private/`** mudou, **`.\scripts\private-git-sync.ps1`**.
+
+---
+
+## Bloco 0 — Manhã (10–15 min)
+
+Roda **`carryover-sweep`** ou **`.\scripts\operator-day-ritual.ps1 -Mode Morning`**. Depois:
+
+1. Confirmar que não ficou PR aberto redundante em cima do README pitch (**`gh pr list --state open`**).
+2. Opcional: **`uv run pytest tests/test_readme_stakeholder_pitch_contract.py tests/test_docs_pt_br_locale.py -q`**
+
+**Fila:** [CARRYOVER.pt_BR.md](CARRYOVER.pt_BR.md) · **Publicado:** [PUBLISHED_SYNC.pt_BR.md](PUBLISHED_SYNC.pt_BR.md)
+
+### Social / editorial (hub privado) — ~2 min
+
+- [ ] Olhar **`docs/private/social_drafts/editorial/SOCIAL_HUB.md`** por **Alvo** em **2026-04-22** — [SOCIAL_PUBLISH_AND_TODAY_MODE.pt_BR.md](SOCIAL_PUBLISH_AND_TODAY_MODE.pt_BR.md).
+
+---
+
+## Carryover — do EOD anterior
+
+- [ ] **`main`** atualizado após merge do **#213** — sem trabalho pendente na branch antiga, salvo follow-up explícito.
+- [ ] **Git privado:** se o ritual sinalizou pendências, commit/push no repo empilhado (nada de segredo em PR público).
+
+---
+
+## Fim do dia
+
+- **`eod-sync`** ou **`.\scripts\operator-day-ritual.ps1 -Mode Eod`**
+- Reler ou criar **`OPERATOR_TODAY_MODE_2026-04-23.md`** a partir deste arquivo se precisar
+
+---
+
+## Referências rápidas
+
+- **`docs/adr/0035-readme-stakeholder-pitch-vs-deck-vocabulary.md`** — pitch vs deck
+- **`docs/plans/PLANS_TODO.md`** · **`docs/plans/PLANS_HUB.md`**
+- Atalhos: **`eod-sync`**, **`carryover-sweep`**, **`pmo-view`**


### PR DESCRIPTION
Adds paired today-mode checklists for 2026-04-22 after PR #213 merge: pull main, optional README/locale pytest, PLANS_TODO next slice, private-git sync. Prepares morning ritual and EOD pointer to 2026-04-23.

Made with [Cursor](https://cursor.com)