### PR TITLE
docs(cursor): Slack mission log protocol for Web audit trail

### DIFF
--- a/.cursor/rules/cloud-agents-token-aware-safety.mdc
+++ b/.cursor/rules/cloud-agents-token-aware-safety.mdc
@@ -69,3 +69,7 @@ uv run pytest -q
 - any action that depends on private inventory values
 - any destructive actions (mass deletes, force pushes, infra changes) without explicit operator intent
 
+## Optional Slack `#data-boar-ops` mission log (operator-requested)
+
+When the operator wants **audit-trail style** updates aligned with **`#data-boar-ops`**, follow **`.cursor/rules/slack-mission-log-protocol.mdc`** (situational — **`@slack-mission-log-protocol.mdc`** if globs miss). **Never** put webhook URLs or tokens in tracked files. Cloud Agents usually **cannot POST to Slack** without a configured Slack-capable tool or an operator-run step with **`SLACK_WEBHOOK_URL`** in env — if posting is impossible, **emit the formatted block in chat** so the operator can paste once.
+

--- a/.cursor/rules/slack-mission-log-protocol.mdc
+++ b/.cursor/rules/slack-mission-log-protocol.mdc
@@ -1,0 +1,47 @@
+---
+description: Optional Slack #data-boar-ops mission-event log format for Cursor Web / operator audit trail (no secrets in repo)
+alwaysApply: false
+---
+
+# Slack mission log (`#data-boar-ops`) — optional audit trail
+
+Use when the operator enables **mission-style telemetry** for **Cursor Web / Cloud Agents** sessions: treat `#data-boar-ops` as an **event log**, not casual chat.
+
+## Hard constraints (repository safety)
+
+- **Never** paste **`SLACK_WEBHOOK_URL`**, tokens, or webhook URLs into tracked files, issues, PRs, or chat transcripts destined for GitHub.
+- **Agents cannot POST to Slack** unless the runtime exposes a **configured** Slack tool or the **operator** runs a local/script step with secrets from env — see **`docs/ops/OPERATOR_NOTIFICATION_CHANNELS.md`** (`SLACK_WEBHOOK_URL` in GitHub Actions or gitignored config).
+- **Redact by default:** branch names and PR numbers are OK; avoid third-party identifiers, reproduction steps with private data, and large log dumps.
+
+## When to emit a line (mission events)
+
+Post (or, if Slack POST is unavailable, **echo this block in the Cursor thread** so the operator can paste once) on:
+
+- **START** — task id + goal one-liner.
+- **RCA / pivot** — hypothesis, evidence tried, next step (before large code edits).
+- **PR** — opened or updated (title scope); link when available from `gh` / UI.
+- **CI / tests** — **FAIL** (first failing test name + <=10 lines) or **SUCCESS** after a gate you ran.
+- **HEARTBEAT** — if work spans **> ~15 minutes** wall time without a state change, send a one-line still-alive + what is running.
+
+## Message template (copy-friendly)
+
+```text
+[TASK_ID] | [PERSONA: NASA/Gibson] | [STATUS: RUNNING|FAIL|SUCCESS]
+Summary: <one sentence, active voice>
+Drift Check: <locale/tests/docs alignment — e.g. EN/pt-BR guard status>
+Performance: <current vs target — use N/A unless you have measured metrics>
+```
+
+- **`TASK_ID`:** short slug (e.g. `cursor/fix-auth-3be5`, issue `#nnn`, or date `YYYY-MM-DD-scope`).
+- **`PERSONA`:** optional voice constraint for the run; keep labels **ASCII** for Slack search.
+- **`Performance`:** do **not** invent numbers; use **`N/A`** or cite a real metric from the last command output.
+
+## Integration hints
+
+- **GitHub Actions → Slack** already uses **`SLACK_WEBHOOK_URL`** for CI failure and manual ping — that is **system** telemetry, separate from this **session** protocol.
+- **Product / local notify:** `scripts/notify_webhook.py` posts via app config when enabled — also separate from agent chat paste.
+
+## Related
+
+- **`docs/ops/OPERATOR_NOTIFICATION_CHANNELS.md`** — webhook setup, secrets, `#data-boar-ops`
+- **`.cursor/rules/cloud-agents-token-aware-safety.mdc`** — Cloud Agent limits vs desktop `check-all`

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,20 @@
+# Data Boar — optional Cursor user rules (project root)
+
+This repository’s canonical agent instructions live under **`.cursor/rules/`** and **`AGENTS.md`**.
+
+## Slack mission log (`#data-boar-ops`) — optional
+
+When the operator asks for **audit-trail style** updates in Slack, treat `#data-boar-ops` as a **mission event log** (not casual chat). Do **not** put webhook URLs or tokens in files, issues, or PRs.
+
+**Message template:**
+
+```text
+[TASK_ID] | [PERSONA: NASA/Gibson] | [STATUS: RUNNING|FAIL|SUCCESS]
+Summary: <one sentence, active voice>
+Drift Check: <locale/tests/docs alignment>
+Performance: <N/A or real metric from last command — never invented>
+```
+
+Emit on: session start, RCA before big edits, PR open/update, test/CI fail or pass, and **HEARTBEAT** if idle > ~15 minutes between state changes. If Slack POST is not available, print the same block in chat for the operator to forward.
+
+Full policy: **`.cursor/rules/slack-mission-log-protocol.mdc`** · **`docs/ops/OPERATOR_NOTIFICATION_CHANNELS.md`**.

