### PR TITLE
fix(rust): use u32::is_multiple_of(10) in Luhn check (clippy 1.95)

### DIFF
--- a/rust/boar_fast_filter/src/lib.rs
+++ b/rust/boar_fast_filter/src/lib.rs
@@ -92,7 +92,7 @@ impl FastFilter {
             })
             .sum();
 
-        sum % 10 == 0
+        sum.is_multiple_of(10)
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## CI AUTOFIX — Rust CI

`AUTOFIX_RUN_ANCHOR: 25058531301`

### Failing run

- Workflow: **Rust CI**, run [25058531301](https://github.com/FabioLeitao/data-boar/actions/runs/25058531301), event `pull_request` on Dependabot Cargo PR #226 (`pyo3 0.23.5 → 0.24.1`).
- Head SHA on that run: `fb481f1909b54a37b5822c566b3f468f57bb2d34` (the SHA `12a006e…` referenced in the trigger message belongs to the unrelated pip-group PR #309 — autofix anchored to the run page's actual SHA per protocol §0).
- Single failing step: `cargo clippy (deny warnings)` (`-D warnings`).
- Same lint also fails the `Rust CI` run on `main` (`25058465401`, SHA `3b1d70de`), so this is **not** caused by the `pyo3` bump — it is a toolchain regression that hit `main` independently.

### Root cause (one chain, evidence-first)

```
error: manual implementation of `.is_multiple_of()`
  --> src/lib.rs:95:9
   |
95 |         sum % 10 == 0
   |         ^^^^^^^^^^^^^ help: replace with: `sum.is_multiple_of(10)`
   = note: `-D clippy::manual-is-multiple-of` implied by `-D warnings`
```

Rust **1.95.0** stabilized `clippy::manual_is_multiple_of`. The Luhn check at `rust/boar_fast_filter/src/lib.rs:95` uses `sum % 10 == 0`, which now triggers `-D warnings`.

### Fix (smallest possible diff)

Replace one expression with the clippy-suggested form. `u32::is_multiple_of` is stable since Rust 1.87, well below the toolchain in use. Behavior is identical for `u32` operands.

```diff
-        sum % 10 == 0
+        sum.is_multiple_of(10)
```

### Local validation (rustc 1.95.0 / clippy 0.1.95 — same toolchain as CI)

- `cargo fmt --all -- --check` ✅
- `cargo check --all-targets --locked` ✅
- `cargo test --all-targets --locked` ✅ — 19/19 passed, including every `luhn_*` test and `detects_mixed_signal_batch`
- `cargo clippy --all-targets --locked -- -D warnings` ✅

Pre-commit hooks (PII guards, lockfile parity) also passed locally.

### Residual risk

- None for behavior: `u32 % 10 == 0` and `u32::is_multiple_of(10)` are equivalent on the integer type used here.
- Once this lands on `main`, Dependabot PR #226 will rebatch on top of a green Rust CI; if a maintainer prefers, they can also rebase #226 directly to clear it without a fresh Dependabot cycle.

### Out of scope (not done by design — protocol §4 / §7)

- No `#[allow(clippy::manual_is_multiple_of)]` escape hatch (silencing > fixing).
- No toolchain pinning, no `rust-toolchain.toml` change, no clippy config relaxation.
- No unrelated formatting or refactors.
- No second PR for the same anchor.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://data-boar.slack.com/archives/C0AN7HY3NP9/p1777575322038579?thread_ts=1777575322.038579&cid=C0AN7HY3NP9)

<div><a href="https://cursor.com/agents/bc-dcca7483-468f-5a23-b001-7d96fd99868a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcca7483-468f-5a23-b001-7d96fd99868a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

