### PR TITLE
chore(deps): keep pytest stack and tooling out of runtime deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,8 @@ jobs:
 
       - name: Install dependencies
         # shares extra: smbprotocol/webdav — keeps SMB/CIFS/WebDAV connector registration aligned with TECH_GUIDE
-        run: uv sync --extra shares
+        # dev group: pytest, hypothesis, pre-commit stack — not shipped to end-user `uv sync` default in CI test matrix
+        run: uv sync --extra shares --group dev
 
       - name: Run tests
         run: uv run pytest -v -W error
@@ -92,9 +93,7 @@ jobs:
           version: "0.11.2"
 
       - name: Install dependencies
-        run: uv sync --extra shares
-
-      # Single gate: same hooks as local `uv run pre-commit run --all-files` (.pre-commit-config.yaml).
+        run: uv sync --extra shares --group dev
       - name: Pre-commit (all files)
         run: uv run pre-commit run --all-files
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     "annotated-doc>=0.0.4",
     "annotated-types>=0.7.0",
     "anyio>=4.12.1",
-    "asyncio>=4.0.0",
     # beautifulsoup4 is a transitive dep of extract-msg, but pinned here as a
     # direct constraint so Dependabot/uv stop trying to bump past 4.14 until
     # upstream extract-msg relaxes its `beautifulsoup4<4.14` requirement.
