### PR TITLE
feat(lab-op): NOPASSWD wrapper for Podman Ansible (T14)

### DIFF
--- a/docs/ops/LAB_OP_PRIVILEGED_COLLECTION.md
+++ b/docs/ops/LAB_OP_PRIVILEGED_COLLECTION.md
@@ -85,6 +85,38 @@ sudo -n /bin/bash "$HOME/Projects/dev/data-boar/scripts/homelab-host-report.sh" 
 .\scripts\lab-op-sync-and-collect.ps1 -SkipGitPull -Privileged -Deep
 ```
 
+## Ansible Podman apply (same narrow NOPASSWD discipline)
+
+To avoid **BECOME** password prompts when installing **only** Podman via
+`playbooks/t14-podman.yml`, extend the sudoers include with **fixed** commands for
+`scripts/t14-ansible-labop-podman-apply.sh` (same spirit as `homelab-host-report.sh`).
+The Ansible role **`t14_labop_sudoers`** writes **`LABOP_HOST_REPORT`** and
+**`LABOP_ANSIBLE_PODMAN`** together when **`t14_labop_sudoers_enable: true`**.
+
+Example merge (replace `LEITAO_USER` / `REPO_PATH`):
+
+```text
+Cmnd_Alias LABOP_ANSIBLE_PODMAN = /bin/bash REPO_PATH/scripts/t14-ansible-labop-podman-apply.sh --apply, \
+                                  /bin/bash REPO_PATH/scripts/t14-ansible-labop-podman-apply.sh --check
+
+LEITAO_USER ALL=(root) NOPASSWD: LABOP_HOST_REPORT, LABOP_ANSIBLE_PODMAN
+```
+
+On the host (after `visudo -cf`):
+
+```bash
+sudo -n /bin/bash "$HOME/Projects/dev/data-boar/scripts/t14-ansible-labop-podman-apply.sh" --check
+sudo -n /bin/bash "$HOME/Projects/dev/data-boar/scripts/t14-ansible-labop-podman-apply.sh" --apply
+```
+
+From Windows (**non-interactive** SSH; no Ansible `-K` prompt):
+
+```powershell
+.\scripts\t14-ansible-baseline.ps1 -SshHost t14 -Apply -SkipCheck -PodmanOnly -NoAskBecomePass
+```
+
+Requires **`ansible-playbook`** on the target and the sudoers lines above.
+
 ## Guardrails
 
 - Prefer removing the sudoers file after the collection window if you don't need it long term.

--- a/docs/ops/LAB_OP_PRIVILEGED_COLLECTION.pt_BR.md
+++ b/docs/ops/LAB_OP_PRIVILEGED_COLLECTION.pt_BR.md
@@ -85,6 +85,37 @@ sudo -n /bin/bash "$HOME/Projects/dev/data-boar/scripts/homelab-host-report.sh" 
 .\scripts\lab-op-sync-and-collect.ps1 -SkipGitPull -Privileged -Deep
 ```
 
+## Ansible Podman apply (mesmo NOPASSWD estreito)
+
+Para evitar prompt de **BECOME** ao instalar **só** Podman via `playbooks/t14-podman.yml`,
+amplie o include do sudoers com comandos **fixos** para `scripts/t14-ansible-labop-podman-apply.sh`
+(mesmo critério do `homelab-host-report.sh`). O role **`t14_labop_sudoers`** grava
+**`LABOP_HOST_REPORT`** e **`LABOP_ANSIBLE_PODMAN`** juntos quando **`t14_labop_sudoers_enable: true`**.
+
+Exemplo (substitua `LEITAO_USER` / `REPO_PATH`):
+
+```text
+Cmnd_Alias LABOP_ANSIBLE_PODMAN = /bin/bash REPO_PATH/scripts/t14-ansible-labop-podman-apply.sh --apply, \
+                                  /bin/bash REPO_PATH/scripts/t14-ansible-labop-podman-apply.sh --check
+
+LEITAO_USER ALL=(root) NOPASSWD: LABOP_HOST_REPORT, LABOP_ANSIBLE_PODMAN
+```
+
+No host:
+
+```bash
+sudo -n /bin/bash "$HOME/Projects/dev/data-boar/scripts/t14-ansible-labop-podman-apply.sh" --check
+sudo -n /bin/bash "$HOME/Projects/dev/data-boar/scripts/t14-ansible-labop-podman-apply.sh" --apply
+```
+
+No Windows (SSH **sem** TTY para senha do Ansible):
+
+```powershell
+.\scripts\t14-ansible-baseline.ps1 -SshHost t14 -Apply -SkipCheck -PodmanOnly -NoAskBecomePass
+```
+
+Exige **`ansible-playbook`** no alvo e as linhas do sudoers acima.
+
 ## Guardrails
 
 - Se você não precisar disso no dia a dia, remova o arquivo do sudoers após a janela de coleta.