--- a/docs/ops/CURSOR_AGENT_POLICY_HUB.md
+++ b/docs/ops/CURSOR_AGENT_POLICY_HUB.md
@@ -44,6 +44,7 @@ This page is **consolidation phase B**: the same **theme → first place to look
 | **Direct execution** (clear “ship it” requests) | [`.cursor/rules/operator-direct-execution.mdc`](../../.cursor/rules/operator-direct-execution.mdc) |
 | **Private history / evidence mirrors** (full non-GitHub mirror set when align or sync is obvious) | [`.cursor/rules/operator-evidence-backup-no-rhetorical-asks.mdc`](../../.cursor/rules/operator-evidence-backup-no-rhetorical-asks.mdc) · [ADR 0040](../adr/0040-assistant-private-stack-evidence-mirrors-default.md) · [`PRIVATE_STACK_SYNC_RITUAL.md`](PRIVATE_STACK_SYNC_RITUAL.md) |
 | **Publication truthfulness** (no invented dates/facts; **capture permalinks** when reachable) | [`.cursor/rules/publication-truthfulness-no-invented-facts.mdc`](../../.cursor/rules/publication-truthfulness-no-invented-facts.mdc) · [`docs/private/social_drafts/editorial/SOCIAL_HUB.md`](../private/social_drafts/editorial/SOCIAL_HUB.md) (*Política de data* + inventory) |
+| **Slack `#data-boar-ops` mission log** (optional Cursor Web audit trail — template + secrets hygiene) | [`.cursor/rules/slack-mission-log-protocol.mdc`](../../.cursor/rules/slack-mission-log-protocol.mdc) (**situational** — **`@slack-mission-log-protocol.mdc`**) · [`OPERATOR_NOTIFICATION_CHANNELS.md`](OPERATOR_NOTIFICATION_CHANNELS.md) ([pt-BR](OPERATOR_NOTIFICATION_CHANNELS.pt_BR.md)) §4.3 · [`.cursorrules`](../../.cursorrules) (short copy for User Rules) |
 
 ## Related operator runbooks
 

--- a/docs/ops/CURSOR_AGENT_POLICY_HUB.pt_BR.md
+++ b/docs/ops/CURSOR_AGENT_POLICY_HUB.pt_BR.md
@@ -44,6 +44,7 @@ Esta página é a **fase B de consolidação**: o mesmo mapa **tema → primeiro
 | **Execução direta** (pedido claro de fechar — evitar confirmação redundante) | [`.cursor/rules/operator-direct-execution.mdc`](../../.cursor/rules/operator-direct-execution.mdc) |
 | **Histórico privado / espelhos de evidência** (conjunto completo de espelhos não-GitHub quando alinhar ou sync é óbvio) | [`.cursor/rules/operator-evidence-backup-no-rhetorical-asks.mdc`](../../.cursor/rules/operator-evidence-backup-no-rhetorical-asks.mdc) · [ADR 0040](../adr/0040-assistant-private-stack-evidence-mirrors-default.md) (EN) · [`PRIVATE_STACK_SYNC_RITUAL.md`](PRIVATE_STACK_SYNC_RITUAL.md) |
 | **Verdade em publicação** (sem inventar datas/fatos; **capturar permalinks** quando der) | [`.cursor/rules/publication-truthfulness-no-invented-facts.mdc`](../../.cursor/rules/publication-truthfulness-no-invented-facts.mdc) · [`docs/private/social_drafts/editorial/SOCIAL_HUB.md`](../private/social_drafts/editorial/SOCIAL_HUB.md) (*Política de data* + inventário) |
+| **Log de missão Slack `#data-boar-ops`** (trilha opcional no Cursor Web — modelo + higiene de segredos) | [`.cursor/rules/slack-mission-log-protocol.mdc`](../../.cursor/rules/slack-mission-log-protocol.mdc) (**situacional** — **`@slack-mission-log-protocol.mdc`**) · [`OPERATOR_NOTIFICATION_CHANNELS.pt_BR.md`](OPERATOR_NOTIFICATION_CHANNELS.pt_BR.md) ([EN](OPERATOR_NOTIFICATION_CHANNELS.md)) §4.3 · [`.cursorrules`](../../.cursorrules) (cópia curta para User Rules) |
 
 ## Runbooks relacionados
 

--- a/docs/ops/OPERATOR_NOTIFICATION_CHANNELS.md
+++ b/docs/ops/OPERATOR_NOTIFICATION_CHANNELS.md
@@ -160,6 +160,14 @@ An **incoming webhook** only **posts to a channel**. That is not the same as a *
 
 **Do not** paste your member ID into public issues or commits; keep it in the **Variables** UI only.
 
