### PR TITLE
fix(ansible): T14 Podman before Docker + minimal playbook

### DIFF
--- a/docs/adr/0009-ansible-idempotent-roles-as-single-automation-source.md
+++ b/docs/adr/0009-ansible-idempotent-roles-as-single-automation-source.md
@@ -50,7 +50,7 @@ configuration — not just hardening — within the same Ansible role model.
 | Role | Purpose | Default |
 |---|---|---|
 | `t14_docker_ce` | Docker CE from official repo + Compose plugin + Swarm opt-in | off |
-| `t14_podman` | Podman rootless + buildah + skopeo + podman-compose | off |
+| `t14_podman` | Podman rootless + buildah + skopeo + podman-compose + uidmap/slirp4netns/fuse-overlayfs | on (role default; override in inventory to skip) |
 | `t14_k3s` | k3s lightweight Kubernetes (installs from get.k3s.io) | off |
 | `t14_observability` | iotop, iftop, ctop, munin-node, monit, node_exporter, rsyslog forwarding, Wazuh agent | CLI tools on; services opt-in |
 

--- a/ops/automation/ansible/README.md
+++ b/ops/automation/ansible/README.md
@@ -53,6 +53,25 @@ Run these **once** on the laptop (as `leitao`, with sudo):
    # Edit [t14] if you run from a different machine than localhost; for local runs use localhost as in the script.
    ```
 
+### Podman-only (fast path when Docker CE is broken or you want OCI without Swarm)
+
+The full **`playbooks/t14-baseline.yml`** installs **Podman before Docker CE** so a Docker/apt failure still leaves Podman on disk. If you only need **`podman`** for LAB completão:
+
+```bash
+cd ~/Projects/dev/data-boar/ops/automation/ansible
+cp -f inventory.example.ini inventory.local.ini
+# Pattern A from inventory.example.ini: [t14] → localhost + ansible_connection=local
+ansible-playbook -i inventory.local.ini --ask-become-pass playbooks/t14-podman.yml --diff
+```
+
+From **Windows** (repo root, SSH to T14 with a TTY for BECOME):
+
+```powershell
+.\scripts\t14-ansible-baseline.ps1 -SshHost t14 -Apply -SkipCheck -PodmanOnly
+```
+
+Role **`t14_podman`** installs **`podman`**, **`buildah`**, **`skopeo`**, rootless helpers (**`uidmap`**, **`slirp4netns`**, **`fuse-overlayfs`**), optional **`podman-compose`**, runs **`loginctl enable-linger`** for the resolved operator login (not `root`), then **`podman --version`**.
+
 ### Run order
 
 1) Create `inventory.local.ini` (see above).
@@ -107,6 +126,12 @@ To apply changes after a check pass:
 
 ```powershell
 .\scripts\t14-ansible-baseline.ps1 -SshHost t14 -Apply
