### PR TITLE
workflow: align check-all.sh with PS1 delegation + optional Rust build

### DIFF
--- a/docs/ops/SCRIPTS_CROSS_PLATFORM_PAIRING.md
+++ b/docs/ops/SCRIPTS_CROSS_PLATFORM_PAIRING.md
@@ -24,7 +24,7 @@ Some **developer gates** and **thin wrappers** exist in **two forms**: **PowerSh
 | Pytest subset (`-Path` / `-Keyword`) | `scripts/quick-test.ps1` | `scripts/quick-test.sh` |
 | Pre-commit + full pytest (no gatekeeper / no plans-stats) | `scripts/pre-commit-and-tests.ps1` | `scripts/pre-commit-and-tests.sh` |
 
-**Note:** `check-all.ps1` calls **`gatekeeper-audit.ps1`** and **`plans-stats.py`** before delegating to **`pre-commit-and-tests.ps1`**; `check-all.sh` does the same at the shell level. **`pre-commit-and-tests.*`** skips gatekeeper and plans-stats by design.
+**Note:** `check-all.ps1` calls **`gatekeeper-audit.ps1`** and **`plans-stats.py`** before delegating to **`pre-commit-and-tests.ps1`**; `check-all.sh` runs the same two steps then calls **`pre-commit-and-tests.sh`** (same delegation pattern; not an inlined duplicate of pre-commit/pytest). **`pre-commit-and-tests.*`** skips gatekeeper and plans-stats by design. Optional Rust **boar_fast_filter** build lives in **`pre-commit-and-tests.*`** (best-effort when `rustc` is on PATH; `DATA_BOAR_SKIP_RUST_BUILD=1` skips).
 
 ## Verification
 

--- a/docs/ops/SCRIPTS_CROSS_PLATFORM_PAIRING.pt_BR.md
+++ b/docs/ops/SCRIPTS_CROSS_PLATFORM_PAIRING.pt_BR.md
@@ -24,7 +24,7 @@ Alguns **gates de desenvolvimento** e **wrappers finos** existem em **duas forma
 | Subconjunto *pytest* (`-Path` / `-Keyword`) | `scripts/quick-test.ps1` | `scripts/quick-test.sh` |
 | *Pre-commit* + *pytest* completo (sem *gatekeeper* / sem *plans-stats*) | `scripts/pre-commit-and-tests.ps1` | `scripts/pre-commit-and-tests.sh` |
 
