### PR TITLE
ci(rust): boar_fast_filter — testable pure-Rust core, 19 unit tests, clippy 1.95-safe CI gate

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,0 +1,62 @@
+# Rust prefilter crate (boar_fast_filter): fmt, check, test, clippy on push/PR.
+#
+# Clippy uses -D warnings so any lint fires a hard CI failure (the "fail on lint
+# errors" requirement). The toolColleague-Nn is installed via rustup directly to avoid
+# adding a new third-party Action SHA to track; the existing pinned
+# actions/checkout and actions/setup-python SHAs are reused from ci.yml.
+#
+# Triggers are scoped via paths: so unrelated Python/docs PRs do not spin Rust
+# builds. permissions: contents: read mirrors ci.yml.
+name: Rust CI
+
+permissions:
+  contents: read
+
+'on':
+  push:
+    branches: [main, master]
+    paths:
+      - 'rust/**'
+      - '.github/workflows/rust-ci.yml'
+  pull_request:
+    branches: [main, master]
+    paths:
+      - 'rust/**'
+      - '.github/workflows/rust-ci.yml'
+
+jobs:
+  rust:
+    name: cargo (fmt, check, test, clippy)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust/boar_fast_filter
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # PyO3 needs a Python interpreter at link time even for `cargo check`
+      # because pyo3-build-config probes the active Python ABI.
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Install Rust stable toolColleague-Nn (rustup)
+        run: |
+          rustup toolColleague-Nn install stable --profile minimal
+          rustup component add clippy rustfmt --toolColleague-Nn stable
+          rustup default stable
+          rustc --version
+          cargo --version
+
+      - name: cargo fmt --check
+        run: cargo fmt --all -- --check
+
+      - name: cargo check
+        run: cargo check --all-targets --locked --verbose
+
+      - name: cargo test
+        run: cargo test --all-targets --locked --verbose
+
+      - name: cargo clippy (-D warnings)
+        run: cargo clippy --all-targets --locked -- -D warnings

--- a/.github/workflows/slack-ci-failure-notify.yml
+++ b/.github/workflows/slack-ci-failure-notify.yml
@@ -8,7 +8,7 @@ permissions:
 
 'on':
   workflow_run:
-    workflows: [CI, Semgrep, SBOM]
+    workflows: [CI, Rust CI, Semgrep, SBOM]
     types: [completed]
 
 jobs:

--- a/rust/boar_fast_filter/README.md
+++ b/rust/boar_fast_filter/README.md
@@ -38,3 +38,20 @@ from boar_fast_filter import FastFilter
 f = FastFilter()
 print(f.filter_batch(["clean", "cpf 390.533.447-05", "mail a@example.test"]))
 ```
+
+## Rust-only test loop (no Python required)
+
+The crate exposes a pure-Rust API (`FastFilter::try_new`,
+`FastFilter::filter_batch_pure`, `FastFilter::check_luhn`) so `cargo test`
+exercises the same logic that PyO3 binds. From `rust/boar_fast_filter/`:
+
+```bash
+cargo fmt --all -- --check
+cargo check --all-targets --locked
+cargo test --all-targets --locked
+cargo clippy --all-targets --locked -- -D warnings
+```
+
+CI runs the same four steps via `.github/workflows/rust-ci.yml` (path-scoped
+to `rust/**` so unrelated PRs do not spin Rust builds). Clippy uses
+`-D warnings`, so any new lint promotes to a CI failure.

--- a/rust/boar_fast_filter/src/lib.rs
+++ b/rust/boar_fast_filter/src/lib.rs
@@ -1,10 +1,20 @@
+//! Boar fast filter: high-speed PII pre-filter (PyO3 binding + pure-Rust core).
+//!
+//! Exposes a [`FastFilter`] that scans a batch of strings and returns the
+//! indexes that look like they may contain PII (CPF, email, or a credit card
+//! number passing Luhn). The hot path is a single sweep with pre-compiled
+//! regexes shared across calls.
+//!
+//! The pure-Rust API ([`FastFilter::try_new`], [`FastFilter::filter_batch_pure`],
+//! [`FastFilter::check_luhn`]) is intentionally exposed so it can be exercised
+//! by `cargo test` without depending on a Python interpreter at test time.
+
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use regex::Regex;
 
 #[pyclass]
 pub struct FastFilter {
-    // Compiled once; reused for all batches.
     cpf_pattern: Regex,
     email_pattern: Regex,
     credit_card_pattern: Regex,
@@ -13,14 +23,27 @@ pub struct FastFilter {
 #[pymethods]
 impl FastFilter {
     #[new]
-    fn new() -> PyResult<Self> {
-        let cpf_pattern = Regex::new(r"\d{3}\.?\d{3}\.?\d{3}-?\d{2}")
-            .map_err(|e| PyRuntimeError::new_err(format!("cpf regex compile error: {e}")))?;
-        let email_pattern = Regex::new(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}")
-            .map_err(|e| PyRuntimeError::new_err(format!("email regex compile error: {e}")))?;
-        let credit_card_pattern = Regex::new(r"\b(?:\d[ -]*?){13,19}\b").map_err(|e| {
-            PyRuntimeError::new_err(format!("credit card regex compile error: {e}"))
-        })?;
+    fn py_new() -> PyResult<Self> {
+        Self::try_new().map_err(|e| PyRuntimeError::new_err(format!("regex compile error: {e}")))
+    }
+
+    /// Return only suspect indexes from the input batch.
+    ///
+    /// Panic-free by design: regex matching does not unwrap dynamic state.
+    /// Delegates to [`Self::filter_batch_pure`] so the Python and Rust paths
+    /// share one implementation.
+    fn filter_batch(&self, batch: Vec<String>) -> PyResult<Vec<usize>> {
+        Ok(self.filter_batch_pure(&batch))
+    }
+}
+
+impl FastFilter {
+    /// Pure-Rust constructor. Returns the underlying [`regex::Error`] directly
+    /// so it can be unit-tested without a Python interpreter.
+    pub fn try_new() -> Result<Self, regex::Error> {
+        let cpf_pattern = Regex::new(r"\d{3}\.?\d{3}\.?\d{3}-?\d{2}")?;
+        let email_pattern = Regex::new(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}")?;
+        let credit_card_pattern = Regex::new(r"\b(?:\d[ -]*?){13,19}\b")?;
         Ok(FastFilter {
             cpf_pattern,
             email_pattern,
@@ -28,9 +51,9 @@ impl FastFilter {
         })
     }
 
-    /// Return only suspect indexes from the input batch.
-    /// Panic-free by design: regex matching does not unwrap dynamic state.
-    fn filter_batch(&self, batch: Vec<String>) -> PyResult<Vec<usize>> {
+    /// Pure-Rust filter that returns suspect indexes for a borrowed slice.
+    /// Output indexes preserve input order and each index appears at most once.
+    pub fn filter_batch_pure(&self, batch: &[String]) -> Vec<usize> {
         let mut suspects = Vec::new();
         for (idx, content) in batch.iter().enumerate() {
             if self.cpf_pattern.is_match(content) || self.email_pattern.is_match(content) {
@@ -41,18 +64,29 @@ impl FastFilter {
                 suspects.push(idx);
             }
         }
-        Ok(suspects)
+        suspects
     }
-}
 
-impl FastFilter {
     fn has_valid_luhn_card(&self, content: &str) -> bool {
         self.credit_card_pattern
             .find_iter(content)
             .any(|m| Self::check_luhn(m.as_str()))
     }
 
-    fn check_luhn(card_number: &str) -> bool {
+    /// Standard Luhn check on the digits found in `card_number`. Non-digit
+    /// characters (spaces, dashes) are ignored. Returns `false` for digit
+    /// sequences outside the 13..=19 range used by real card numbers.
+    //
+    // `% 10` keeps the canonical Luhn arithmetic readable. The
+    // `clippy::manual_is_multiple_of` lint (clippy 1.95+) suggests
+    // `.is_multiple_of(10)` but that std method only stabilized in Rust 1.87
+    // for unsigned ints, which would break older toolColleague-Nns used by
+    // contributors and the homelab (currently pinned at 1.83). `unknown_lints`
+    // is paired with the lint name so older clippys (which haven't seen the
+    // new lint yet) don't reject the attribute. We choose readable + portable
+    // over chasing the newest clippy hint.
+    #[allow(unknown_lints, clippy::manual_is_multiple_of)]
+    pub fn check_luhn(card_number: &str) -> bool {
         let digits: Vec<u32> = card_number
             .chars()
             .filter(|c| c.is_ascii_digit())
@@ -70,7 +104,11 @@ impl FastFilter {
             .map(|(i, &digit)| {
                 if i % 2 == 1 {
                     let d = digit * 2;
-                    if d > 9 { d - 9 } else { d }
+                    if d > 9 {
+                        d - 9
+                    } else {
+                        d
+                    }
                 } else {
                     digit
                 }
@@ -85,4 +123,167 @@ impl FastFilter {
 fn boar_fast_filter(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<FastFilter>()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ff() -> FastFilter {
+        FastFilter::try_new().expect("baseline regexes must compile")
+    }
+
+    fn s(items: &[&str]) -> Vec<String> {
+        items.iter().map(|x| (*x).to_string()).collect()
+    }
+
+    // ---------- Constructor -------------------------------------------------
+
+    #[test]
+    fn try_new_compiles_all_patterns() {
+        let _ = ff();
+    }
+
+    // ---------- Luhn --------------------------------------------------------
+
+    #[test]
+    fn luhn_accepts_known_valid_visa_test_number() {
+        // Public Visa test PAN, passes Luhn.
+        assert!(FastFilter::check_luhn("4539578763621486"));
+    }
+
+    #[test]
+    fn luhn_accepts_known_valid_mastercard_test_number() {
+        assert!(FastFilter::check_luhn("5555555555554444"));
+    }
+
+    #[test]
+    fn luhn_accepts_known_valid_amex_test_number() {
+        // 15 digits — Amex.
+        assert!(FastFilter::check_luhn("378282246310005"));
+    }
+
+    #[test]
+    fn luhn_rejects_invalid_check_digit() {
+        // Same as the valid Visa above with last digit perturbed.
+        assert!(!FastFilter::check_luhn("4539578763621487"));
+    }
+
+    #[test]
+    fn luhn_rejects_too_short() {
+        // 12 digits is below the 13-digit minimum.
+        assert!(!FastFilter::check_luhn("123456789012"));
+    }
+
+    #[test]
+    fn luhn_rejects_too_long() {
+        // 20 digits is above the 19-digit maximum.
+        assert!(!FastFilter::check_luhn("12345678901234567890"));
+    }
+
+    #[test]
+    fn luhn_ignores_separators() {
+        // Spaces and dashes must not change the result.
+        assert!(FastFilter::check_luhn("4539-5787-6362-1486"));
+        assert!(FastFilter::check_luhn("4539 5787 6362 1486"));
+    }
+
+    #[test]
+    fn luhn_rejects_empty_and_non_numeric() {
+        assert!(!FastFilter::check_luhn(""));
+        assert!(!FastFilter::check_luhn("not-a-card"));
+    }
+
+    // ---------- filter_batch_pure: positive matches -------------------------
+
+    #[test]
+    fn detects_cpf_with_punctuation() {
+        let f = ff();
+        let batch = s(&["clean line", "cpf 390.533.447-05", "another clean line"]);
+        assert_eq!(f.filter_batch_pure(&batch), vec![1]);
+    }
+
+    #[test]
+    fn detects_cpf_without_punctuation() {
+        let f = ff();
+        let batch = s(&["nope", "39053344705"]);
+        assert_eq!(f.filter_batch_pure(&batch), vec![1]);
+    }
+
+    #[test]
+    fn detects_email() {
+        let f = ff();
+        let batch = s(&["please contact a@example.test about it"]);
+        assert_eq!(f.filter_batch_pure(&batch), vec![0]);
+    }
+
+    #[test]
+    fn detects_credit_card_with_valid_luhn() {
+        let f = ff();
+        let batch = s(&["card on file: 4539 5787 6362 1486 ok"]);
+        assert_eq!(f.filter_batch_pure(&batch), vec![0]);
+    }
+
+    // ---------- filter_batch_pure: negative cases ---------------------------
+
+    #[test]
+    fn skips_clean_content() {
+        let f = ff();
+        let batch = s(&["totally clean", "still fine", "no PII here"]);
+        assert!(f.filter_batch_pure(&batch).is_empty());
+    }
+
+    #[test]
+    fn skips_card_like_groups_failing_luhn() {
+        // 16 digits in card-style groups, invalid Luhn check digit. Spaces also
+        // prevent the CPF regex from matching, so the line is exercising the
+        // credit-card path specifically and must NOT be flagged.
+        let f = ff();
+        let batch = s(&["order id 1234 5678 9012 3456 here"]);
+        assert!(f.filter_batch_pure(&batch).is_empty());
+    }
+
+    #[test]
+    fn handles_empty_batch() {
+        let f = ff();
+        let batch: Vec<String> = Vec::new();
+        assert!(f.filter_batch_pure(&batch).is_empty());
+    }
+
+    // ---------- filter_batch_pure: behaviour --------------------------------
+
+    #[test]
+    fn each_item_reported_at_most_once() {
+        // CPF + email in same line: should still produce exactly one index.
+        let f = ff();
+        let batch = s(&["cpf 390.533.447-05 mail a@example.test"]);
+        assert_eq!(f.filter_batch_pure(&batch), vec![0]);
+    }
+
+    #[test]
+    fn preserves_input_order_in_output_indexes() {
+        let f = ff();
+        let batch = s(&[
+            "a@example.test",
+            "clean",
+            "cpf 390.533.447-05",
+            "clean",
+            "4539578763621486",
+        ]);
+        assert_eq!(f.filter_batch_pure(&batch), vec![0, 2, 4]);
+    }
+
+    #[test]
+    fn mixed_signal_batch_returns_indexes_in_input_order() {
+        let f = ff();
+        let batch = s(&[
+            "clean",
+            "4539 5787 6362 1486", // valid card
+            "clean",
+            "cpf 390.533.447-05", // CPF
+            "clean",
+            "user@example.test", // email
+        ]);
+        assert_eq!(f.filter_batch_pure(&batch), vec![1, 3, 5]);
+    }
 }

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -39,7 +39,7 @@ def test_slack_ci_failure_notify_workflow_present_and_valid() -> None:
     assert "workflow_run" in on
     wr = on["workflow_run"]
     assert isinstance(wr, dict)
-    assert wr.get("workflows") == ["CI", "Semgrep", "SBOM"]
+    assert wr.get("workflows") == ["CI", "Rust CI", "Semgrep", "SBOM"]
     assert "notify" in (data.get("jobs") or {})
 
 
@@ -228,6 +228,45 @@ def test_ci_yml_pins_actions_and_uv_cli() -> None:
         assert sha_40.search(code), (
             f"expected full commit SHA in uses line: {line.strip()!r}"
         )
+
+
+def test_rust_ci_workflow_present_and_valid() -> None:
+    """Rust CI gate exists, is path-scoped to rust/**, and uses a clippy `-D warnings` step.
+
+    Regression guard so removing the Rust gate (or quietly downgrading clippy)
+    is caught at PR time, not after a Rust regression lands on `main`.
+    """
+    data = _load_workflow("rust-ci.yml")
+    assert data.get("name") == "Rust CI"
+    perms = data.get("permissions") or {}
+    assert perms.get("contents") == "read"
+
+    on = data.get("on") or {}
+    push = on.get("push") or {}
+    pr = on.get("pull_request") or {}
+    push_paths = push.get("paths") or []
+    pr_paths = pr.get("paths") or []
+    assert any(p.startswith("rust/") for p in push_paths), (
+        "rust-ci.yml push trigger should be scoped to rust/**"
+    )
+    assert any(p.startswith("rust/") for p in pr_paths), (
+        "rust-ci.yml pull_request trigger should be scoped to rust/**"
+    )
+
+    jobs = data.get("jobs") or {}
+    assert jobs, "rust-ci.yml must define at least one job"
+    job = next(iter(jobs.values()))
+    assert isinstance(job, dict)
+    assert job.get("runs-on") == "ubuntu-latest"
+    defaults = job.get("defaults") or {}
+    run_defaults = defaults.get("run") or {}
+    assert run_defaults.get("working-directory") == "rust/boar_fast_filter"
+
+    runs = "\n".join(_ci_step_run_texts(job))
+    assert "cargo fmt --all -- --check" in runs
+    assert "cargo check --all-targets --locked" in runs
+    assert "cargo test --all-targets --locked" in runs
+    assert "cargo clippy --all-targets --locked -- -D warnings" in runs
 
 
 def test_ci_lint_job_runs_pre_commit_all_files() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Lands the missing **CI/CD coverage and unit tests for the repository's only Rust component** — `rust/boar_fast_filter/` (PyO3 high-speed PII pre-filter for Data Boar Pro+). Supersedes the failing PRs in the #255–#260 series by combining the cleanest scope from each, fixing the `clippy 1.95 manual_is_multiple_of` self-block, and proving the gate green on **both** the homelab toolchain (Rust 1.83) and the CI runner toolchain (stable Rust 1.95).

> **Scoping note.** The original task brief named a "data-board-report" Rust component. There is no such crate in this repo — the only Rust code is `rust/boar_fast_filter/`. I treated that as the intended target. If a separate `data-board-report` crate lands later, this workflow will pick it up automatically once it is added under `rust/**`, since the `paths:` trigger is `rust/**` rather than crate-specific.

## What changes

### 1. Pure-Rust testable core in `rust/boar_fast_filter/src/lib.rs`

The previous module returned `PyResult<Self>` from `new` and consumed `Vec<String>` by value, both awkward to drive from `cargo test`. Refactor with **zero behaviour change** for the Python binding:

- `pub fn try_new() -> Result<Self, regex::Error>` — pure-Rust constructor.
- `pub fn filter_batch_pure(&self, batch: &[String]) -> Vec<usize>` — borrowed-slice testable core. The PyO3-exposed `filter_batch` delegates here so the Python and Rust paths share **one** implementation.
- `pub fn check_luhn(...)` — exposed for direct unit testing.

### 2. 19 `#[cfg(test)]` unit tests

| Group | Cases |
| --- | --- |
| Luhn (8) | valid Visa / MasterCard / Amex test PANs, invalid check digit, too short, too long, separator tolerance (`-` and space), empty / non-numeric |
| Constructor (1) | `try_new` compiles all baseline regexes |
| Detection (4) | CPF with punctuation, CPF without punctuation, email, valid-Luhn credit card |
| Negative paths (3) | clean content, card-shaped digits failing Luhn, empty batch |
| Behaviour (3) | each line reported at most once, output preserves input order, mixed-signal batch returns indexes in order |

### 3. `.github/workflows/rust-ci.yml`

- Triggers on push and PR to `main` / `master`, scoped via `paths:` to `rust/**` and the workflow file itself.
- `working-directory: rust/boar_fast_filter`.
- Reuses the `actions/checkout` and `actions/setup-python` SHAs already vetted in `ci.yml` (PyO3 needs a Python interpreter at link time).
- Toolchain installed via `rustup` directly to avoid adding a new third-party Action SHA to track.
- Steps: `cargo fmt --all -- --check` → `cargo check --all-targets --locked` → `cargo test --all-targets --locked` → `cargo clippy --all-targets --locked -- -D warnings`. **Any clippy lint promotes to a CI failure.**
- `permissions: contents: read` only.

### 4. Slack failure notify

`slack-ci-failure-notify.yml` now subscribes to `CI, Rust CI, Semgrep, SBOM` (was `CI, Semgrep, SBOM`). When the Rust gate fails, the operator gets a Slack ping on the same `SLACK_WEBHOOK_URL` secret as every other CI failure. Skipped cleanly when the secret is unset (per `tests/test_github_workflows.py::test_slack_post_workflows_guard_webhook_secret`).

### 5. Workflow guard test

New `test_rust_ci_workflow_present_and_valid` in `tests/test_github_workflows.py` asserts `name`, `contents: read`, path-scoped triggers, working directory, and that all four cargo steps (with the exact `-D warnings` predicate) are present. Regression guard so removing or downgrading the Rust gate is caught at PR time.

## The clippy 1.95 fix (why we keep `% 10`)

clippy 1.95 added `manual_is_multiple_of`, which suggests rewriting `sum % 10 == 0` as `sum.is_multiple_of(10)`. With `-D warnings`, that's a hard error. But `u32::is_multiple_of` only stabilised in **Rust 1.87**, and the homelab toolchain is pinned at **1.83**. Following clippy's auto-suggestion would break the homelab build with `error[E0658]: use of unstable library feature 'unsigned_is_multiple_of'`.

The chosen fix keeps the canonical Luhn arithmetic readable and tells clippy this is intentional:

```rust
#[allow(unknown_lints, clippy::manual_is_multiple_of)]
pub fn check_luhn(card_number: &str) -> bool { ... sum % 10 == 0 }
```

`unknown_lints` is paired with the lint name so older clippys (which haven't seen `manual_is_multiple_of` yet) still accept the attribute.

## Local verification (both toolchains)

From `rust/boar_fast_filter/`:

```
# Rust 1.83 (homelab pin)
cargo fmt --all -- --check                                # clean
cargo check --all-targets --locked                        # clean
cargo test --all-targets --locked                         # 19 passed
cargo clippy --all-targets --locked -- -D warnings        # clean

# Rust 1.95 (CI runner)
rustup run stable cargo fmt --all -- --check              # clean
rustup run stable cargo check --all-targets --locked      # clean
rustup run stable cargo test --all-targets --locked       # 19 passed
rustup run stable cargo clippy --all-targets --locked -- -D warnings   # clean
```

Repository hygiene:

```
uv run pytest tests/test_github_workflows.py -q           # 12 of 12 passed (incl. new Rust CI guard)
uv run pre-commit run --files .github/workflows/rust-ci.yml \
    .github/workflows/slack-ci-failure-notify.yml \
    tests/test_github_workflows.py \
    rust/boar_fast_filter/src/lib.rs                      # all hooks green
```

## Defensive architecture review

- **DB locks / customer impact:** none. `boar_fast_filter` is a pure-CPU regex+Luhn prefilter; it does not open connections, hold locks, or change any DB-bound code path.
- **Behaviour delta vs `main`:** zero on the hot path. `filter_batch` still takes `Vec<String>` and returns `PyResult<Vec<usize>>`; it just delegates to `filter_batch_pure`. Every existing caller in Python keeps working.
- **Forward-compat:** when the homelab eventually moves to Rust 1.87+, the `#[allow]` becomes a one-line removal — the `is_multiple_of` migration is a clean follow-up.
- **No supply-chain change:** no new dependencies, no MSRV bump, no new third-party Action.

## Commits (split per commit-grouping policy)

- `test(rust): expose pure-Rust API and add 19 unit tests for boar_fast_filter`
- `ci(rust): add Rust CI workflow with fmt, check, test, clippy -D warnings`

## Relationship to the open PR series

- **#260** (`cursor/fix-rust-ci-coverage-9061`) — same intent, but the Rust CI job fails on clippy 1.95. This PR carries the equivalent lib.rs refactor + 19 tests, plus the `#[allow(clippy::manual_is_multiple_of)]` fix already validated on PR #258.
- **#258 / #256** — fix-only PRs that supersede the clippy block. This PR rolls their fix in alongside the workflow + Slack wiring so the gate ships green from the first commit on this branch.
- **#255** — initial Rust CI workflow. Same gap (clippy 1.95).

The maintainer can pick this branch and close the others as superseded, or cherry-pick the `% 10` `#[allow]` block into whichever branch they prefer to land.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://data-boar.slack.com/archives/C0AN7HY3NP9/p1777319304671169?thread_ts=1777319304.671169&cid=C0AN7HY3NP9)

<div><a href="https://cursor.com/agents/bc-d615e7c0-0f2a-510f-906d-a0bc2f03c9ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d615e7c0-0f2a-510f-906d-a0bc2f03c9ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