@@ -38,9 +37,7 @@ dependencies = [
     "h11>=0.16.0",
     "httpcore>=1.0.9",
     "httpx>=0.28.1",
-    "hypothesis>=6.152.7",
     "idna>=3.15",
-    "iniconfig>=2.3.0",
     "itsdangerous>=2.2.0",
     "jinja2>=3.1.6",
     "joblib>=1.5.3",
@@ -57,7 +54,6 @@ dependencies = [
     "packaging>=26.1",
     "pandas>=3.0.3",
     "pillow>=12.2.0",
-    "pluggy>=1.6.0",
     "psycopg2-binary>=2.9.11",
     "pycparser>=3.0 ; implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'",
     "pydantic>=2.13.2",
@@ -68,7 +64,6 @@ dependencies = [
     "pyparsing>=3.3.2",
     "pypdf>=6.11.0",
     "pyjwt>=2.12.0",
-    "pytest>=9.0.3",
     "python-dateutil>=2.9.0.post0",
     "python-docx>=1.2.0",
     "python-dotenv>=1.2.1",
@@ -80,8 +75,6 @@ dependencies = [
     "scikit-learn>=1.8.0",
     "scipy>=1.17.0",
     "seaborn>=0.13.2",
-    "setuptools>=82.0.1",
-    "six>=1.17.0",
     "sqlalchemy>=2.0.48",
     "starlette>=0.52.1",
     "threadpoolctl>=3.6.0",
@@ -233,16 +226,20 @@ packages = [
 
 [dependency-groups]
 dev = [
-    "pre-commit>=4.0.0",
-    "ruff>=0.15.13",
-    "rapidfuzz>=3.9.0",
     "bandit>=1.9.4",
-    "mypy>=2.1.0",
-    "types-pyyaml>=6.0.12.20250915",
-    # CycloneDX SBOM from uv-exported requirements (ADR 0003); same CLI as CI `sbom.yml`.
-    "cyclonedx-bom>=7.0.0",
     # chardet is transitive via cyclonedx-bom; dev-only pin matches cyclonedx-bom's
     # chardet>=5.1,<6.0 until upstream allows 6+ (ADR 0054).
     "chardet>=5.1,<6.0",
+    # CycloneDX SBOM from uv-exported requirements (ADR 0003); same CLI as CI `sbom.yml`.
+    "cyclonedx-bom>=7.0.0",
+    "hypothesis>=6.152.7",
+    "iniconfig>=2.3.0",
     "markdown>=3.10.2",
+    "mypy>=2.1.0",
+    "pluggy>=1.6.0",
+    "pre-commit>=4.0.0",
+    "pytest>=9.0.3",
+    "rapidfuzz>=3.9.0",
+    "ruff>=0.15.13",
+    "types-pyyaml>=6.0.12.20250915",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,10 +57,6 @@ ast-serialize==0.3.0 \
     --hash=sha256:f5e110cdce2a347e1dd987529c88ef54d26f67848dce3eba1b3b2cc2cf085c94 \
     --hash=sha256:f5ef88cc5842a5d7a6ac09dc0d5fc2c98f5d276c1f076f866d55047ce886785b
     # via mypy
-asyncio==4.0.0 \
-    --hash=sha256:570cd9e50db83bc1629152d4d0b7558d6451bb1bfd5dfc2e935d96fc2f40329b \
-    --hash=sha256:c1eddb0659231837046809e68103969b2bef8b0400d59cfa6363f6b5ed8cc88b
-    # via data-boar
 attrs==26.1.0 \
     --hash=sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309 \
     --hash=sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32
@@ -549,7 +545,6 @@ httpx==0.28.1 \
 hypothesis==6.152.7 \
     --hash=sha256:741dedcede2ae0f32c32929a5992804b61f2b0400403b6a51a881a2b58482782 \
     --hash=sha256:c0b17dd428fcb6e962f60315f6f4a77816c72fbb281ce9ba73699dabead5ec82
-    # via data-boar
 identify==2.6.19 \
     --hash=sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a \
     --hash=sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842
@@ -566,9 +561,7 @@ idna==3.15 \
 iniconfig==2.3.0 \
     --hash=sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730 \
     --hash=sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12
-    # via
-    #   data-boar
-    #   pytest
+    # via pytest
 isoduration==20.11.0 \
     --hash=sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9 \
     --hash=sha256:b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042
@@ -1255,9 +1248,7 @@ platformdirs==4.9.6 \
 pluggy==1.6.0 \
     --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \
     --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
-    # via
-    #   data-boar
-    #   pytest
+    # via pytest
 pre-commit==4.6.0 \
     --hash=sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9 \
     --hash=sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b
@@ -1459,7 +1450,6 @@ pypdf==6.11.0 \
 pytest==9.0.3 \
     --hash=sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9 \
     --hash=sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c
-    # via data-boar
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
@@ -1895,15 +1885,10 @@ seaborn==0.13.2 \
     --hash=sha256:636f8336facf092165e27924f223d3c62ca560b1f2bb5dff7ab7fad265361987 \
     --hash=sha256:93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7
     # via data-boar
-setuptools==82.0.1 \
-    --hash=sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9 \
-    --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
-    # via data-boar
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
     # via
-    #   data-boar
     #   python-dateutil
     #   rfc3339-validator
 sortedcontainers==2.4.0 \

--- a/uv.lock
+++ b/uv.lock
@@ -124,15 +124,6 @@ wheels = [
 ]
 
 [[package]]
-name = "asyncio"
-version = "4.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/71/ea/26c489a11f7ca862d5705db67683a7361ce11c23a7b98fc6c2deaeccede2/asyncio-4.0.0.tar.gz", hash = "sha256:570cd9e50db83bc1629152d4d0b7558d6451bb1bfd5dfc2e935d96fc2f40329b", size = 5371, upload-time = "2025-08-05T02:51:46.605Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/64/eff2564783bd650ca25e15938d1c5b459cda997574a510f7de69688cb0b4/asyncio-4.0.0-py3-none-any.whl", hash = "sha256:c1eddb0659231837046809e68103969b2bef8b0400d59cfa6363f6b5ed8cc88b", size = 5555, upload-time = "2025-08-05T02:51:45.767Z" },
-]
-
-[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -760,7 +751,6 @@ dependencies = [
     { name = "annotated-doc" },
     { name = "annotated-types" },
     { name = "anyio" },
-    { name = "asyncio" },
     { name = "beautifulsoup4" },
     { name = "blinker" },
     { name = "certifi" },
@@ -783,9 +773,7 @@ dependencies = [
     { name = "h11" },
     { name = "httpcore" },
     { name = "httpx" },
-    { name = "hypothesis" },
     { name = "idna" },
-    { name = "iniconfig" },
     { name = "itsdangerous" },
     { name = "jinja2" },
     { name = "joblib" },
@@ -802,7 +790,6 @@ dependencies = [
     { name = "packaging" },
     { name = "pandas" },
     { name = "pillow" },
-    { name = "pluggy" },
     { name = "psycopg2-binary" },
     { name = "pycparser", marker = "implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'" },
     { name = "pydantic" },
@@ -813,7 +800,6 @@ dependencies = [
     { name = "pyodbc" },
     { name = "pyparsing" },
     { name = "pypdf" },
-    { name = "pytest" },
     { name = "python-dateutil" },
     { name = "python-docx" },
     { name = "python-dotenv" },
@@ -825,8 +811,6 @@ dependencies = [
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "seaborn" },
-    { name = "setuptools" },
-    { name = "six" },
     { name = "sqlalchemy" },
     { name = "starlette" },
     { name = "threadpoolctl" },
@@ -880,9 +864,13 @@ dev = [
     { name = "bandit" },
     { name = "chardet" },
     { name = "cyclonedx-bom" },
+    { name = "hypothesis" },
+    { name = "iniconfig" },
     { name = "markdown" },
     { name = "mypy" },
+    { name = "pluggy" },
     { name = "pre-commit" },
+    { name = "pytest" },
     { name = "rapidfuzz" },
     { name = "ruff" },
     { name = "types-pyyaml" },
@@ -893,7 +881,6 @@ requires-dist = [
     { name = "annotated-doc", specifier = ">=0.0.4" },
     { name = "annotated-types", specifier = ">=0.7.0" },
     { name = "anyio", specifier = ">=4.12.1" },
-    { name = "asyncio", specifier = ">=4.0.0" },
     { name = "beautifulsoup4", specifier = ">=4.13.5,<4.14" },
     { name = "blinker", specifier = ">=1.9.0" },
     { name = "certifi", specifier = ">=2026.2.25" },
@@ -918,9 +905,7 @@ requires-dist = [
     { name = "h11", specifier = ">=0.16.0" },
     { name = "httpcore", specifier = ">=1.0.9" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "hypothesis", specifier = ">=6.152.7" },
     { name = "idna", specifier = ">=3.15" },
-    { name = "iniconfig", specifier = ">=2.3.0" },
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "joblib", specifier = ">=1.5.3" },
@@ -940,7 +925,6 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pillow-heif", marker = "extra == 'richmedia'", specifier = ">=0.16.0" },
     { name = "plotly", marker = "extra == 'grc-dashboard'", specifier = ">=5.24.0" },
-    { name = "pluggy", specifier = ">=1.6.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "py7zr", marker = "extra == 'compressed'", specifier = ">=0.20.0" },
     { name = "pyarrow", marker = "extra == 'dataformats'", specifier = ">=14.0.0" },
@@ -955,7 +939,6 @@ requires-dist = [
     { name = "pyparsing", specifier = ">=3.3.2" },
     { name = "pypdf", specifier = ">=6.11.0" },
     { name = "pytesseract", marker = "extra == 'richmedia'", specifier = ">=0.3.13" },
-    { name = "pytest", specifier = ">=9.0.3" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "python-docx", specifier = ">=1.2.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
@@ -971,8 +954,6 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.17.0" },
     { name = "seaborn", specifier = ">=0.13.2" },
     { name = "sentence-transformers", marker = "extra == 'dl'", specifier = ">=5.5.0" },
-    { name = "setuptools", specifier = ">=82.0.1" },
-    { name = "six", specifier = ">=1.17.0" },
     { name = "smbprotocol", marker = "extra == 'shares'", specifier = ">=1.2.0" },
     { name = "snowflake-connector-python", marker = "extra == 'bigdata'", specifier = ">=4.5.0" },
     { name = "sqlalchemy", specifier = ">=2.0.48" },
@@ -994,9 +975,13 @@ dev = [
     { name = "bandit", specifier = ">=1.9.4" },
     { name = "chardet", specifier = ">=5.1,<6.0" },
     { name = "cyclonedx-bom", specifier = ">=7.0.0" },
+    { name = "hypothesis", specifier = ">=6.152.7" },
+    { name = "iniconfig", specifier = ">=2.3.0" },
     { name = "markdown", specifier = ">=3.10.2" },
     { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pluggy", specifier = ">=1.6.0" },
     { name = "pre-commit", specifier = ">=4.0.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "rapidfuzz", specifier = ">=3.9.0" },
     { name = "ruff", specifier = ">=0.15.13" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },


### PR DESCRIPTION
## Summary

This PR fixes packaging hygiene from GitHub issues: **pytest**, **hypothesis**, **iniconfig**, and **pluggy** no longer sit under **`[project]`** runtime dependencies, and bogus **`asyncio`** (PyPI stub), **`six`**, and **`setuptools`** entries are removed from the runtime list.

## Changes

- **`pyproject.toml`**: move the pytest stack into **`[dependency-groups] dev`**; drop **`asyncio`**, **`six`**, **`setuptools`** from **`[project] dependencies`**.
- **`.github/workflows/ci.yml`**: **Test**, **Lint**, and **Bandit** jobs use **`uv sync --extra shares --group dev`** so CI keeps pytest, pre-commit, and bandit available.
- **`uv.lock`** / **`requirements.txt`**: regenerated to match **`pyproject.toml`**.

## Verification

Local **`check-all`** passed (pre-commit + full pytest).

Closes #461
Closes #481
Closes #482
Closes #484