--- a/docs/ops/TOKEN_AWARE_SCRIPTS_HUB.md
+++ b/docs/ops/TOKEN_AWARE_SCRIPTS_HUB.md
@@ -107,6 +107,7 @@
 | `external-review-pack.ps1` | Pack for external review | Pair with **`feedback-inbox`**, **`GEMINI_PUBLIC_BUNDLE_REVIEW.md`** |
 | `auto-mode-session-pack.ps1` | Session pack | Operator workflow experiments |
 | `t14-ansible-baseline.ps1` | Ansible baseline | Lab host provisioning (private details stay private) |
+| `t14-ansible-labop-podman-apply.sh` | Podman Ansible (sudoers-fixed args) | Invoked via `sudo -n` + narrow `LABOP_ANSIBLE_PODMAN`; see **LAB_OP_PRIVILEGED_COLLECTION.md** |
 | `unifi-ssh-deep-audit.ps1` | Deep UniFi SSH | High signal; LAN-specific — **private** notes only |
 | `linkedin-review-batch.ps1` | LinkedIn batch | Talent / social; keep outputs private |
 | `gh-ensure-default.ps1` | GitHub default branch | One-off setup |

--- a/docs/ops/TOKEN_AWARE_SCRIPTS_HUB.pt_BR.md
+++ b/docs/ops/TOKEN_AWARE_SCRIPTS_HUB.pt_BR.md
@@ -106,6 +106,7 @@
 | `external-review-pack.ps1` | Pacote para revisão externa | **`feedback-inbox`**, **`GEMINI_PUBLIC_BUNDLE_REVIEW.md`** |
 | `auto-mode-session-pack.ps1` | Pacote de sessao | Experimentos de workflow |
 | `t14-ansible-baseline.ps1` | Baseline Ansible | Provisionamento (detalhes privados) |
+| `t14-ansible-labop-podman-apply.sh` | Ansible só Podman (args fixos no sudoers) | Via `sudo -n` + `LABOP_ANSIBLE_PODMAN` estreito; ver **LAB_OP_PRIVILEGED_COLLECTION.pt_BR.md** |
 | `unifi-ssh-deep-audit.ps1` | SSH profundo UniFi | Alto sinal; LAN — só notas **privadas** |
 | `linkedin-review-batch.ps1` | Batch LinkedIn | Talent / social; saídas privadas |
 | `gh-ensure-default.ps1` | Branch default no GitHub | Setup pontual |

--- a/ops/automation/ansible/README.md
+++ b/ops/automation/ansible/README.md
@@ -70,6 +70,15 @@ From **Windows** (repo root, SSH to T14 with a TTY for BECOME):
 .\scripts\t14-ansible-baseline.ps1 -SshHost t14 -Apply -SkipCheck -PodmanOnly
 ```
 
+**Passwordless (narrow sudoers):** when **`LABOP_ANSIBLE_PODMAN`** is installed (see
+**`docs/ops/LAB_OP_PRIVILEGED_COLLECTION.md`** and role **`t14_labop_sudoers`**), run:
+
+```powershell
+.\scripts\t14-ansible-baseline.ps1 -SshHost t14 -Apply -SkipCheck -PodmanOnly -NoAskBecomePass
+```
+
+That path invokes **`sudo -n /bin/bash …/scripts/t14-ansible-labop-podman-apply.sh`** (`--apply` or `--check`) — no Ansible **`-K`** prompt.
+
 Role **`t14_podman`** installs **`podman`**, **`buildah`**, **`skopeo`**, rootless helpers (**`uidmap`**, **`slirp4netns`**, **`fuse-overlayfs`**), optional **`podman-compose`**, runs **`loginctl enable-linger`** for the resolved operator login (not `root`), then **`podman --version`**.
 
 ### Run order

--- a/ops/automation/ansible/playbooks/t14-podman.yml
+++ b/ops/automation/ansible/playbooks/t14-podman.yml
@@ -7,7 +7,9 @@
 #   ansible-playbook -i inventory.local.ini --ask-become-pass playbooks/t14-podman.yml --diff
 #
 # From Windows (repo root):
-#   .\scripts\t14-ansible-baseline.ps1 -SshHost t14 -Apply -SkipCheck
+#   .\scripts\t14-ansible-baseline.ps1 -SshHost t14 -Apply -SkipCheck -PodmanOnly
+# Non-interactive (narrow sudoers LABOP_ANSIBLE_PODMAN — see LAB_OP_PRIVILEGED_COLLECTION.md):
+#   .\scripts\t14-ansible-baseline.ps1 -SshHost t14 -Apply -SkipCheck -PodmanOnly -NoAskBecomePass
 #   # then on T14 run only this play, or add a dedicated wrapper script if needed.
 - name: T14 Podman only (rootless stack)
   hosts: t14

--- a/ops/automation/ansible/roles/t14_labop_sudoers/tasks/main.yml
+++ b/ops/automation/ansible/roles/t14_labop_sudoers/tasks/main.yml
@@ -16,7 +16,13 @@
       #
       Cmnd_Alias LABOP_HOST_REPORT = /bin/bash {{ t14_labop_repo_path }}/scripts/homelab-host-report.sh --privileged, \
                                      /bin/bash {{ t14_labop_repo_path }}/scripts/homelab-host-report.sh --privileged --deep
-      {{ t14_labop_sudoers_user }} ALL=(root) NOPASSWD: LABOP_HOST_REPORT
+      #
+      # Narrow Ansible Podman apply (same path discipline as homelab-host-report).
+      # Invoked as: sudo -n /bin/bash {{ t14_labop_repo_path }}/scripts/t14-ansible-labop-podman-apply.sh --apply
+      #
+      Cmnd_Alias LABOP_ANSIBLE_PODMAN = /bin/bash {{ t14_labop_repo_path }}/scripts/t14-ansible-labop-podman-apply.sh --apply, \
+                                        /bin/bash {{ t14_labop_repo_path }}/scripts/t14-ansible-labop-podman-apply.sh --check
+      {{ t14_labop_sudoers_user }} ALL=(root) NOPASSWD: LABOP_HOST_REPORT, LABOP_ANSIBLE_PODMAN
   failed_when: false
 
 - name: Validate sudoers include syntax (visudo -c)

--- a/scripts/t14-ansible-baseline.ps1
+++ b/scripts/t14-ansible-baseline.ps1
@@ -74,6 +74,24 @@ $preflightLines = @(
 )
 Invoke-T14Ssh ($preflightLines -join "`n")
 
