### PR TITLE
fix(engine): catch connector instantiation errors in sequential runs

### DIFF
--- a/core/engine.py
+++ b/core/engine.py
@@ -87,12 +87,21 @@ try:
 except ImportError:
     pass
 
+from connectors.sql_connector import SQLConnector
 from core.connector_registry import connector_for_target
 from core.crypto_audit import StrongCryptoSignal, summarize_crypto_from_connection_info
 from core.database import LocalDBManager
 from core.sampling import SamplingPolicy
 from core.scanner import DataScanner
 from core.session import new_session_id
+
+_CONNECTOR_SAMPLING_POLICY_BASES: tuple[type, ...] = (SQLConnector,)
+try:
+    from connectors.snowflake_connector import SnowflakeConnector
+
+    _CONNECTOR_SAMPLING_POLICY_BASES = (SQLConnector, SnowflakeConnector)
+except ImportError:
+    pass
 
 
 class AuditEngine:
@@ -281,8 +290,32 @@ class AuditEngine:
         )
         file_passwords = fs_config.get("file_passwords") or {}
         ext = fs_config.get("extensions")
-        if t == "filesystem":
-            if ext is not None:
+        from core.validation import clean_error
+
+        try:
+            if t == "filesystem":
+                if ext is not None:
+                    connector = connector_class(
+                        target_with_fs,
+                        self.scanner,
+                        self.db_manager,
+                        extensions=ext,
+                        scan_sqlite_as_db=scan_sqlite_as_db,
+                        sample_limit=sample_limit,
+                        file_sample_max_chars=file_sample_max_chars,
+                        file_passwords=file_passwords,
+                    )
+                else:
+                    connector = connector_class(
+                        target_with_fs,
+                        self.scanner,
+                        self.db_manager,
+                        scan_sqlite_as_db=scan_sqlite_as_db,
+                        sample_limit=sample_limit,
+                        file_sample_max_chars=file_sample_max_chars,
+                        file_passwords=file_passwords,
+                    )
+            elif t in ("sharepoint", "webdav", "smb", "cifs", "nfs"):
                 connector = connector_class(
                     target_with_fs,
                     self.scanner,
@@ -293,69 +326,45 @@ class AuditEngine:
                     file_sample_max_chars=file_sample_max_chars,
                     file_passwords=file_passwords,
                 )
-            else:
+            elif t in ("powerbi", "dataverse", "powerapps"):
                 connector = connector_class(
-                    target_with_fs,
+                    target,
                     self.scanner,
                     self.db_manager,
-                    scan_sqlite_as_db=scan_sqlite_as_db,
                     sample_limit=sample_limit,
-                    file_sample_max_chars=file_sample_max_chars,
-                    file_passwords=file_passwords,
+                    detection_config=self.config.get("detection"),
                 )
-        elif t in ("sharepoint", "webdav", "smb", "cifs", "nfs"):
-            connector = connector_class(
-                target_with_fs,
-                self.scanner,
-                self.db_manager,
-                extensions=ext,
-                scan_sqlite_as_db=scan_sqlite_as_db,
-                sample_limit=sample_limit,
-                file_sample_max_chars=file_sample_max_chars,
-                file_passwords=file_passwords,
-            )
-        elif t in ("powerbi", "dataverse", "powerapps"):
-            connector = connector_class(
-                target,
-                self.scanner,
-                self.db_manager,
-                sample_limit=sample_limit,
-                detection_config=self.config.get("detection"),
-            )
-        else:
-            # Database targets (postgresql, mysql, sqlite, mssql, oracle, mongodb, etc.): pass
-            # sample_limit from file_scan (row/doc caps) and detection config for optional probes.
-            extra_kw: dict[str, Any] = {}
-            if connector_class.__name__ in ("SQLConnector", "SnowflakeConnector"):
-                extra_kw["sampling_policy"] = self._sampling_policy
-            connector = connector_class(
-                target,
-                self.scanner,
-                self.db_manager,
-                sample_limit=sample_limit,
-                detection_config=self.config.get("detection"),
-                **extra_kw,
-            )
-            # Phase 1: inspect connection info to collect coarse crypto/transport hints.
-            name = (target.get("name") or "").strip() or "database"
-            driver = (target.get("driver") or "").strip()
-            dsn = (target.get("dsn") or "").strip()
-            sslmode = (target.get("sslmode") or "").strip()
-            conn_info = {
-                "type": "database",
-                "name": name,
-                "driver": driver,
-                "dsn": dsn,
-                "sslmode": sslmode,
-            }
-            signals = summarize_crypto_from_connection_info(conn_info)
-            if signals:
-                self._crypto_signals.append((name, signals))
-        try:
+            else:
+                # Database targets (postgresql, mysql, sqlite, mssql, oracle, mongodb, etc.): pass
+                # sample_limit from file_scan (row/doc caps) and detection config for optional probes.
+                extra_kw: dict[str, Any] = {}
+                if issubclass(connector_class, _CONNECTOR_SAMPLING_POLICY_BASES):
+                    extra_kw["sampling_policy"] = self._sampling_policy
+                connector = connector_class(
+                    target,
+                    self.scanner,
+                    self.db_manager,
+                    sample_limit=sample_limit,
+                    detection_config=self.config.get("detection"),
+                    **extra_kw,
+                )
+                # Phase 1: inspect connection info to collect coarse crypto/transport hints.
+                name = (target.get("name") or "").strip() or "database"
+                driver = (target.get("driver") or "").strip()
+                dsn = (target.get("dsn") or "").strip()
+                sslmode = (target.get("sslmode") or "").strip()
+                conn_info = {
+                    "type": "database",
+                    "name": name,
+                    "driver": driver,
+                    "dsn": dsn,
+                    "sslmode": sslmode,
+                }
+                signals = summarize_crypto_from_connection_info(conn_info)
+                if signals:
+                    self._crypto_signals.append((name, signals))
             connector.run()
         except Exception as e:
