### PR TITLE
feat(licensing): tier fixtures and graceful feature_gate (#559)

### DIFF
--- a/core/licensing/feature_gate.py
+++ b/core/licensing/feature_gate.py
@@ -1,0 +1,65 @@
+"""
+Structured feature-tier checks (graceful deny paths for Pro/Enterprise gates).
+
+Use :func:`check_feature` before activating tier-gated product behaviour.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from core.licensing.tier_features import (
+    Tier,
+    get_required_tier,
+    is_feature_available,
+)
+
+_TIER_LABEL = {
+    Tier.COMMUNITY: "Community",
+    Tier.PRO: "Pro",
+    Tier.ENTERPRISE: "Enterprise",
+    Tier.OPEN: "Open",
+}
+
+
+@dataclass(frozen=True)
+class FeatureCheckResult:
+    """Outcome of a tier gate check — never raises for tier denial."""
+
+    allowed: bool
+    reason: str
+    feature: str
+    required_tier: str
+    current_tier: str
+
+
+def _tier_label(tier: Tier) -> str:
+    return _TIER_LABEL.get(tier, tier.value)
+
+
+def check_feature(feature: str, current_tier: Tier) -> FeatureCheckResult:
+    """
+    Return whether *feature* is allowed for *current_tier* with a human-readable reason.
+
+    OPEN tier bypasses restrictions (lab / enforcement off). Denials do not raise.
+    """
+    name = (feature or "").strip()
+    required = get_required_tier(name)
+    allowed = is_feature_available(name, current_tier)
+    if allowed:
+        reason = ""
+    elif current_tier == Tier.OPEN:
+        reason = ""
+    else:
+        reason = (
+            f"Feature '{name}' requires {_tier_label(required)} tier or higher; "
+            f"current tier is {_tier_label(current_tier)}. "
+            "Upgrade your subscription or set licensing.effective_tier in lab config."
+        )
+    return FeatureCheckResult(
+        allowed=allowed,
+        reason=reason,
+        feature=name,
+        required_tier=required.value,
+        current_tier=current_tier.value,
+    )

--- a/core/licensing/guard.py
+++ b/core/licensing/guard.py
@@ -12,7 +12,13 @@ from typing import Any
 
 import jwt
 
+from core.licensing.feature_gate import FeatureCheckResult, check_feature
 from core.licensing.fingerprint import compute_machine_fingerprint
+from core.licensing.runtime_feature_tier import (
+    get_runtime_tier_for_features,
+    map_dbtier_string_to_tier,
+)
+from core.licensing.tier_features import Tier
 from core.licensing.integrity import (
     check_build_digest_expected,
     verify_manifest_optional,
@@ -337,6 +343,22 @@ class LicenseGuard:
         if c.state in ("OPEN", "VALID", "GRACE") and c.trial and c.max_report_rows > 0:
             return c.max_report_rows
         return None
+
+    def product_tier_for_features(self) -> Tier:
+        """Resolve product tier for feature gates (YAML, JWT, dev override)."""
+        return get_runtime_tier_for_features(self._config)
+
+    def check_feature(self, feature: str) -> FeatureCheckResult:
+        """Structured tier gate — does not raise on denial."""
+        return check_feature(feature, self.product_tier_for_features())
+
+    def is_allowed(self, feature: str) -> bool:
+        return self.check_feature(feature).allowed
+
+    @staticmethod
+    def tier_from_dbtier_string(raw: str) -> Tier:
+        """Map a tier label (fixtures / tests) to :class:`Tier`."""
+        return map_dbtier_string_to_tier(raw)
 
 
 def _ts_iso(ts: float) -> str:

--- a/core/licensing/runtime_feature_tier.py
+++ b/core/licensing/runtime_feature_tier.py
@@ -6,9 +6,27 @@ Shared by API routes, RBAC, and maturity POC so tier logic stays in one place.
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from core.licensing.tier_features import Tier
+
+
+def is_dev_tier_override_env() -> bool:
+    """True when CI/dev may honor DATA_BOAR_TIER_OVERRIDE (never production builds)."""
+    env = os.environ.get("DATA_BOAR_ENV", "").strip().lower()
+    if env in ("development", "dev", "ci"):
+        return True
+    debug = os.environ.get("DEBUG", "").strip().lower()
+    return debug in ("1", "true", "yes")
+
+
+def tier_override_from_env() -> Tier | None:
+    """Optional lab/CI tier simulation via DATA_BOAR_TIER_OVERRIDE."""
+    raw = os.environ.get("DATA_BOAR_TIER_OVERRIDE", "").strip().lower()
+    if not raw or not is_dev_tier_override_env():
+        return None
+    return map_dbtier_string_to_tier(raw)
 
 
 def map_dbtier_string_to_tier(raw: str) -> Tier:
@@ -30,6 +48,10 @@ def get_runtime_tier_for_features(cfg: dict[str, Any]) -> Tier:
     Resolve tier for ``is_feature_available``: JWT ``dbtier`` when enforced and VALID/GRACE wins over
     ``licensing.effective_tier``; otherwise lab YAML; default OPEN (all features on).
     """
+    env_override = tier_override_from_env()
+    if env_override is not None:
+        return env_override
+
     dbtier_claim = ""
     try:
         from core.licensing.guard import get_license_guard

--- a/core/licensing/tier_features.py
+++ b/core/licensing/tier_features.py
@@ -63,6 +63,14 @@ FEATURE_TIER_MAP: dict[str, Tier] = {
     "connector_azure_blob": Tier.PRO,
     "connector_gcs": Tier.PRO,
     "scheduled_scans": Tier.PRO,
+    # Aliases / upcoming gates (see GitHub #558, #544, #552, #551)
+    "scan_scheduler_pro": Tier.PRO,
+    "scan_scheduler_ui_enterprise": Tier.ENTERPRISE,
+    "governance_lens_pro": Tier.PRO,
+    "governance_lens_enterprise": Tier.ENTERPRISE,
+    "findings_sink_sql": Tier.PRO,
+    "scan_max_workers_pro": Tier.PRO,
+    "scan_max_workers_enterprise": Tier.ENTERPRISE,
     "api_key_management_ui": Tier.PRO,
     "dashboard_rbac": Tier.PRO,
     # GRC-style org maturity questionnaire UI (POC); not open core — see PLAN_MATURITY_SELF_ASSESSMENT_GRC_QUESTIONNAIRE.md

--- a/docs/ops/today-mode/OPERATOR_TODAY_MODE_2026-05-19.md
+++ b/docs/ops/today-mode/OPERATOR_TODAY_MODE_2026-05-19.md
@@ -2,7 +2,9 @@
 
 **Português (Brasil):** [OPERATOR_TODAY_MODE_2026-05-19.pt_BR.md](OPERATOR_TODAY_MODE_2026-05-19.pt_BR.md)
 
-**Note:** Prepared end of **2026-05-18** — **Block 0** runs first.
+**Note:** Updated end of **2026-05-19** (operator TZ **-03**) after overnight agent pass — **Block 0** runs first.
+
+**`main` anchor:** CLI plan slices **#520–#522** merged (**#565** `--diff`, **#566** `--export-dsar`). Tier gate work **#559** may be open as PR — confirm with `gh pr list`.
 
 ---
 
@@ -11,9 +13,9 @@
 Run **`carryover-sweep`** or **`.\scripts\operator-day-ritual.ps1 -Mode Morning`**. Then:
 
 1. **`origin/main`:** `git fetch` · `git status -sb` · `git pull origin main` when behind — confirm **`ci.yml`** green on **`main`** before deep work.
-2. **Open PRs:** `gh pr list --state open` — merge when green per **`.\scripts\pr-merge-when-green.ps1`** where safe.
-3. **Plans PMO:** Read **`docs/plans/PLANS_TODO.md`** intro + **[PLANS_DOCUMENTATION_HIERARCHY.md](../PLANS_DOCUMENTATION_HIERARCHY.md)** if you are promoting issue work into **`PLAN_*.md`** (then **`plans_hub_sync.py --write`**).
-4. **Carry thread / handoff:** If continuing a **GitHub issue** with another assistant or reviewer, **decisions** in the issue; **persist** outcomes in **`docs/plans/`** per the hierarchy doc.
+2. **Open PRs:** `gh pr list --state open` — merge when green per **`.\scripts\pr-merge-when-green.ps1`** where safe (e.g. licensing tier gates **#559**).
+3. **Plans PMO:** Read **`docs/plans/PLANS_TODO.md`** intro + **[PLANS_DOCUMENTATION_HIERARCHY.md](../PLANS_DOCUMENTATION_HIERARCHY.md)** when promoting issue work into **`PLAN_*.md`** (then **`plans_hub_sync.py --write`**).
+4. **Carry thread / handoff:** Decisions on the GitHub issue; persist outcomes in **`docs/plans/`** per hierarchy doc.
 
 **Rolling queue:** [CARRYOVER.md](CARRYOVER.md) · **Published:** [PUBLISHED_SYNC.md](PUBLISHED_SYNC.md)
 
@@ -23,13 +25,24 @@ Run **`carryover-sweep`** or **`.\scripts\operator-day-ritual.ps1 -Mode Morning`
 
 ---
 
+## Suggested focus (P1 thin slices)
+
+| Priority | Item | Notes |
+| -------- | ---- | ----- |
+| **P1** | [#559](https://github.com/FabioLeitao/data-boar/issues/559) tier fixtures + graceful denial | Merge PR if green; then enable enforcement follow-ups. |
+| **P1** | [#544](https://github.com/FabioLeitao/data-boar/issues/544) `governance_lens` in runtime map | Keys may already exist after **#559** — wire API/CLI gate next. |
+| **P1** | [#512](https://github.com/FabioLeitao/data-boar/issues/512) process batch | Promote durable rows into **`docs/plans/`**; close echo issues with evidence. |
+| **H1** | CLI plan **complete** | [PLAN_CLI_VALIDATE_DIFF_AND_DSAR_EXPORT.md](../../plans/PLAN_CLI_VALIDATE_DIFF_AND_DSAR_EXPORT.md) — next theme from **PLANS_TODO** (licensing / governance docs **#556+**). |
+
+---
+
 ## Carryover — spine
 
 | Track | Item | Notes |
 | ----- | ---- | ----- |
 | Pilot gate | **M-PILOT-READY** | Release / Maestro / pilot criteria in **PLANS_TODO**; **v1.7.4** when checklist green. |
-| Plans ops | **Hierarchy doc + new `PLAN_*.md` slices** | Commit/push **`docs/ops/PLANS_DOCUMENTATION_HIERARCHY*.md`** + README/cold-start links when ready; align issue threads to committed plans. |
-| Governance | Open **P0/P1** triage | [#512](https://github.com/FabioLeitao/data-boar/issues/512) process plan; promote durable work into **`docs/plans/`**. |
+| Plans ops | **Hierarchy doc + new `PLAN_*.md` slices** | Commit/push **`docs/ops/PLANS_DOCUMENTATION_HIERARCHY*.md`** when ready. |
+| Governance | Open **P0/P1** triage | **#512**; **#550** closed (pwsh timeout duplicate of **#563**). |
 
 ---
 

--- a/docs/ops/today-mode/OPERATOR_TODAY_MODE_2026-05-19.pt_BR.md
+++ b/docs/ops/today-mode/OPERATOR_TODAY_MODE_2026-05-19.pt_BR.md
@@ -2,7 +2,9 @@
 
 **English:** [OPERATOR_TODAY_MODE_2026-05-19.md](OPERATOR_TODAY_MODE_2026-05-19.md)
 
-**Nota:** Preparado no fecho da noite **2026-05-18** — o **Bloco 0** manda na abertura do dia.
+**Nota:** Atualizado no fim da noite **2026-05-19** (fuso do operador **-03**) após passagem noturna do agente — o **Bloco 0** manda na abertura do dia.
+
+**Âncora `main`:** Fatias CLI **#520–#522** mergeadas (**#565** `--diff`, **#566** `--export-dsar`). Trabalho de tier **#559** pode estar em PR aberto — confirma com `gh pr list`.
 
 ---
 
@@ -11,9 +13,9 @@
 Corre **`carryover-sweep`** ou **`.\scripts\operator-day-ritual.ps1 -Mode Morning`**. Depois:
 
 1. **`origin/main`:** `git fetch` · `git status -sb` · `git pull origin main` se estiver atrás — confirma **`ci.yml`** verde no **`main`** antes de trabalho profundo.
-2. **PRs abertos:** `gh pr list --state open` — faz merge quando verde com **`.\scripts\pr-merge-when-green.ps1`** onde for seguro.
+2. **PRs abertos:** `gh pr list --state open` — faz merge quando verde com **`.\scripts\pr-merge-when-green.ps1`** onde for seguro (ex.: tier licensing **#559**).
 3. **PMO de planos:** Lê a intro de **`docs/plans/PLANS_TODO.md`** + **[PLANS_DOCUMENTATION_HIERARCHY.pt_BR.md](../PLANS_DOCUMENTATION_HIERARCHY.pt_BR.md)** se fores promover trabalho de **issue** para **`PLAN_*.md`** (depois **`plans_hub_sync.py --write`**).
-4. **Handoff em issue:** Se continuares uma **issue** do GitHub com outro assistente ou revisor, **decisões** na thread; **persiste** o resultado em **`docs/plans/`** conforme o doc de hierarquia.
+4. **Handoff em issue:** Decisões na thread da issue; **persiste** o resultado em **`docs/plans/`** conforme o doc de hierarquia.
 
 **Fila contínua:** [CARRYOVER.md](CARRYOVER.md) · **Publicado:** [PUBLISHED_SYNC.md](PUBLISHED_SYNC.md)
 
@@ -23,13 +25,24 @@ Corre **`carryover-sweep`** ou **`.\scripts\operator-day-ritual.ps1 -Mode Mornin
 
 ---
 
+## Foco sugerido (fatias finas P1)
+
+| Prioridade | Item | Notas |
+| ---------- | ---- | ----- |
+| **P1** | [#559](https://github.com/FabioLeitao/data-boar/issues/559) fixtures + negação graciosa | Merge do PR se verde; depois enforcement real. |
+| **P1** | [#544](https://github.com/FabioLeitao/data-boar/issues/544) `governance_lens` no mapa | Chaves podem existir após **#559** — ligar gate API/CLI em seguida. |
+| **P1** | [#512](https://github.com/FabioLeitao/data-boar/issues/512) lote de processo | Promove para **`docs/plans/`**; fecha ecos com evidência. |
+| **H1** | Plano CLI **completo** | [PLAN_CLI_VALIDATE_DIFF_AND_DSAR_EXPORT.md](../../plans/PLAN_CLI_VALIDATE_DIFF_AND_DSAR_EXPORT.md) — próximo tema no **PLANS_TODO** (docs governança **#556+**). |
+
+---
+
 ## Carryover — espinha
 
 | Trilho | Item | Notas |
 | ------ | ---- | ----- |
 | Piloto | **M-PILOT-READY** | Critérios no **PLANS_TODO**; **v1.7.4** quando checklist verde. |
-| Ops de planos | **Doc de hierarquia + fatias `PLAN_*.md`** | Commit/push **`docs/ops/PLANS_DOCUMENTATION_HIERARCHY*.md`** + links no README/cold-start quando pronto; alinha issues a planos commitados. |
-| Governança | Triagem **P0/P1** aberta | [#512](https://github.com/FabioLeitao/data-boar/issues/512) plano de processo; promove trabalho durável para **`docs/plans/`**. |
+| Ops de planos | **Doc de hierarquia + fatias `PLAN_*.md`** | Commit/push **`docs/ops/PLANS_DOCUMENTATION_HIERARCHY*.md`** quando pronto. |
+| Governança | Triagem **P0/P1** aberta | **#512**; **#550** fechada (duplicata do timeout pwsh **#563**). |
 
 ---
 

--- a/tests/test_licensing_tier_gates.py
+++ b/tests/test_licensing_tier_gates.py
@@ -1,0 +1,114 @@
+"""Tier licensing fixtures and graceful feature denial (#559)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from core.licensing.guard import LicenseGuard, reset_license_guard_for_tests
+from core.licensing.runtime_feature_tier import (
+    get_runtime_tier_for_features,
+    tier_override_from_env,
+)
+from core.licensing.tier_features import Tier
+
+
+def _guard_for_effective_tier(tier: str) -> LicenseGuard:
+    reset_license_guard_for_tests()
+    return LicenseGuard({"licensing": {"mode": "open", "effective_tier": tier}})
+
+
+@pytest.fixture
+def community_guard():
+    return _guard_for_effective_tier("community")
+
+
+@pytest.fixture
+def pro_guard():
+    return _guard_for_effective_tier("pro")
+
+
+@pytest.fixture
+def enterprise_guard():
+    return _guard_for_effective_tier("enterprise")
+
+
+@pytest.fixture(autouse=True)
+def _clean_license_env():
+    reset_license_guard_for_tests()
+    keys = (
+        "DATA_BOAR_TIER_OVERRIDE",
+        "DATA_BOAR_ENV",
+        "DEBUG",
+        "DATA_BOAR_LICENSE_MODE",
+    )
+    saved = {k: os.environ.get(k) for k in keys}
+    yield
+    reset_license_guard_for_tests()
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+def test_scheduler_allowed_pro(pro_guard):
+    assert pro_guard.is_allowed("scan_scheduler_pro")
+
+
+def test_scheduler_allowed_enterprise(enterprise_guard):
+    assert enterprise_guard.is_allowed("scan_scheduler_pro")
+
+
+def test_governance_lens_allowed_pro(pro_guard):
+    assert pro_guard.is_allowed("governance_lens_pro")
+
+
+def test_governance_lens_enterprise_allowed(enterprise_guard):
+    assert enterprise_guard.is_allowed("governance_lens_enterprise")
+
+
+def test_scheduler_denied_community(community_guard):
+    result = community_guard.check_feature("scan_scheduler_pro")
+    assert not result.allowed
+    assert result.reason
+    assert "Pro" in result.reason or "upgrade" in result.reason.lower()
+
+
+def test_governance_lens_denied_community(community_guard):
+    result = community_guard.check_feature("governance_lens_pro")
+    assert not result.allowed
+    assert result.reason
+
+
+def test_governance_lens_enterprise_denied_pro(pro_guard):
+    result = pro_guard.check_feature("governance_lens_enterprise")
+    assert not result.allowed
+
+
+def test_findings_sink_sql_denied_community(community_guard):
+    result = community_guard.check_feature("findings_sink_sql")
+    assert not result.allowed
+
+
+def test_scan_max_workers_enterprise_denied_pro(pro_guard):
+    result = pro_guard.check_feature("scan_max_workers_enterprise")
+    assert not result.allowed
+
+
+def test_tier_override_env_requires_dev_env(monkeypatch):
+    monkeypatch.setenv("DATA_BOAR_TIER_OVERRIDE", "pro")
+    monkeypatch.delenv("DATA_BOAR_ENV", raising=False)
+    monkeypatch.delenv("DEBUG", raising=False)
+    assert tier_override_from_env() is None
+
+
+def test_tier_override_env_honored_in_dev(monkeypatch):
+    monkeypatch.setenv("DATA_BOAR_TIER_OVERRIDE", "community")
+    monkeypatch.setenv("DATA_BOAR_ENV", "development")
+    reset_license_guard_for_tests()
+    cfg = {"licensing": {"mode": "open", "effective_tier": "pro"}}
+    assert get_runtime_tier_for_features(cfg) == Tier.COMMUNITY
+    g = LicenseGuard(cfg)
+    assert not g.is_allowed("governance_lens_pro")

--- a/tests/test_tier_features_open_core_subscription.py
+++ b/tests/test_tier_features_open_core_subscription.py
@@ -92,3 +92,14 @@ def test_runtime_tier_from_yaml_effective_tier():
         "api": {},
     }
     assert get_runtime_tier_for_features(cfg) == Tier.PRO
+
+
+def test_runtime_tier_env_override_wins_in_dev(monkeypatch):
+    monkeypatch.setenv("DATA_BOAR_TIER_OVERRIDE", "enterprise")
+    monkeypatch.setenv("DATA_BOAR_ENV", "ci")
+    reset_license_guard_for_tests()
+    cfg: dict = {
+        "licensing": {"mode": "open", "effective_tier": "community"},
+        "api": {},
+    }
+    assert get_runtime_tier_for_features(cfg) == Tier.ENTERPRISE


### PR DESCRIPTION
## Summary
- core/licensing/feature_gate.py + LicenseGuard.check_feature / is_allowed
- FEATURE_TIER_MAP aliases (governance_lens, scan_scheduler, findings_sink, max_workers)
- DATA_BOAR_TIER_OVERRIDE when DATA_BOAR_ENV=development|ci or DEBUG=1
- tests/test_licensing_tier_gates.py
- today-mode 2026-05-19 morning handoff

## Follow-ups (separate PRs)
- HTTP 402 on API tier denial
- Remove OPEN stub enforcement in tier_features when legal signs off

Closes #559

Made with [Cursor](https://cursor.com)