-**Nota:** o **`check-all.ps1`** chama **`gatekeeper-audit.ps1`** e **`plans-stats.py`** antes de delegar ao **`pre-commit-and-tests.ps1`**; o **`check-all.sh`** faz o mesmo ao nível do *shell*. Os **`pre-commit-and-tests.*`** ignoram *gatekeeper* e *plans-stats* de propósito.
+**Nota:** o **`check-all.ps1`** chama **`gatekeeper-audit.ps1`** e **`plans-stats.py`** antes de delegar ao **`pre-commit-and-tests.ps1`**; o **`check-all.sh`** executa os mesmos dois passos e chama **`pre-commit-and-tests.sh`** (o mesmo padrão de delegação, sem duplicar *pre-commit*/*pytest*). Os **`pre-commit-and-tests.*`** ignoram *gatekeeper* e *plans-stats* de propósito. O *build* opcional do Rust **boar** fica em **`pre-commit-and-tests.*`** (melhor esforço com `rustc` no `PATH`; `DATA_BOAR_SKIP_RUST_BUILD=1` pula).
 
 ## Verificação
 

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# check-all.sh — Linux/macOS (bash) mirror of scripts/check-all.ps1.
+# check-all.sh — Linux/macOS mirror of scripts/check-all.ps1.
+# Delegates lint/tests to scripts/pre-commit-and-tests.sh (same as check-all.ps1).
 # Full gate: optional gatekeeper (requires pwsh) + plans dashboard + pre-commit + pytest.
+# Optional Rust prefilter build runs inside pre-commit-and-tests.* when rustc is available.
 # From repo root:
 #   ./scripts/check-all.sh
 #   ./scripts/check-all.sh --skip-pre-commit
@@ -32,7 +34,7 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-echo "=== check-all.sh: lint + tests (repo: $REPO_ROOT) ===" >&2
+echo "=== check-all: lint + tests ===" >&2
 
 # PII gate (parity with check-all.ps1) — reuses PowerShell script.
 if command -v pwsh >/dev/null 2>&1; then
@@ -41,7 +43,7 @@ else
   echo "check-all.sh: WARN: pwsh not on PATH; skipping gatekeeper-audit.ps1 (install PowerShell for parity)." >&2
 fi
 
-# Plan dashboard
+# Plan dashboard (same order as check-all.ps1 — before pre-commit-and-tests).
 PY=python3
 if ! command -v python3 >/dev/null 2>&1; then
   PY=python
@@ -49,44 +51,20 @@ fi
 echo "Refreshing plans status dashboard..." >&2
 "$PY" "$REPO_ROOT/scripts/plans-stats.py" --write
 
-# Recover from missing venv
-if [[ ! -f .venv/pyvenv.cfg ]]; then
-  echo "No .venv/pyvenv.cfg - running uv sync to recreate the environment..." >&2
-  uv sync
-  if [[ ! -f .venv/pyvenv.cfg ]]; then
-    echo "check-all.sh: uv sync did not create .venv; fix disk path or UV_* env and retry." >&2
-    exit 2
-  fi
+ARGS=()
+if [[ "$SKIP_PRECOMMIT" -eq 1 ]]; then
+  ARGS+=(--skip-pre-commit)
 fi
 
-if [[ "$SKIP_PRECOMMIT" -eq 0 ]]; then
-  echo "Running pre-commit (Ruff + markdown + pt-BR locale guards)..." >&2
-  if ! uv run pre-commit run --all-files; then
-    echo "pre-commit failed. Attempting to auto-apply Ruff formatting and re-run pre-commit once..." >&2
-    uv run ruff format . 2>/dev/null || true
-    if ! uv run pre-commit run --all-files; then
-      echo "pre-commit still failing after auto-format. Fix issues above before committing or pushing." >&2
-      exit 1
-    fi
-  fi
-fi
+"$REPO_ROOT/scripts/pre-commit-and-tests.sh" "${ARGS[@]}"
+exit_code=$?
 
-echo "Running pytest (full suite, warnings treated as errors)..." >&2
-set +e
-uv run pytest -v -W error --tb=short
-pytest_rc=$?
-set -e
-if [[ "$pytest_rc" -ne 0 ]]; then
-  echo "pytest failed. Fix test failures before committing or pushing." >&2
-  exit "$pytest_rc"
-fi
-
-if [[ "$INCLUDE_VERSION_SMOKE" -eq 1 ]]; then
+if [[ "$exit_code" -eq 0 ]] && [[ "$INCLUDE_VERSION_SMOKE" -eq 1 ]]; then
   vsmoke="$REPO_ROOT/scripts/version-readiness-smoke.ps1"
   if [[ -f "$vsmoke" ]]; then
     if command -v pwsh >/dev/null 2>&1; then
       echo "Running version readiness smoke..." >&2
-      pwsh "$vsmoke" || exit "$?"
+      pwsh "$vsmoke" || exit_code=$?
     else
       echo "check-all.sh: --include-version-smoke needs pwsh; skipping (script present)." >&2
     fi
@@ -95,5 +73,10 @@ if [[ "$INCLUDE_VERSION_SMOKE" -eq 1 ]]; then
   fi
 fi
 
-echo "check-all.sh: OK (pre-commit and pytest passed)." >&2
-exit 0
+if [[ "$exit_code" -eq 0 ]]; then
+  echo "check-all: OK (pre-commit and pytest passed)." >&2
+else
+  echo "check-all: FAILED (see output above)." >&2
+fi
+
+exit "$exit_code"

--- a/scripts/pre-commit-and-tests.ps1
+++ b/scripts/pre-commit-and-tests.ps1
@@ -1,5 +1,6 @@
 #!/usr/bin/env pwsh
 # Run pre-commit (Ruff + plans-stats --check + markdown + pt-BR + commercial guard) and full pytest via uv.
+# When not skipped, may run an optional maturin build for rust/boar_fast_filter (see build-rust-prefilter.ps1).
 # Linux/macOS twin: scripts/pre-commit-and-tests.sh
 # Usage (from repo root):
 #   .\scripts\pre-commit-and-tests.ps1
@@ -21,6 +22,22 @@ if (-not (Test-Path -LiteralPath $venvCfg)) {
     if (-not (Test-Path -LiteralPath $venvCfg)) {
         Write-Host "check gate: uv sync did not create .venv; fix disk path or UV_* env and retry." -ForegroundColor Red
         exit 2
+    }
+}
+
+# Optional Rust native extension (parity with scripts/build-rust-prefilter.ps1).
+# Best-effort: developers without rustc/maturin still pass the gate; CI typically skips importorskip tests.
+$rustManifest = Join-Path $repoRoot "rust\boar_fast_filter\Cargo.toml"
+if ((-not $SkipPreCommit) -and (Test-Path -LiteralPath $rustManifest) -and ($env:DATA_BOAR_SKIP_RUST_BUILD -ne "1")) {
+    if (Get-Command rustc -ErrorAction SilentlyContinue) {
+        Write-Host "Building Rust prefilter (boar_fast_filter)..." -ForegroundColor Cyan
+        uv run pip install maturin 2>$null | Out-Null
+        uv run maturin develop --manifest-path $rustManifest --release
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "Rust prefilter build failed or incomplete; continuing without native extension (tests may skip)." -ForegroundColor Yellow
+        }
+    } else {
+        Write-Host "rustc not on PATH; skipping Rust prefilter build." -ForegroundColor Yellow
     }
 }
 

--- a/scripts/pre-commit-and-tests.sh
+++ b/scripts/pre-commit-and-tests.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # pre-commit-and-tests.sh — Linux/macOS mirror of scripts/pre-commit-and-tests.ps1.
+# Optional: maturin develop for rust/boar_fast_filter when rustc is on PATH (see build-rust-prefilter.ps1).
 # Runs pre-commit (unless skipped) then full pytest with warnings as errors.
 # Usage (from repo root):
 #   ./scripts/pre-commit-and-tests.sh
@@ -32,6 +33,23 @@ if [[ ! -f .venv/pyvenv.cfg ]]; then
   if [[ ! -f .venv/pyvenv.cfg ]]; then
     echo "pre-commit-and-tests.sh: uv sync did not create .venv; fix disk path or UV_* env and retry." >&2
     exit 2
+  fi
+fi
+
+# Optional Rust native extension (parity with scripts/build-rust-prefilter.ps1).
+# Best-effort; set DATA_BOAR_SKIP_RUST_BUILD=1 to skip. Mirrors pre-commit-and-tests.ps1.
+RUST_MANIFEST="$REPO_ROOT/rust/boar_fast_filter/Cargo.toml"
+if [[ "$SKIP_PRECOMMIT" -eq 0 ]] && [[ -f "$RUST_MANIFEST" ]] && [[ "${DATA_BOAR_SKIP_RUST_BUILD:-}" != "1" ]]; then
+  if command -v rustc >/dev/null 2>&1; then
+    echo "Building Rust prefilter (boar_fast_filter)..." >&2
+    uv run pip install maturin >/dev/null 2>&1 || true
+    if uv run maturin develop --manifest-path "$RUST_MANIFEST" --release; then
+      :
+    else
+      echo "Rust prefilter build failed or incomplete; continuing without native extension (tests may skip)." >&2
+    fi
+  else
+    echo "rustc not on PATH; skipping Rust prefilter build." >&2
   fi
 fi
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -636,6 +636,19 @@ def test_commit_or_pr_mentions_gh_default_repo_guard():
     assert "RunVersionSmoke" in text
 
 
+def test_check_all_sh_delegates_to_pre_commit_and_tests():
+    """check-all.sh mirrors check-all.ps1 by calling pre-commit-and-tests.sh (not inlining)."""
+    root = _project_root()
+    script = root / "scripts" / "check-all.sh"
+    if not script.exists():
+        return
+    text = script.read_text(encoding="utf-8", errors="replace")
+    assert "pre-commit-and-tests.sh" in text
+    assert "pre-commit run" not in text, (
+        "check-all.sh should delegate to pre-commit-and-tests.sh"
+    )
+
+
 def test_check_all_supports_optional_version_smoke():
     """check-all script exposes optional version readiness smoke switch."""
     root = _project_root()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **`scripts/check-all.sh`** now mirrors **`check-all.ps1`**: gatekeeper-audit → `plans-stats.py --write` → **`scripts/pre-commit-and-tests.sh`** (delegation, not inlined pre-commit/pytest).
- **`pre-commit-and-tests.ps1`** / **`pre-commit-and-tests.sh`**: optional **`maturin develop`** for **`rust/boar_fast_filter`** when **`rustc`** is on PATH (aligned with **`build-rust-prefilter.ps1`**); **`DATA_BOAR_SKIP_RUST_BUILD=1`** skips.
- **`docs/ops/SCRIPTS_CROSS_PLATFORM_PAIRING`** (EN + pt-BR): updated note for delegation + Rust opt-in.
- **`tests/test_scripts.py`**: asserts **`check-all.sh`** delegates via **`pre-commit-and-tests.sh`**.

Pre-commit hooks passed on touched files locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://data-boar.slack.com/archives/C0AN7HY3NP9/p1777326554032499?thread_ts=1777326554.032499&cid=C0AN7HY3NP9)

<div><a href="https://cursor.com/agents/bc-219035ce-ec0c-5901-9818-3b1104b093be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-219035ce-ec0c-5901-9818-3b1104b093be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