+```
+
+Podman-only apply (one BECOME prompt when not NOPASSWD):
+
+```powershell
+.\scripts\t14-ansible-baseline.ps1 -SshHost t14 -Apply -SkipCheck -PodmanOnly
 ```
 
 ### Note (fewer prompts)

--- a/ops/automation/ansible/playbooks/t14-baseline.yml
+++ b/ops/automation/ansible/playbooks/t14-baseline.yml
@@ -78,10 +78,11 @@
     - role: t14_aide
     - role: t14_auditd
     - role: t14_zram
-    # --- Containers (Docker CE default; Podman / k3s opt-in) ---
+    # --- Containers: Podman before Docker CE so a partial Docker/apt failure still leaves Podman
+    # (LAB completão / variety path). Docker CE remains default for ctop/Swarm per play vars.
+    - role: t14_podman
     - role: t14_docker_ce
     - role: t14_operator_supplementary_groups
-    - role: t14_podman
     - role: t14_k3s
     # --- Observability (progressive opt-in) ---
     - role: t14_observability

--- a/ops/automation/ansible/playbooks/t14-podman.yml
+++ b/ops/automation/ansible/playbooks/t14-podman.yml
@@ -1,0 +1,20 @@
+---
+# Minimal Podman install for T14 (LMDE / Debian) — use when full baseline is too heavy
+# or Docker CE is misconfigured but you need Podman for LAB completão.
+#
+# From T14 (inventory with localhost + connection=local):
+#   cd ~/Projects/dev/data-boar/ops/automation/ansible
+#   ansible-playbook -i inventory.local.ini --ask-become-pass playbooks/t14-podman.yml --diff
+#
+# From Windows (repo root):
+#   .\scripts\t14-ansible-baseline.ps1 -SshHost t14 -Apply -SkipCheck
+#   # then on T14 run only this play, or add a dedicated wrapper script if needed.
+- name: T14 Podman only (rootless stack)
+  hosts: t14
+  become: true
+  environment: "{{ labop_debian_unattended_apt_environment | combine(t14_play_apt_environment_extra | default({})) }}"
+  vars:
+    t14_play_apt_environment_extra: {}
+    t14_install_podman: true
+  roles:
+    - role: t14_podman

--- a/ops/automation/ansible/roles/t14_podman/defaults/main.yml
+++ b/ops/automation/ansible/roles/t14_podman/defaults/main.yml
@@ -1,8 +1,15 @@
 ---
-t14_install_podman: false
+# Align with playbooks/t14-baseline.yml (LAB-OP + completão). Override in inventory to skip.
+t14_install_podman: true
 
 # Install podman-compose for docker-compose.yml compatibility.
 t14_podman_install_compose: true
+
+# Rootless stack (Debian bookworm/trixie + LMDE): strongly recommended with podman.
+t14_podman_rootless_packages:
+  - uidmap
+  - slirp4netns
+  - fuse-overlayfs
 
 # Add optional docker CLI alias (alias docker=podman) to /etc/profile.d/.
 # Disabled by default — edge cases exist; enable consciously.

--- a/ops/automation/ansible/roles/t14_podman/tasks/main.yml
+++ b/ops/automation/ansible/roles/t14_podman/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Install Podman (rootless containers)
   when: t14_install_podman | bool
   block:
-    - name: Install podman
+    - name: Install podman and OCI tooling
       ansible.builtin.apt:
         name:
           - podman
@@ -16,15 +16,48 @@
         state: present
         update_cache: true
 
+    - name: Install rootless dependencies (uidmap, slirp4netns, fuse-overlayfs)
+      ansible.builtin.apt:
+        name: "{{ t14_podman_rootless_packages }}"
+        state: present
+
     - name: Install podman-compose
       when: t14_podman_install_compose | bool
       ansible.builtin.apt:
         name: podman-compose
         state: present
 
-    - name: Enable lingering for current user (rootless containers survive logout)
-      ansible.builtin.command: loginctl enable-linger "{{ ansible_user_id }}"
+    # loginctl enable-linger must target the human login, not root (become) nor a stale ansible_user_id.
+    - name: Resolve login for podman rootless linger
+      ansible.builtin.set_fact:
+        t14_podman_linger_login: "{{ _pl }}"
+      vars:
+        _override: "{{ t14_operator_target_user | default('') | trim }}"
+        _sudo_u: "{{ ansible_env.SUDO_USER | default('') | trim }}"
+        _fallback: "{{ ansible_user | default(ansible_user_id) }}"
+        _pl: "{{ _override if (_override | length > 0) else (_sudo_u if (_sudo_u | length > 0) else _fallback) }}"
+
+    - name: Hint when linger would target root (wrong for rootless podman)
+      ansible.builtin.debug:
+        msg: >-
+          Podman linger skipped: resolved login is root. Set t14_operator_target_user in inventory
+          (e.g. leitao) or run ansible-playbook as your normal user with --ask-become-pass
+          (avoid `sudo ansible-playbook` without that override).
+      when: t14_podman_linger_login == 'root'
+
+    - name: Enable lingering for operator user (rootless containers survive logout)
+      when: t14_podman_linger_login != 'root'
+      ansible.builtin.command: loginctl enable-linger "{{ t14_podman_linger_login }}"
       changed_when: false
+
+    - name: Verify podman binary (post-install)
+      ansible.builtin.command: podman --version
+      register: t14_podman_version_cmd
+      changed_when: false
+
+    - name: Report podman version
+      ansible.builtin.debug:
+        msg: "{{ t14_podman_version_cmd.stdout | default('') }}"
 
     - name: Write docker alias to profile.d (optional)
       when: t14_podman_docker_alias | bool

--- a/scripts/t14-ansible-baseline.ps1
+++ b/scripts/t14-ansible-baseline.ps1
@@ -13,7 +13,11 @@ param(
 
   # Omit when sudo is NOPASSWD for this user (no BECOME password prompt).
   [Parameter(Mandatory = $false)]
-  [switch]$NoAskBecomePass
+  [switch]$NoAskBecomePass,
+
+  # Run only playbooks/t14-podman.yml (Podman + rootless deps) instead of the full baseline.
+  [Parameter(Mandatory = $false)]
+  [switch]$PodmanOnly
 )
 
 Set-StrictMode -Version Latest
@@ -51,10 +55,12 @@ function Invoke-T14Ssh {
   }
 }
 
-Write-Host "== T14 Ansible baseline ==" -ForegroundColor Cyan
+Write-Host "== T14 Ansible $(if ($PodmanOnly) { 'Podman-only' } else { 'baseline' }) ==" -ForegroundColor Cyan
 Write-Host "Host: $SshHost"
 Write-Host "Repo: $RepoPath"
 Write-Host "Mode: $(if ($Apply) { 'APPLY' } else { 'CHECK' })"
+$playbookRel = if ($PodmanOnly) { "playbooks/t14-podman.yml" } else { "playbooks/t14-baseline.yml" }
+Write-Host "Playbook: $playbookRel"
 
 $bashRepoRoot = Get-BashCdPath $RepoPath
 $bashAnsibleDir = Get-BashCdPath "$RepoPath/ops/automation/ansible"
@@ -84,10 +90,10 @@ $runLines = @(
   "perl -0777 -pe 's/^\[t14\]\n.*?\n\n/[t14]\nlocalhost ansible_connection=local\n\n/ms' -i inventory.local.ini"
 )
 if ($Apply -and -not $SkipCheck) {
-  $runLines += "ANSIBLE_ROLES_PATH=./roles ansible-playbook -i inventory.local.ini $becomePart playbooks/t14-baseline.yml --check --diff"
-  $runLines += "ANSIBLE_ROLES_PATH=./roles ansible-playbook -i inventory.local.ini $becomePart playbooks/t14-baseline.yml --diff"
+  $runLines += "ANSIBLE_ROLES_PATH=./roles ansible-playbook -i inventory.local.ini $becomePart $playbookRel --check --diff"
+  $runLines += "ANSIBLE_ROLES_PATH=./roles ansible-playbook -i inventory.local.ini $becomePart $playbookRel --diff"
 } else {
-  $runLines += "ANSIBLE_ROLES_PATH=./roles ansible-playbook -i inventory.local.ini $becomePart playbooks/t14-baseline.yml $runModeArgs"
+  $runLines += "ANSIBLE_ROLES_PATH=./roles ansible-playbook -i inventory.local.ini $becomePart $playbookRel $runModeArgs"
 }
 Invoke-T14Ssh ($runLines -join "`n") -AllocateTTY
 


### PR DESCRIPTION
Installs and documents a reliable Podman path for LAB completão on T14 (LMDE).

- Role \	14_podman\: default on, rootless packages, correct \loginctl enable-linger\ user resolution, \podman --version\ verify.
- \	14-baseline.yml\: run Podman role before Docker CE so partial Docker failures still leave Podman.
- New \playbooks/t14-podman.yml\ + \	14-ansible-baseline.ps1 -PodmanOnly\ for fast apply from Windows.
- README + ADR 0009 table updated.

Made with [Cursor](https://cursor.com)