### PR TITLE
fix(engine): ADR-0049 unknown connector + gitleaks allowlist + pyo3 bump

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,12 @@
+title = "data-boar gitleaks config"
+
+[allowlist]
+description = "Confirmed FP 2026-05-18 — synthetic test data and operator howto curl examples"
+paths = [
+  '''scripts/generate_synthetic_poc_corpus\.py''',
+  '''docs/ops/API_KEY_FROM_ENV_OPERATOR_STEPS\.md''',
+  '''docs/ops/API_KEY_FROM_ENV_OPERATOR_STEPS\.pt_BR\.md''',
+  '''docs/ops/SECURE_DASHBOARD_AUTH_AND_HTTPS_HOWTO\.md''',
+  '''docs/ops/SECURE_DASHBOARD_AUTH_AND_HTTPS_HOWTO\.pt_BR\.md''',
+  '''docs/OPERATOR_NOTIFICATION_CHANNELS\.md'''
+]

--- a/core/engine.py
+++ b/core/engine.py
@@ -272,10 +272,15 @@ class AuditEngine:
         """Run one target: resolve connector, instantiate, run()."""
         resolved = connector_for_target(target)
         if not resolved:
+            tname = target.get("name", "unknown")
+            ttype = target.get("type", "?")
             self.db_manager.save_failure(
-                target.get("name", "unknown"),
-                "error",
-                "Unsupported target type or driver",
+                tname,
+                "unknown_connector_type",
+                (
+                    f"No connector registered for type '{ttype}'. "
+                    "Check config.yaml — possible typo or missing optional dependency."
+                ),
             )
             return
         connector_class, _ = resolved

--- a/rust/boar_fast_filter/Cargo.lock
+++ b/rust/boar_fast_filter/Cargo.lock
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "unicode-ident"

--- a/rust/boar_fast_filter/Cargo.toml
+++ b/rust/boar_fast_filter/Cargo.toml
@@ -9,5 +9,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 #pyo3 = { version = "0.23", features = ["extension-module"] }
-pyo3 = { version = "0.23", features = ["extension-module", "abi3-py37"] }
+pyo3 = { version = "0.24.1", features = ["extension-module", "abi3-py38"] }
 regex = "1.10"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -85,3 +85,28 @@ def test_run_target_run_error_still_records_save_failure(tmp_path, monkeypatch) 
     assert len(recorded) == 1
     assert recorded[0][0] == "run-fail"
     assert "exploded" in recorded[0][2]
+
+
+def test_unknown_target_type_creates_failure(tmp_path, monkeypatch) -> None:
+    """Unknown target type must record scan_failures (ADR-0049, #416)."""
+    config: dict[str, Any] = {
+        "targets": [{"name": "snow", "type": "unknowntype_xyz"}],
+        "file_scan": {"sample_limit": 5, "extensions": [".txt"]},
+        "detection": {},
+    }
+    eng = AuditEngine(config, db_path=str(tmp_path / "audit3.db"))
+    recorded: list[tuple[str, str, str]] = []
+
+    monkeypatch.setattr(
+        eng.db_manager,
+        "save_failure",
+        lambda n, r, d: recorded.append((n, r, d)),
+    )
+    monkeypatch.setattr("core.engine.connector_for_target", lambda _t: None)
+
+    eng._run_target(config["targets"][0])
+
+    assert len(recorded) == 1
+    assert recorded[0][0] == "snow"
+    assert recorded[0][1] == "unknown_connector_type"
+    assert "unknowntype_xyz" in recorded[0][2]


### PR DESCRIPTION
## Summary
- **#416:** `save_failure` with `unknown_connector_type` and regression test in `tests/test_engine.py`.
- **#524:** repo-root `.gitleaks.toml` allowlist for confirmed FP paths (synthetic corpus + operator howto placeholders).
- **#525:** `pyo3` 0.24.1 + `abi3-py38` in `boar_fast_filter` (RUSTSEC-2025-0020 / Dependabot #31).

## Triage (no code)
- Closed **#396**, **#399** (content already correct on `main`).
- Applied **[P1]/[P2]/[P3]** title bands per **#523** (comment on meta-issue).

## Test plan
- [x] `pytest tests/test_engine.py tests/test_github_workflows.py`
- [ ] CI green (Rust + Gitleaks schedule on merge)

Closes #524, #525. #416 already closed with reference.