### PR TITLE
chore(deps): bump PyO3 in boar_fast_filter; fix check-all.ps1 paths on Linux

### DIFF
--- a/rust/boar_fast_filter/Cargo.lock
+++ b/rust/boar_fast_filter/Cargo.lock
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "unicode-ident"

--- a/rust/boar_fast_filter/Cargo.toml
+++ b/rust/boar_fast_filter/Cargo.toml
@@ -8,5 +8,5 @@ name = "boar_fast_filter"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.23", features = ["extension-module"] }
+pyo3 = { version = "0.24", features = ["extension-module"] }
 regex = "1.10"

--- a/scripts/check-all.ps1
+++ b/scripts/check-all.ps1
@@ -16,7 +16,7 @@ $repoRoot = (Get-Item $PSScriptRoot).Parent.FullName
 Set-Location $repoRoot
 
 # PII gate: maintainer seeds vs staged paths only (see scripts/gatekeeper-audit.ps1).
-& "$repoRoot\scripts\gatekeeper-audit.ps1"
+& (Join-Path (Join-Path $repoRoot "scripts") "gatekeeper-audit.ps1")
 if ($LASTEXITCODE -ne 0) {
     Write-Host "check-all: ABORTED by gatekeeper-audit (PII seed hit in staged files)." -ForegroundColor Red
     exit $LASTEXITCODE
@@ -26,7 +26,7 @@ Write-Host "=== check-all: lint + tests ===" -ForegroundColor Cyan
 
 # Keep plan dashboard stats in sync before lint/tests.
 Write-Host "Refreshing plans status dashboard..." -ForegroundColor Yellow
-& python "$repoRoot\scripts\plans-stats.py" --write
+& python (Join-Path (Join-Path $repoRoot "scripts") "plans-stats.py") --write
 if ($LASTEXITCODE -ne 0) {
     Write-Host "check-all: FAILED to refresh plans dashboard." -ForegroundColor Red
     exit $LASTEXITCODE
@@ -38,11 +38,11 @@ if ($SkipPreCommit) {
     $argsList += "-SkipPreCommit"
 }
 
-& "$repoRoot\scripts\pre-commit-and-tests.ps1" @argsList
+& (Join-Path (Join-Path $repoRoot "scripts") "pre-commit-and-tests.ps1") @argsList
 $exitCode = $LASTEXITCODE
 
 if ($exitCode -eq 0 -and $IncludeVersionSmoke) {
-    $smokeScript = "$repoRoot\scripts\version-readiness-smoke.ps1"
+    $smokeScript = Join-Path (Join-Path $repoRoot "scripts") "version-readiness-smoke.ps1"
     if (Test-Path -LiteralPath $smokeScript) {
         Write-Host "Running version readiness smoke..." -ForegroundColor Yellow
         & $smokeScript


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Bump `pyo3` from `0.23` to `0.24` in `rust/boar_fast_filter/Cargo.toml` and refresh `Cargo.lock` (resolves the published RUSTSEC buffer-overflow advisory for the older PyO3 line).
- `cargo build --release` in `rust/boar_fast_filter/` succeeds with the new stack.
- `scripts/check-all.ps1` used hard-coded Windows path separators (`$repoRoot\scripts\...`), which made `pwsh` on Linux fail before lint/tests. Replaced with `Join-Path` so the same script runs on Windows and on Linux/macOS `pwsh` without changing behaviour.

## Validation

- `pwsh -NoProfile -File ./scripts/check-all.ps1` (full pre-commit + pytest) — green (984 passed, 5 skipped).

## Notes

- No new shell scripts added; `check-all.sh` unchanged in this branch.
- Two commits: (1) Cargo bump, (2) PS1 path portability — easy to split or squash on merge if you prefer a single commit.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://data-boar.slack.com/archives/C0AN7HY3NP9/p1777327057313259?thread_ts=1777327057.313259&cid=C0AN7HY3NP9)

<div><a href="https://cursor.com/agents/bc-3edcf142-3f5a-5010-8e4b-5a560c684f8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3edcf142-3f5a-5010-8e4b-5a560c684f8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

