### PR TITLE
docs(ops): refresh workboard snapshot and WRB follow-up row

### DIFF
--- a/docs/ops/today-mode/WORKBOARD.md
+++ b/docs/ops/today-mode/WORKBOARD.md
@@ -14,6 +14,7 @@
 | Plan index/map | [../../plans/PLANS_HUB.md](../../plans/PLANS_HUB.md) | Fast lookup of `PLAN_*.md` files |
 | Sprint and milestones view | [../../plans/SPRINTS_AND_MILESTONES.md](../../plans/SPRINTS_AND_MILESTONES.md) | Theme-level sequencing and milestone semantics |
 | Carryover queue (rolling) | [CARRYOVER.md](CARRYOVER.md) | Open items crossing days/blocks |
+| WRB follow-up (token window) | [GitHub issue #189](https://github.com/FabioLeitao/data-boar/issues/189) | Resume external review cycle now that tokens are available |
 | Dated execution checklist | [README.md](README.md) + `OPERATOR_TODAY_MODE_YYYY-MM-DD.md` | Daily focus and closure flow |
 | Publish alignment | [PUBLISHED_SYNC.md](PUBLISHED_SYNC.md) | Repo version vs GitHub Release vs Docker Hub |
 | Private rhythm/reminders | `docs/private/TODAY_MODE_CARRYOVER_AND_FOUNDER_RHYTHM.md` | Operator-only reminders and cadence |
@@ -25,12 +26,14 @@
 
 Update this section with concise bullets only. Keep details in canonical docs above.
 
-- **Now (top 1):** `S2a` transport + trust checkpoint from `PLANS_TODO`.
+- **Now (top 1):** `S2a` transport + trust (Phase 7 + trust-state slice aligned with `#86`) is selected in `PLANS_TODO`.
 - **Next (top 3):**
-  - `-1L` homelab proof pass when calendar allows.
-  - Continue prioritized trust/commercial slices after `S2a`.
-  - Keep carryover queue clean (`CARRYOVER.md`).
-- **Blockers:** write one line per blocker and link to the owning doc.
+  - Close the `1.7.0` carryover lane (`gh run list` on `main` + optional `lab-op` smoke follow-up in `CARRYOVER.md`).
+  - Run `-1L` homelab proof / `benchmark-ab` when the lab window is available.
+  - Send WRB follow-up and triage external review deltas into `PLANS_TODO`.
+- **Blockers:**
+  - Lab calendar/hardware window for `-1L` and `benchmark-ab` execution (`PLANS_TODO` + `CARRYOVER.md`).
+  - External review cadence for WRB follow-up (GitHub issue cycle + response wait).
 - **Deferred with date:** keep date + owner in `CARRYOVER.md`.
 
 ---

--- a/docs/ops/today-mode/WORKBOARD.pt_BR.md
+++ b/docs/ops/today-mode/WORKBOARD.pt_BR.md
@@ -14,6 +14,7 @@
 | Índice/mapa de planos | [../../plans/PLANS_HUB.md](../../plans/PLANS_HUB.md) | Busca rápida de arquivos `PLAN_*.md` |
 | Visão de sprint e marcos | [../../plans/SPRINTS_AND_MILESTONES.pt_BR.md](../../plans/SPRINTS_AND_MILESTONES.pt_BR.md) | Sequência por tema e semântica dos marcos |
 | Fila viva de carryover | [CARRYOVER.pt_BR.md](CARRYOVER.pt_BR.md) | Itens abertos que atravessam dias/blocos |
+| Follow-up WRB (janela de token) | [GitHub issue #189](https://github.com/FabioLeitao/data-boar/issues/189) | Retomar agora o ciclo de revisão externa com token disponível |
 | Checklist diário datado | [README.pt_BR.md](README.pt_BR.md) + `OPERATOR_TODAY_MODE_YYYY-MM-DD.md` | Foco do dia e fechamento |
 | Alinhamento de publish | [PUBLISHED_SYNC.pt_BR.md](PUBLISHED_SYNC.pt_BR.md) | Versão no repo vs GitHub Release vs Docker Hub |
 | Ritmo/lembretes privados | `docs/private/TODAY_MODE_CARRYOVER_AND_FOUNDER_RHYTHM.md` | Lembretes e cadência do operador |
@@ -25,12 +26,14 @@
 
 Atualize esta seção com bullets curtos. Detalhes ficam nas fontes canônicas acima.
 
-- **Agora (top 1):** checkpoint `S2a` de transporte + confiança no `PLANS_TODO`.
+- **Agora (top 1):** `S2a` transporte + confiança (Fase 7 + fatia de trust-state alinhada com `#86`) está selecionado no `PLANS_TODO`.
 - **Próximos (top 3):**
-  - `-1L` passada de prova em homelab quando houver janela.
-  - Continuar fatias priorizadas de confiança/comercial após `S2a`.
-  - Manter a fila de carryover limpa (`CARRYOVER.pt_BR.md`).
-- **Bloqueios:** uma linha por bloqueio com link para o doc dono.
+  - Fechar a trilha de carryover do `1.7.0` (`gh run list` no `main` + follow-up opcional de smoke `lab-op` no `CARRYOVER.md`).
+  - Rodar a prova `-1L` de homelab / `benchmark-ab` quando houver janela de laboratório.
+  - Enviar o follow-up WRB e triar os deltas da revisão externa para o `PLANS_TODO`.
+- **Bloqueios:**
+  - Janela de calendário/hardware do lab para executar `-1L` e `benchmark-ab` (`PLANS_TODO` + `CARRYOVER.md`).
+  - Cadência externa de revisão para o follow-up WRB (ciclo no GitHub + espera de resposta).
 - **Adiado com data:** manter data + dono em `CARRYOVER.pt_BR.md`.
 
 ---


### PR DESCRIPTION
## Summary
- refreshes the current workboard snapshot with today's PLANS_TODO + CARRYOVER truth
- adds GitHub issue #189 as canonical WRB follow-up source in WORKBOARD tables (EN + pt-BR)

## Test plan
- [x] .\\scripts\\lint-only.ps1
- [x] pre-commit hooks passed during commit