### PR TITLE
docs(compliance): BR insurance LGPD anchor sample + frameworks subsection

### DIFF
--- a/docs/COMPLIANCE_FRAMEWORKS.md
+++ b/docs/COMPLIANCE_FRAMEWORKS.md
@@ -28,6 +28,20 @@ For **slide banks, workshop handouts, and structured compliance technical docs**
 
 ---
 
+## Brazil insurance sector (LGPD anchoring + prudential references) {#brazil-insurance-sector-lgpd-anchoring-prudential-references}
+
+**Not legal advice.** This subsection orients technical and compliance readers who operate in **Brazilian private insurance** (SUSEP-supervised undertakings, brokers, and service providers). It is **not** a substitute for counsel, ANPD guidance, or prudential supervision practice.
+
+**What the product does here:** Data Boar supports **discovery, sampling, and metadata-oriented reporting** (including configurable **`norm_tag`** text). It does **not** certify **LGPD** compliance, **SUSEP/CNSP** compliance, solvency reporting, licensing, or any supervisory outcome.
+
+**LGPD as the primary data-protection anchor:** Personal and sensitive data processed in insurance workflows remain subject to the **Lei Geral de Proteção de Dados** (LGPD). Official text: [Planalto — Lei nº 13.709/2018](https://www.planalto.gov.br/ccivil_03/leis/2018/l13709.htm). The **ANPD** publishes guidance applicable across sectors: [gov.br — ANPD](https://www.gov.br/anpd/pt-br).
+
+**Prudential and market-conduct layer (sector, not a substitute for LGPD):** **SUSEP** supervises private insurance in Brazil; **CNSP** (within that policy ecosystem) issues resolutions that firms must operationalise alongside LGPD where personal data is involved. Official entry point for instruments and communications: [gov.br — SUSEP](https://www.gov.br/susep/pt-br). **Circular letters** and **CNSP** norms appear in SUSEP’s official **legislation / normative** channels on the same portal; always use the **current consolidated** text on **gov.br** before relying on any deep link.
+
+**Optional YAML skeleton:** For **generic** insurance-sector column names and document vocabulary with **LGPD-inventory-oriented** `norm_tag` strings (still **not** a regulatory certification), see [compliance-sample-br_insurance_lgpd_anchor.yaml](compliance-samples/compliance-sample-br_insurance_lgpd_anchor.yaml) in the table below. Pair it with the full **[compliance-sample-lgpd.yaml](compliance-samples/compliance-sample-lgpd.yaml)** profile when you need Brazilian identifier coverage (CPF, CNPJ, etc.).
+
+---
+
 ## Compliance samples
 
 Sample configuration files for **UK GDPR**, **EU GDPR**, **Benelux**, **PIPEDA**, **POPIA**, **APPI**, **PCI-DSS**, **Russia (152-FZ)**, and optional regional frameworks are in [compliance-samples/](compliance-samples/). Each file is self-contained (regex overrides, ML terms, recommendation overrides) so you can enable one framework by pointing your config at that file and merging its overrides.
@@ -39,6 +53,7 @@ Laws, guidance, and real-world identifier usage evolve in many sampled jurisdict
 | Regulation / region           | Sample file                                                                                                 | Purpose                                                                                             |
 | -------------------           | -----------                                                                                                 | -------                                                                                             |
 | **LGPD (Brazil)**             | [compliance-sample-lgpd.yaml](compliance-samples/compliance-sample-lgpd.yaml)                               | Bilingual PT-BR + EN terms; RG/CEP regex; Brazilian deployments.                                    |
+| **Brazil (insurance sector — LGPD inventory skeleton)** | [compliance-sample-br_insurance_lgpd_anchor.yaml](compliance-samples/compliance-sample-br_insurance_lgpd_anchor.yaml) | Generic insurance lexicon + LGPD-anchored **`norm_tag`** for inventory; **not** SUSEP/CNSP certification (see [insurance subsection](#brazil-insurance-sector-lgpd-anchoring-prudential-references)). |
 | **UK GDPR**                   | [compliance-sample-uk_gdpr.yaml](compliance-samples/compliance-sample-uk_gdpr.yaml)                         | UK post-Brexit, ICO-aligned; norm_tag and recommendation overrides.                                 |
 | **EU GDPR (EEA)**             | [compliance-sample-eu_gdpr.yaml](compliance-samples/compliance-sample-eu_gdpr.yaml)                         | EU 2016/679 Art. 4(1), EDPB, member-state DPAs; optional EN + DE/FR terms.                          |
 | **Benelux (BE, NL, LU)**      | [compliance-sample-benelux.yaml](compliance-samples/compliance-sample-benelux.yaml)                         | EU GDPR base + national IDs (BSN, NISS, LU); national DPA overrides; EN + NL/FR.                    |

--- a/docs/COMPLIANCE_FRAMEWORKS.pt_BR.md
+++ b/docs/COMPLIANCE_FRAMEWORKS.pt_BR.md
@@ -26,6 +26,20 @@ Para **decks**, **apostilas de workshop** e **documentação técnica estruturad
 
 ---
 
+## Setor segurador no Brasil (ancoragem LGPD + referências prudenciais) {#setor-segurador-brasil-lgpd-referencias-prudenciais}
+
+**Não é aconselhamento jurídico.** Este trecho orienta leitores técnicos e de **conformidade** que atuam em **seguros privados** no Brasil (sociedades supervisionadas pela **SUSEP**, corretores e prestadores). **Não** substitui assessoria jurídica, orientações da **ANPD** ou prática perante o supervisor prudencial.
+
+**O que o produto faz aqui:** o Data Boar apoia **descoberta, amostragem e relatórios orientados a metadados** (incluindo texto configurável de **`norm_tag`**). **Não** certifica **conformidade** com a **LGPD**, com regras **SUSEP/CNSP**, com solvência, licenciamento ou qualquer resultado supervisionado.
+
+**LGPD como âncora principal de proteção de dados:** dados pessoais e sensíveis tratados em fluxos de seguro continuam sujeitos à **Lei Geral de Proteção de Dados**. Texto oficial: [Planalto — Lei nº 13.709/2018](https://www.planalto.gov.br/ccivil_03/leis/2018/l13709.htm). A **ANPD** publica orientações aplicáveis em setores cruzados: [gov.br — ANPD](https://www.gov.br/anpd/pt-br).
+
+**Camada prudencial e de conduta de mercado (setor, sem substituir a LGPD):** a **SUSEP** supervisiona os seguros privados no Brasil; o **CNSP** integra o arcabouço normativo com resoluções que as sociedades precisam operacionalizar **em conjunto** com a LGPD quando houver dados pessoais. Ponto de entrada oficial para instrumentos e comunicações: [gov.br — SUSEP](https://www.gov.br/susep/pt-br). **Circulares** e normas do **CNSP** aparecem nos canais oficiais de **legislação / normativos** do mesmo portal; use sempre o **texto consolidado atual** em **gov.br** antes de depender de qualquer link profundo.
+
+**Esqueleto YAML opcional:** para vocabulário **genérico** de colunas e documentos do **setor segurador** com strings de **`norm_tag`** orientadas a **inventário sob a LGPD** (ainda **sem** certificação regulatória), veja [compliance-sample-br_insurance_lgpd_anchor.yaml](compliance-samples/compliance-sample-br_insurance_lgpd_anchor.yaml) na tabela abaixo. Combine com o perfil completo **[compliance-sample-lgpd.yaml](compliance-samples/compliance-sample-lgpd.yaml)** quando precisar de cobertura de identificadores brasileiros (CPF, CNPJ, etc.).
+
+---
+
 ## Amostras de conformidade
 
 Arquivos de configuração de amostra para **UK GDPR**, **EU GDPR**, **Benelux**, **PIPEDA**, **POPIA**, **APPI**, **PCI-DSS**, **Rússia (152-FZ)** e frameworks regionais opcionais estão em [compliance-samples/](compliance-samples/). Cada arquivo é autocontido (regex overrides, termos ML, recommendation overrides) para você habilitar um framework apontando o config para esse arquivo e mesclando os overrides.
@@ -37,6 +51,7 @@ Lei, orientações de autoridade e o uso real de identificadores evoluem em muit
 | Regulamento / região            | Arquivo                                                                                                     | Finalidade                                                                                                                          |
 | --------------------            | -------                                                                                                     | ----------                                                                                                                          |
 | **LGPD (Brasil)**               | [compliance-sample-lgpd.yaml](compliance-samples/compliance-sample-lgpd.yaml)                               | Termos PT-BR + EN; regex RG/CEP; implantações brasileiras.                                                                          |
+| **Brasil (setor segurador — esqueleto inventário LGPD)** | [compliance-sample-br_insurance_lgpd_anchor.yaml](compliance-samples/compliance-sample-br_insurance_lgpd_anchor.yaml) | Léxico genérico de seguros + **`norm_tag`** ancorada em inventário LGPD; **não** é certificação SUSEP/CNSP (ver [subseção setor segurador](#setor-segurador-brasil-lgpd-referencias-prudenciais)). |
 | **UK GDPR**                     | [compliance-sample-uk_gdpr.yaml](compliance-samples/compliance-sample-uk_gdpr.yaml)                         | Pós-Brexit, ICO; norm_tag e recommendation overrides.                                                                               |
 | **EU GDPR (EEE)**               | [compliance-sample-eu_gdpr.yaml](compliance-samples/compliance-sample-eu_gdpr.yaml)                         | Regulamento 2016/679 Art. 4(1), EDPB, DPAs nacionais; EN + DE/FR opcionais.                                                         |
 | **Benelux (BE, NL, LU)**        | [compliance-sample-benelux.yaml](compliance-samples/compliance-sample-benelux.yaml)                         | Base EU GDPR + IDs nacionais (BSN, NISS, LU); overrides DPA nacionais; EN + NL/FR.                                                  |

--- a/docs/compliance-samples/README.md
+++ b/docs/compliance-samples/README.md
@@ -11,6 +11,7 @@ For operational governance (scope, minimization, retention, traceability), use [
 | File                                           | Purpose                                                                                                                                                             |
 | ------                                         | ---------                                                                                                                                                           |
 | **compliance-sample-lgpd.yaml**                | LGPD (Brazil): bilingual PT-BR + EN terms (e.g. documento oficial / official document, RG, CNH / Driver License); RG/CEP regex; for Brazilian deployments.          |
+| **compliance-sample-br_insurance_lgpd_anchor.yaml** | Brazil insurance sector: **skeleton** EN-header sample with generic insurance terms and LGPD-inventory **`norm_tag`** strings; **not** SUSEP/CNSP certification — see [COMPLIANCE_FRAMEWORKS.md](../COMPLIANCE_FRAMEWORKS.md#brazil-insurance-sector-lgpd-anchoring-prudential-references). |
 | **compliance-sample-uk_gdpr.yaml**             | UK GDPR (UK post-Brexit + EU-like): norm_tag and recommendation overrides aligned with ICO and UK provisions.                                                       |
 | **compliance-sample-eu_gdpr.yaml**             | EU GDPR (EEA): EU 2016/679 Art. 4(1), EDPB, member-state DPAs; optional EN + DE/FR terms.                                                                           |
 | **compliance-sample-benelux.yaml**             | Benelux (BE, NL, LU): EU GDPR base + national IDs (BSN, NISS, Luxembourg ID) and national DPA overrides; EN + NL/FR terms.                                          |
@@ -55,6 +56,7 @@ When choosing or authoring a sample, consider the **language(s)** of the target 
 | Regulation / region               | Recommended language(s) for terms and labels                                                                   |
 | -------------------               | ---------------------------------------------                                                                  |
 | **LGPD (Brazil)**                 | Portuguese (BR) and English (e.g. "documento oficial" and "official document", "CNH" and "Driver License").    |
+| **Brazil (insurance — LGPD skeleton)** | Portuguese (BR) and English for policy/claims/brokerage column names; merge with full LGPD sample for national IDs. |
 | **PIPEDA (Canada)**               | English and French (e.g. "personal information" and "renseignements personnels") where scanning Canadian data. |
 | **UK GDPR**                       | English.                                                                                                       |
 | **EU GDPR (EEA)**                 | English; optional German/French for multilingual EU data.                                                      |

--- a/docs/compliance-samples/README.pt_BR.md
+++ b/docs/compliance-samples/README.pt_BR.md
@@ -11,6 +11,7 @@ Para governança operacional (escopo, minimização, retenção e rastreabilidad
 | Arquivo                                        | Finalidade                                                                                                                                                                                          |
 | ---------                                      | ------------                                                                                                                                                                                        |
 | **compliance-sample-lgpd.yaml**                | LGPD (Brasil): termos bilíngues PT-BR + EN (ex.: documento oficial / official document, RG, CNH / Driver License); regex RG/CEP; para implantações brasileiras.                                     |
+| **compliance-sample-br_insurance_lgpd_anchor.yaml** | Setor segurador (Brasil): amostra **esqueleto** (cabeçalho EN) com termos genéricos e **`norm_tag`** de inventário ancorada na LGPD; **não** certifica SUSEP/CNSP — ver [COMPLIANCE_FRAMEWORKS.pt_BR.md](../COMPLIANCE_FRAMEWORKS.pt_BR.md#setor-segurador-brasil-lgpd-referencias-prudenciais). |
 | **compliance-sample-uk_gdpr.yaml**             | UK GDPR (Reino Unido pós-Brexit + semelhante à UE): norm_tag e recommendation overrides alinhados à ICO e disposições britânicas.                                                                   |
 | **compliance-sample-eu_gdpr.yaml**             | EU GDPR (EEE): Art. 4(1) Reg. UE 2016/679, EDPB, autoridades nacionais; termos opcionais EN + DE/FR.                                                                                                |
 | **compliance-sample-benelux.yaml**             | Benelux (BE, NL, LU): base EU GDPR + IDs nacionais (BSN, NISS, ID Luxemburgo) e overrides para DPAs nacionais; termos EN + NL/FR.                                                                   |
@@ -39,6 +40,7 @@ Ao escolher ou criar uma amostra, considere o(s) **idioma(s)** da região alvo p
 | Regulamento / região             | Idioma(s) recomendado(s) para termos e rótulos                                                             |
 | --------------------             | ------------------------------------------------                                                           |
 | **LGPD (Brasil)**                | Português (BR) e inglês (ex.: "documento oficial" e "official document", "CNH" e "Driver License").        |
+| **Brasil (seguros — esqueleto LGPD)** | Português (BR) e inglês para nomes de colunas de apólice/sinistro/corretagem; mescle com a amostra LGPD completa para identificadores nacionais. |
 | **PIPEDA (Canadá)**              | Inglês e francês (ex.: "personal information" e "renseignements personnels") ao varrer dados canadenses.   |
 | **UK GDPR**                      | Inglês.                                                                                                    |
 | **EU GDPR (EEE)**                | Inglês; opcional alemão/francês para dados multilingues na UE.                                             |

--- a/docs/compliance-samples/compliance-sample-br_insurance_lgpd_anchor.yaml
+++ b/docs/compliance-samples/compliance-sample-br_insurance_lgpd_anchor.yaml
@@ -1,0 +1,59 @@
+# Brazil — insurance-sector data inventory (LGPD-anchored labels) — skeleton sample (EN header)
+#
+# NOT LEGAL ADVICE. This file is a technical starting point for tagging column names
+# and free text that often appear in insurance operations. It does NOT certify
+# compliance with LGPD, SUSEP, CNSP, or any prudential rule. It does NOT replace
+# counsel, DPO analysis, or regulator-facing filings.
+#
+# Scope: generic norm_tag strings for inventory and report wording only. Extend
+# regex and terms after your own legal and data-governance review.
+#
+# How to use:
+#   regex_overrides_file: path/to/compliance-sample-br_insurance_lgpd_anchor.yaml
+#   ml_patterns_file: path/to/compliance-sample-br_insurance_lgpd_anchor.yaml
+# Merge recommendation_overrides into report.recommendation_overrides.
+
+regex:
+  - name: "INS_POLICY_MENTION_GENERIC"
+    pattern: "(?i)\\b(insurance\\s+policy|policy\\s+holder|ap[oó]lice\\s+de\\s+seguro)\\b"
+    norm_tag: "LGPD inventory (insurance document mention)"
+
+terms:
+  - text: "insured party"
+    label: sensitive
+  - text: "policyholder"
+    label: sensitive
+  - text: "beneficiary name"
+    label: sensitive
+  - text: "premium amount"
+    label: sensitive
+  - text: "claim number"
+    label: sensitive
+  - text: "underwriting notes"
+    label: sensitive
+  - text: "segurado"
+    label: sensitive
+  - text: "seguradora"
+    label: sensitive
+  - text: "sinistro"
+    label: sensitive
+  - text: "apolice"
+    label: sensitive
+  - text: "beneficiario"
+    label: sensitive
+  - text: "beneficiário"
+    label: sensitive
+  - text: "corretagem"
+    label: sensitive
+  - text: "proposta de seguro"
+    label: sensitive
+  - text: "dados cadastrais"
+    label: sensitive
+
+recommendation_overrides:
+  - norm_tag_pattern: "LGPD inventory (insurance document mention)"
+    base_legal: "LGPD (Brazil) — personal and sensitive data in insurance operations; this tag marks document or field vocabulary for inventory only."
+    risk: "Insurance files often combine identifiers, health or financial context, and third-party data; false positives and jurisdictional overlap are common without legal and facts review."
+    recommendation: "Pair this inventory output with your LGPD RoPA/legitimate basis mapping and sector-specific obligations. Consult DPO and qualified counsel; do not treat detector labels as regulatory certification."
+    priority: "MEDIA"
+    relevant_for: "DPO, insurance compliance, IT security, legal counsel"

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -69,6 +69,10 @@ def test_commit_or_pr_ps1_syntax():
         "$null = [System.Management.Automation.Language.Parser]::ParseFile($path, [ref]$null, [ref]$errors); "
         "exit ([int]($errors -and $errors.Count -gt 0))"
     )
+    # CI runners occasionally cold-start pwsh slowly; try both shells and allow
+    # a bit more time than a typical local parse.
+    timeout_s = 30
+    errors: list[str] = []
     for pw in ("pwsh", "powershell"):
         try:
             proc = subprocess.run(
@@ -76,14 +80,21 @@ def test_commit_or_pr_ps1_syntax():
                 cwd=str(root),
                 capture_output=True,
                 text=True,
-                timeout=10,
+                timeout=timeout_s,
             )
         except FileNotFoundError:
+            continue
+        except subprocess.TimeoutExpired:
+            errors.append(f"{pw}: timed out after {timeout_s}s")
             continue
         assert proc.returncode == 0, (
             f"commit-or-pr.ps1 parse failed with {pw}: {proc.stderr or proc.stdout}"
         )
         return
+    if errors:
+        raise AssertionError(
+            "commit-or-pr.ps1 parse check: " + "; ".join(errors),
+        )
 
 
 def test_commit_or_pr_ps1_has_param_block():


### PR DESCRIPTION
Adds compliance-sample-br_insurance_lgpd_anchor.yaml (skeleton: generic insurance terms, LGPD-inventory norm_tag, explicit not-legal-advice and no SUSEP/CNSP certification). Adds EN + pt-BR subsection in COMPLIANCE_FRAMEWORKS linking LGPD (Planalto), ANPD, and SUSEP official portal for prudential/circular references. Updates compliance-samples README tables and language hints.

Made with [Cursor](https://cursor.com)