+### 4.3 Cursor Web / optional “mission event log” in `#data-boar-ops`
+
+Some sessions use **`#data-boar-ops`** as a **structured audit trail** (not chat): start, RCA, PR, test/CI outcome, **HEARTBEAT** on long silences. Canonical **message template and redaction rules** live in [`.cursor/rules/slack-mission-log-protocol.mdc`](../../.cursor/rules/slack-mission-log-protocol.mdc). The repo root [`.cursorrules`](../../.cursorrules) carries a short copy for environments that read **User Rules** only.
+
+**Posting mechanics:** An agent **cannot** reliably POST to Slack **unless** the runtime provides a **Slack-capable tool** (e.g. a configured Slack MCP server) **or** the **operator** runs a step with **`SLACK_WEBHOOK_URL`** in the environment (local shell, GitHub Actions, or `scripts/notify_webhook.py` when product notifications are enabled). **Never** embed the webhook URL in tracked files. If no POST path exists, the agent should **print the same formatted block in Cursor chat** so you paste once into Slack—still useful for a shared trail.
+
+**MCP note:** The tracked [`.cursor/mcp.json`](../../.cursor/mcp.json) in this repository configures **Docker MCP gateway** only; it does **not** include Slack. Adding Slack would be a **separate** MCP server plus secrets **outside** Git.
+
 ---
 
 ## 5. Multi-channel pattern

--- a/docs/ops/OPERATOR_NOTIFICATION_CHANNELS.pt_BR.md
+++ b/docs/ops/OPERATOR_NOTIFICATION_CHANNELS.pt_BR.md
@@ -157,6 +157,14 @@ Um **incoming webhook** só **publica no canal**. Isso **não** é o mesmo que *
 
 **Não** cole seu member ID em issue pública nem em commit; use só a UI de **Variables**.
 
+### 4.3 Cursor Web / log opcional de “eventos de missão” no `#data-boar-ops`
+
+Algumas sessões usam **`#data-boar-ops`** como **trilha de auditoria estruturada** (não como chat solto): início, RCA, PR, resultado de teste/CI, **HEARTBEAT** em silêncios longos. O **modelo de mensagem e regras de redação** estão em [`.cursor/rules/slack-mission-log-protocol.mdc`](../../.cursor/rules/slack-mission-log-protocol.mdc). Na raiz do repo, [`.cursorrules`](../../.cursorrules) traz uma cópia curta para ambientes que só leem **User Rules**.
+
+**Como publicar:** O agente **não** consegue dar POST no Slack de forma confiável **a menos que** o runtime ofereça ferramenta tipo Slack (ex.: servidor MCP Slack configurado) **ou** o **operador** rode um passo com **`SLACK_WEBHOOK_URL`** no ambiente (shell local, GitHub Actions ou `scripts/notify_webhook.py` com notificações do produto ligadas). **Nunca** coloque a URL do webhook em arquivos rastreados. Se não houver caminho de POST, o agente deve **imprimir o mesmo bloco formatado no chat do Cursor** para você colar uma vez no Slack — ainda assim registra o mesmo evento para você e para o canal (trilha conjunta).
+
+**Nota MCP:** O [`.cursor/mcp.json`](../../.cursor/mcp.json) rastreado neste repositório configura só o **gateway Docker MCP**; **não** inclui Slack. Acrescentar Slack seria outro servidor MCP + segredos **fora** do Git.
+
 ---
 
 ## 5. Padrão multi-canal


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an optional **mission event log** convention for `#data-boar-ops` when using **Cursor Web / Cloud Agents**: structured template, when to post (start, RCA, PR, tests, HEARTBEAT), and hard rules against putting webhooks in git.

## Changes

- New situational rule: `.cursor/rules/slack-mission-log-protocol.mdc`
- Root `.cursorrules` with a short copy for environments that only read User Rules
- `docs/ops/OPERATOR_NOTIFICATION_CHANNELS.md` (+ pt-BR): new §4.3 (mechanics, MCP note for tracked `.cursor/mcp.json`)
- `docs/ops/CURSOR_AGENT_POLICY_HUB.md` (+ pt-BR): new policy row
- `cloud-agents-token-aware-safety.mdc`: pointer to the mission log + fallback when Slack POST is unavailable

## Notes

- Tracked `/.cursor/mcp.json` in this repo is **Docker MCP gateway only**; Slack is not wired there. True auto-post from the agent needs a **Slack-capable MCP** (or operator-side `SLACK_WEBHOOK_URL` / Actions), or **copy-paste** of the formatted block from chat to Slack.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://data-boar.slack.com/archives/C0AN7HY3NP9/p1777382579313199?thread_ts=1777382579.313199&cid=C0AN7HY3NP9)

<div><a href="https://cursor.com/agents/bc-af650243-3b5c-5129-b3a5-8ab1277c3be5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af650243-3b5c-5129-b3a5-8ab1277c3be5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