+# Passwordless path: narrow sudoers allows sudo -n /bin/bash .../t14-ansible-labop-podman-apply.sh {--apply|--check}
+# (see ops/automation/ansible/roles/t14_labop_sudoers and docs/ops/LAB_OP_PRIVILEGED_COLLECTION.md).
+if ($PodmanOnly -and $NoAskBecomePass) {
+  Write-Host "Using LAB-OP sudoers wrapper (sudo -n ... t14-ansible-labop-podman-apply.sh); no BECOME password prompt." -ForegroundColor Cyan
+  $wrapperLines = @('set -eu', "cd `"$bashRepoRoot`"")
+  if ($Apply -and -not $SkipCheck) {
+    $wrapperLines += 'sudo -n /bin/bash scripts/t14-ansible-labop-podman-apply.sh --check'
+    $wrapperLines += 'sudo -n /bin/bash scripts/t14-ansible-labop-podman-apply.sh --apply'
+  } elseif ($Apply) {
+    $wrapperLines += 'sudo -n /bin/bash scripts/t14-ansible-labop-podman-apply.sh --apply'
+  } else {
+    $wrapperLines += 'sudo -n /bin/bash scripts/t14-ansible-labop-podman-apply.sh --check'
+  }
+  Invoke-T14Ssh ($wrapperLines -join "`n")
+  Write-Host "Done." -ForegroundColor Green
+  return
+}
+
 # Ansible calls sudo non-interactively unless you pass --ask-become-pass (-K). A prior `sudo -v` does not satisfy that.
 $becomePart = if ($NoAskBecomePass) { "" } else { "--ask-become-pass" }
 if (-not $NoAskBecomePass) {

--- a/scripts/t14-ansible-labop-podman-apply.sh
+++ b/scripts/t14-ansible-labop-podman-apply.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Data Boar — narrow LAB-OP entrypoint for Podman Ansible apply (T14 / Debian family).
+#
+# Intended for passwordless sudo via a fixed Cmnd_Alias (same discipline as
+# scripts/homelab-host-report.sh --privileged). Do NOT widen NOPASSWD beyond
+# this script path + the flags listed in sudoers.
+#
+# Usage (as operator, with sudoers configured):
+#   sudo -n /bin/bash /home/USER/Projects/dev/data-boar/scripts/t14-ansible-labop-podman-apply.sh --apply
+#   sudo -n /bin/bash .../t14-ansible-labop-podman-apply.sh --check
+#
+# Without root: re-invokes via sudo -n when possible.
+#
+# See: docs/ops/LAB_OP_PRIVILEGED_COLLECTION.md, ops/automation/ansible/README.md
+
+set -euo pipefail
+
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin${PATH+:$PATH}"
+
+usage() {
+  cat <<'EOF'
+Usage: bash scripts/t14-ansible-labop-podman-apply.sh --apply | --check
+
+  --apply   Run playbooks/t14-podman.yml on this host (localhost inventory).
+  --check   Ansible --check --diff (dry-run).
+
+Requires: ansible-playbook, perl. Passwordless sudo must match the exact
+/bin/bash <repo>/scripts/t14-ansible-labop-podman-apply.sh <flag> allowlist.
+EOF
+}
+
+APPLY=0
+CHECK=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply) APPLY=1; shift ;;
+    --check) CHECK=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$((APPLY + CHECK))" -ne 1 ]]; then
+  echo "Specify exactly one of --apply or --check." >&2
+  usage >&2
+  exit 2
+fi
+
+SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || realpath "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ANSIBLE_DIR="$REPO_ROOT/ops/automation/ansible"
+PLAYBOOK="$ANSIBLE_DIR/playbooks/t14-podman.yml"
+
+if [[ ! -d "$ANSIBLE_DIR" ]] || [[ ! -f "$PLAYBOOK" ]]; then
+  echo "Expected repo layout missing (ansible dir or t14-podman.yml)." >&2
+  exit 2
+fi
+
+# Re-exec as root with sudo -n when not root (NOPASSWD path must match /bin/bash + this script + flag).
+if [[ "$(id -u)" -ne 0 ]]; then
+  if ! command -v sudo >/dev/null 2>&1; then
+    echo "sudo not available; run as root or install sudo." >&2
+    exit 2
+  fi
+  exec sudo -n /bin/bash "$SCRIPT_PATH" "$@"
+fi
+
+cd "$ANSIBLE_DIR"
+cp -f inventory.example.ini inventory.local.ini
+perl -0777 -pe 's/^\[t14\]\n.*?\n\n/[t14]\nlocalhost ansible_connection=local\n\n/ms' -i inventory.local.ini
+
+export ANSIBLE_ROLES_PATH=./roles
+
+OPERATOR="${SUDO_USER:-}"
+if [[ -z "$OPERATOR" || "$OPERATOR" == "root" ]]; then
+  OPERATOR="$(stat -c '%U' "$REPO_ROOT" 2>/dev/null || true)"
+fi
+if [[ -z "$OPERATOR" || "$OPERATOR" == "root" ]]; then
+  echo "Could not resolve operator login for Ansible facts (SUDO_USER or repo owner)." >&2
+  exit 2
+fi
+
+EXTRA_ARGS=()
+if [[ "$CHECK" == 1 ]]; then
+  EXTRA_ARGS=(--check --diff)
+else
+  EXTRA_ARGS=(--diff)
+fi
+
+exec ansible-playbook -i inventory.local.ini "${EXTRA_ARGS[@]}" \
+  -e "ansible_user=$OPERATOR" \
+  "$PLAYBOOK"

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -369,6 +369,27 @@ def test_t14_ansible_preflight_sh_syntax():
     assert proc.returncode == 0, f"bash -n failed: {proc.stderr or proc.stdout}"
 
 