-            from core.validation import clean_error
-
             self.db_manager.save_failure(
                 target.get("name", "unknown"), "error", clean_error(e)
             )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,87 @@
+"""AuditEngine orchestration (connector resolution, instantiation, run)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.engine import AuditEngine
+
+
+def test_run_target_instantiation_error_records_save_failure_sequential(
+    tmp_path, monkeypatch
+) -> None:
+    """Sequential mode must not let __init__ exceptions escape without save_failure (#513)."""
+    config: dict[str, Any] = {
+        "targets": [
+            {
+                "name": "bad-target",
+                "type": "database",
+                "driver": "postgresql",
+            }
+        ],
+        "file_scan": {
+            "sample_limit": 5,
+            "extensions": [".txt"],
+        },
+        "detection": {},
+    }
+    eng = AuditEngine(config, db_path=str(tmp_path / "audit.db"))
+    recorded: list[tuple[str, str, str]] = []
+
+    def capture_save_failure(name: str, reason: str, detail: str) -> None:
+        recorded.append((name, reason, detail))
+
+    monkeypatch.setattr(eng.db_manager, "save_failure", capture_save_failure)
+
+    class BoomInit:
+        def __init__(self, *_a: object, **_k: object) -> None:
+            raise RuntimeError("connector init failed")
+
+        def run(self) -> None:
+            raise AssertionError("run should not be reached")
+
+    def fake_resolve(_target: dict[str, Any]) -> tuple[type, list[str]]:
+        return BoomInit, []
+
+    monkeypatch.setattr("core.engine.connector_for_target", fake_resolve)
+
+    eng._run_target(config["targets"][0])
+
+    assert len(recorded) == 1
+    assert recorded[0][0] == "bad-target"
+    assert recorded[0][1] == "error"
+    assert "init failed" in recorded[0][2]
+
+
+def test_run_target_run_error_still_records_save_failure(tmp_path, monkeypatch) -> None:
+    config: dict[str, Any] = {
+        "targets": [{"name": "run-fail", "type": "database", "driver": "postgresql"}],
+        "file_scan": {"sample_limit": 5, "extensions": [".txt"]},
+        "detection": {},
+    }
+    eng = AuditEngine(config, db_path=str(tmp_path / "audit2.db"))
+    recorded: list[tuple[str, str, str]] = []
+
+    monkeypatch.setattr(
+        eng.db_manager,
+        "save_failure",
+        lambda n, r, d: recorded.append((n, r, d)),
+    )
+
+    class RunFails:
+        def __init__(self, *_a: object, **_k: object) -> None:
+            pass
+
+        def run(self) -> None:
+            raise ValueError("run exploded")
+
+    monkeypatch.setattr(
+        "core.engine.connector_for_target",
+        lambda _t: (RunFails, []),
+    )
+
+    eng._run_target(config["targets"][0])
+
+    assert len(recorded) == 1
+    assert recorded[0][0] == "run-fail"
+    assert "exploded" in recorded[0][2]


### PR DESCRIPTION
Wraps connector construction, crypto-hints (database path), and \connector.run()\ in a single try/except so failures during instantiation are recorded via \save_failure\ (ADR-0049 sequential behaviour).

Uses \issubclass(connector_class, _CONNECTOR_SAMPLING_POLICY_BASES)\ for sampling policy instead of hard-coded SQL connector names (#507).

Closes #513.

Made with [Cursor](https://cursor.com)