### PR TITLE
docs(workflow): PR integrity checklist and agent rigor rule

### DIFF
--- a/.cursor/rules/linguistic-rigor-and-performance.mdc
+++ b/.cursor/rules/linguistic-rigor-and-performance.mdc
@@ -1,0 +1,34 @@
+---
+description: Persona de rigor (voz ativa), baseline de performance 200k e léxico de produto (ADR 0035).
+globs: ["**/*"]
+alwaysApply: true
+---
+
+# Rigor linguístico e de performance
+
+## 1. Persona e voz (operador + código)
+
+- Prefira **voz ativa** e verbos operacionais: o sistema faz X, o gate bloqueia Y, o operador executa Z.
+- Evite abstrações vazias; amarre afirmações a **módulos**, **flags** ou **artefatos** (paths reais) quando descrever comportamento.
+- Em narrativa **pt-BR**, siga **`.cursor/rules/docs-locale-pt-br-contract.mdc`** (léxico brasileiro, não pt-PT).
+
+## 2. Motor Rust e caminho Pro — prioridade de engenharia
+
+- O pré-filtro **`boar_fast_filter`** mora em **`rust/boar_fast_filter/`**. Mudanças que tocam Python **e** o hot path Pro devem considerar o crate explicitamente (build local: **`maturin`** / scripts em **`scripts/build-rust-prefilter.ps1`** quando aplicável ao host).
+- **Não** use “ajuste cosmético” em Python para mascarar regressão no pré-filtro ou no throughput do worker quando o escopo for performance.
+
+## 3. Gate de performance — baseline **0.574x** (perfil 200k documentado)
+
+- O repositório fixa o perfil oficial em **`tests/benchmarks/official_benchmark_200k.json`** (`speedup_vs_opencore = 0.574` — Pro **mais lento** que OpenCore neste perfil; ver **`tests/test_official_benchmark_200k_evidence.py`** e **`docs/plans/BENCHMARK_EVOLUTION.md`** §8).
+- **Safe-Hold (NASA-style):** antes de tratar trabalho como “pronto” ou pedir merge autónomo, confirme que **`uv run pytest tests/test_official_benchmark_200k_evidence.py`** ainda passa. Se o perfil mudar de forma intencional, o mesmo PR deve atualizar **JSON + teste + narrativa** coerente — nunca um silêncio entre artefato e docs.
+- Uma queda de performance **abaixo** do que o JSON/teste permitem não é “aceitável com CI verde” se o contrato do benchmark foi violado sem atualização explícita.
+
+## 4. Taxonomia e marca (não traduzir à toa)
+
+- Mantenha os rótulos canónicos de produto em inglês quando forem **marca ou camada nomeada**: **Data Sniffing**, **Deep Boring**, **Safe-Hold**, **Audit Trail** — alinhado a **ADR 0035** e **`docs/GLOSSARY.md`**.
+- Não traduza esses termos para português em docs públicos só para “naturalizar”; use a forma fixa e explique na primeira ocorrência se necessário.
+
+## 5. Fonte de verdade técnica
+
+- Alterou comportamento, CLI, API ou conectores? Atualize **`docs/TECH_GUIDE.md`** e **`docs/TECH_GUIDE.pt_BR.md`** no mesmo esforço quando a mudança for relevante para operadores (regra espelhada no checklist de PR).
+- Desvio entre código e **TECH_GUIDE** / benchmark evidenciado é **bug de documentação ou de contrato** — trate como tal antes de integrar.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,5 +14,15 @@ Brief description of the change and why it is needed.
 - [ ] Docs/README updated if behaviour or setup changed.
 - [ ] Security-sensitive changes: considered impact and SECURITY.md (e.g. dependency changes, config, auth).
 
+## Integridade (checklist extendido)
+
+Marque o que aplicar ao escopo deste PR (deixe em branco o que for N/A).
+
+- [ ] **Python:** `uv run pytest` e `uv run ruff check .` limpos no escopo tocado.
+- [ ] **Rust (`boar_fast_filter`):** alterei `rust/boar_fast_filter/**` ou o bridge Pro — executei `cargo clippy --locked --manifest-path rust/boar_fast_filter/Cargo.toml -- -D warnings` (e build local conforme `rust/boar_fast_filter/README.md` quando necessário).
+- [ ] **Benchmark 200k / baseline 0.574x:** confirmei que o contrato em `tests/benchmarks/official_benchmark_200k.json` permanece alinhado — `uv run pytest tests/test_official_benchmark_200k_evidence.py` passa; se o perfil mudou de propósito, atualizei JSON + teste + narrativa no mesmo PR.
+- [ ] **Fonte de verdade:** alterações de comportamento/CLI/API/conectores refletidas em `docs/TECH_GUIDE.md` e `docs/TECH_GUIDE.pt_BR.md` quando relevante para operadores.
+- [ ] **Léxico de produto:** termos canônicos (**Data Sniffing**, **Deep Boring**, **Audit Trail**, **Safe-Hold**, etc.) não foram traduzidos ad hoc; seguem ADR 0035 / `docs/GLOSSARY.md`.
+
 ## Related issues
 Fixes (issue number) (if applicable).

--- a/README.pt_BR.md
+++ b/README.pt_BR.md
@@ -1,5 +1,7 @@
 # Data Boar
 
+> O Data Boar não é um software de prateleira; é um instrumento de precisão para auditoria forense. Cada linha de código segue o rigor da engenharia de voo. Se a documentação não reflete o código, a documentação é um bug.
+
 **Data Boar** — descoberta de dados e governança de risco corporativa: mapeamento com consciência de conformidade na sua sopa de dados (motor de inteligência, não um “app de auditoria” de um só marco).
 
 ![Data Boar mascot](api/static/mascot/data_boar_mascote_color.svg)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Extends `.github/PULL_REQUEST_TEMPLATE.md` with an **Integridade** section: Python/Ruff, `cargo clippy` for `rust/boar_fast_filter` when Rust is in scope, the **200k benchmark** contract (`tests/test_official_benchmark_200k_evidence.py` + JSON), `TECH_GUIDE` EN/pt-BR sync, and product lexicon (ADR 0035 / glossary).
- Adds **`.cursor/rules/linguistic-rigor-and-performance.mdc`** (always on): active voice, Rust prefilter priority, **0.574x** evidence baseline as documented in-repo, **Safe-Hold** before calling work done, canonical terms (**Data Sniffing**, **Deep Boring**, etc.).
- Prepends a short **doctrine** blockquote to root **`README.pt_BR.md`**.

## Notes
- The **0.574x** figure matches the pinned `speedup_vs_opencore` in `tests/benchmarks/official_benchmark_200k.json` (Pro slower than OpenCore in that profile); changing it requires updating the JSON, test, and narrative together.
- There is no `rust-ci.yml` in this repo today; the template uses a concrete `cargo clippy` path for `rust/boar_fast_filter`.
- The path `docs/pt_BR/README.pt_BR.md` does not exist; the docs hub is `docs/README.pt_BR.md`. The intro change was applied to **root** `README.pt_BR.md` as in the request’s spirit.

## Checklist
- [x] Pre-commit on touched files
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://data-boar.slack.com/archives/C0AN7HY3NP9/p1777382441819129?thread_ts=1777382441.819129&cid=C0AN7HY3NP9)

<div><a href="https://cursor.com/agents/bc-d306cd8f-10e8-541a-a10e-06188b48755e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d306cd8f-10e8-541a-a10e-06188b48755e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