+def test_t14_ansible_labop_podman_apply_sh_syntax():
+    """scripts/t14-ansible-labop-podman-apply.sh has valid bash syntax (bash -n). Skipped on Windows."""
+    if sys.platform == "win32":
+        return
+    root = _project_root()
+    script = root / "scripts" / "t14-ansible-labop-podman-apply.sh"
+    if not script.exists():
+        return
+    try:
+        proc = subprocess.run(
+            ["bash", "-n", str(script)],
+            cwd=str(root),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except FileNotFoundError:
+        return
+    assert proc.returncode == 0, f"bash -n failed: {proc.stderr or proc.stdout}"
+
+
 def test_t14_session_warm_sh_syntax():
     """scripts/t14-session-warm.sh has valid bash syntax (bash -n). Skipped on Windows."""
     if sys.platform == "win32":


### PR DESCRIPTION
- Adds \scripts/t14-ansible-labop-podman-apply.sh\ with fixed \--apply\ / \--check\ for narrow sudoers (same pattern as \homelab-host-report.sh\).
- Extends \	14_labop_sudoers\ template with \LABOP_ANSIBLE_PODMAN\ next to \LABOP_HOST_REPORT\.
- \	14-ansible-baseline.ps1\: \-PodmanOnly -NoAskBecomePass\ runs the wrapper via \sudo -n\ over SSH (no Ansible \-K\).
- Docs: LAB_OP_PRIVILEGED_COLLECTION (EN/pt-BR), ansible README, TOKEN hub; \ash -n\ test on Linux CI.

**Operator follow-up on T14:** merge the new \Cmnd_Alias\ + updated \NOPASSWD\ line into \/etc/sudoers.d/labop-host-report\ (or re-run baseline with \	14_labop_sudoers_enable: true\), then \sudo visudo -cf /etc/sudoers.d/labop-host-report\.

Made with [Cursor](https://cursor.com)