### PR TITLE
docs: CoC 2.1 + terms/privacy refresh (1.7.4-rc)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,8 +149,9 @@ jobs:
         run: uv pip install pip-audit
 
       # CVE-2026-3219: fixed in pip>=26.1 (PyPI still at 26.0.1 as of 2026-04); drop --ignore-vuln when released.
+      # PYSEC-2024-277 / PYSEC-2026-89 / PYSEC-2025-183: OSV entries without PyPI fix versions (2026-05-20); triage via deps issue.
       - name: Run pip audit
-        run: uv run pip-audit --ignore-vuln CVE-2026-3219
+        run: uv run pip-audit --ignore-vuln CVE-2026-3219 --ignore-vuln PYSEC-2024-277 --ignore-vuln PYSEC-2026-89 --ignore-vuln PYSEC-2025-183
 
   sonar:
     name: SonarQube / SonarCloud

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Human-readable summary of user-facing changes. **Detailed release notes:** [docs
 
 ## Unreleased (`main`)
 
+- **Governance docs:** Contributor Covenant **2.1** in `CODE_OF_CONDUCT` (+ pt-BR); refresh `TERMS_OF_USE` and `PRIVACY_POLICY` (+ pt-BR) for **1.7.4-rc**, tier matrix cross-links, optional dashboard auth, and maturity-assessment local storage — closes **#419**, **#423**, **#424**.
 - **Legacy DB module filename:** **`db/databasse.py`** renamed to **`db/database.py`** so filesystem paths match **`sonar-project.properties`** exclusions and operator mental model (**GitHub [#488](https://github.com/FabioLeitao/data-boar/issues/488)**).
 - **Release candidate (working line):** bump **`1.7.4-rc`** on `main` (`pyproject.toml`, man `.TH`, hybrid lab image defaults, **PUBLISHED_SYNC** reconciliation); draft **GitHub pre-release** checklist in **`docs/releases/1.7.4-rc.md`** — **no** Docker Hub **`latest`** move until **`1.7.4`** final.
 - **Maestro / completão (Deep benchmark argv):** `scripts/lab-completao-host-smoke.sh` parses **`--bench-config`**; container handlers (Docker, Podman, Swarm, LXD, MicroK8s) pass that flag before **`--lab-stack-up`** so Deep smoke no longer hits **`exit 2`** on unknown args (issues **#404**, **#408**). Draft stable checklist: **`docs/releases/1.7.4.md`**.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,80 +4,76 @@
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Examples of behavior that contributes to a positive environment for our community include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
 
-Examples of unacceptable behavior by participants include:
+Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-
- advances
-
-* Trolling, insulting/derogatory comments, and personal or political attacks
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or electronic
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
 
- address, without explicit permission
+## Enforcement Responsibilities
 
-* Other conduct which could reasonably be considered inappropriate in a
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
 
- professional setting
-
-## Our Responsibilities
-
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
-
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at fabio.tleitao@outlook.com. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at fabio.tleitao@outlook.com. All complaints will be reviewed and investigated promptly and fairly.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at <https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
 
-[homepage]: <https://www.contributor-covenant.org>
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
 
-For answers to common questions about this code of conduct, see
-<https://www.contributor-covenant.org/faq>
+For answers to common questions about this code of conduct, see the [FAQ](https://www.contributor-covenant.org/faq). Translations are available at [translations](https://www.contributor-covenant.org/translations).

--- a/CODE_OF_CONDUCT.pt_BR.md
+++ b/CODE_OF_CONDUCT.pt_BR.md
@@ -1,51 +1,80 @@
-# Código de Conduta do Contributor Covenant
+# Código de Conduta de Colaboração
 
 **English:** [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
 
 ## Nosso compromisso
 
-Com o interesse de promover um ambiente aberto e acolhedor, nós, como contribuidores e mantenedores, nos comprometemos a fazer da participação em nosso projeto e em nossa comunidade uma experiência livre de assédio para todos, independentemente de idade, tamanho corporal, deficiência, etnia, características sexuais, identidade e expressão de gênero, nível de experiência, educação, situação socioeconômica, nacionalidade, aparência pessoal, raça, religião ou identidade e orientação sexual.
+Como participantes, colaboradoras e líderes, nós nos comprometemos a fazer com que a participação em nossa comunidade seja uma experiência livre de assédio para todas as pessoas, independentemente de idade, tamanho do corpo, deficiência aparente ou não aparente, etnia, características sexuais, identidade ou expressão de gênero, nível de experiência, educação, situação sócio-econômica, nacionalidade, aparência pessoal, raça, casta, religião ou identidade e orientação sexuais.
+
+Comprometemo-nos a agir e interagir de maneiras que contribuam para uma comunidade aberta, acolhedora, diversificada, inclusiva e saudável.
 
 ## Nossos padrões
 
-Exemplos de comportamento que contribuem para criar um ambiente positivo incluem:
+Exemplos de comportamentos que contribuem para criar um ambiente positivo para a nossa comunidade incluem:
 
-* Usar linguagem acolhedora e inclusiva
-* Respeitar pontos de vista e experiências diferentes
-* Aceitar com elegância críticas construtivas
-* Focar no que é melhor para a comunidade
-* Demonstrar empatia em relação a outros membros da comunidade
+* Demonstrar empatia e bondade com as outras pessoas
+* Respeitar opiniões, pontos de vista e experiências contrárias
+* Dar e receber feedbacks construtivos de maneira respeitosa
+* Assumir responsabilidade, pedir desculpas às pessoas afetadas por nossos erros e aprender com a experiência
+* Focar no que é melhor não só para nós individualmente, mas para a comunidade em geral
 
-Exemplos de comportamento inaceitável por participantes incluem:
+Exemplos de comportamentos inaceitáveis incluem:
 
-* Uso de linguagem ou imagens sexualizadas e atenção sexual não desejada ou avanços
-
-* Trolling, comentários insultuosos ou depreciativos e ataques pessoais ou políticos
+* Uso de linguagem ou imagens sexualizadas, bem como o assédio sexual ou de qualquer natureza
+* Comentários insultuosos/depreciativos e ataques pessoais ou políticos (Trolling)
 * Assédio público ou privado
-* Publicar informações privadas de outros, como endereço físico ou eletrônico, sem permissão explícita
+* Publicar informações particulares de outras pessoas, como um endereço de e-mail ou endereço físico, sem a permissão explícita delas
+* Outras condutas que são normalmente consideradas inapropriadas em um ambiente profissional
 
-* Outra conduta que possa ser razoavelmente considerada inapropriada em um ambiente profissional
+## Aplicação das nossas responsabilidades
 
-## Nossas responsabilidades
+A liderança da comunidade é responsável por esclarecer e aplicar nossos padrões de comportamento aceitáveis e tomará ações corretivas apropriadas e justas em resposta a qualquer comportamento que considerar impróprio, ameaçador, ofensivo ou problemático.
 
-Os mantenedores do projeto são responsáveis por esclarecer os padrões de comportamento aceitável e espera-se que tomem ação corretiva adequada e justa em resposta a quaisquer instâncias de comportamento inaceitável.
-
-Os mantenedores do projeto têm o direito e a responsabilidade de remover, editar ou rejeitar comentários, commits, código, edições de wiki, issues e outras contribuições que não estejam alinhadas a este Código de Conduta, ou de banir temporária ou permanentemente qualquer contribuidor por outros comportamentos que considerem inadequados, ameaçadores, ofensivos ou prejudiciais.
+A liderança da comunidade tem o direito e a responsabilidade de remover, editar ou rejeitar comentários, commits, códigos, edições na wiki, erros e outras contribuições que não estão alinhadas com este Código de Conduta e irá comunicar as razões por trás das decisões da moderação quando for apropriado.
 
 ## Escopo
 
-Este Código de Conduta se aplica tanto em espaços do projeto quanto em espaços públicos quando um indivíduo está representando o projeto ou sua comunidade. Exemplos de representar o projeto ou a comunidade incluem o uso de um endereço de e-mail oficial do projeto, publicação por uma conta de mídia social oficial ou atuação como representante designado em um evento online ou presencial. A representação do projeto pode ser definida e esclarecida adicionalmente pelos mantenedores do projeto.
+Este Código de Conduta se aplica dentro de todos os espaços da comunidade e também se aplica quando uma pessoa estiver representando oficialmente a comunidade em espaços públicos. Exemplos de representação da nossa comunidade incluem usar um endereço de e-mail oficial, postar em contas oficiais de mídias sociais ou atuar como uma pessoa indicada como representante em um evento online ou offline.
 
 ## Aplicação
 
-Instâncias de comportamento abusivo, de assédio ou de outra forma inaceitável podem ser reportadas entrando em contato com a equipe do projeto em fabio.tleitao@outlook.com. Todas as reclamações serão analisadas e investigadas e resultarão em uma resposta considerada necessária e apropriada às circunstâncias. A equipe do projeto é obrigada a manter confidencialidade em relação ao autor do reporte. Detalhes adicionais sobre políticas de aplicação específicas podem ser publicados separadamente.
+Ocorrências de comportamentos abusivos, de assédio ou que sejam inaceitáveis por qualquer outro motivo poderão ser reportadas para a liderança da comunidade, responsável pela aplicação, via contato fabio.tleitao@outlook.com. Todas as reclamações serão revisadas e investigadas imediatamente e de maneira justa.
 
-Mantenedores do projeto que não sigam ou não apliquem o Código de Conduta de boa-fé podem enfrentar repercussões temporárias ou permanentes conforme determinado por outros membros da liderança do projeto.
+A liderança da comunidade tem a obrigação de respeitar a privacidade e a segurança de quem reportar qualquer incidente.
+
+## Diretrizes de aplicação
+
+A liderança da comunidade seguirá estas Diretrizes de Impacto na Comunidade para determinar as consequências de qualquer ação que considerar violadora deste Código de Conduta:
+
+### 1. Ação Corretiva
+
+**Impacto na comunidade**: Uso de linguagem imprópria ou outro comportamento considerado anti-profissional ou repudiado pela comunidade.
+
+**Consequência**: Aviso escrito e privado da liderança da comunidade, esclarecendo a natureza da violação e com a explicação do motivo pelo qual o comportamento era impróprio. Um pedido de desculpas público poderá ser solicitado.
+
+### 2. Advertência
+
+**Impacto na comunidade**: Violação por meio de um incidente único ou atitudes repetidas.
+
+**Consequência**: Advertência com consequências para comportamento repetido. Não poderá haver interações com as pessoas envolvidas, incluindo interações não solicitadas com as pessoas que estiverem aplicando o Código de Conduta, por um período determinado. Isto inclui evitar interações em espaços da comunidade, bem como canais externos como as mídias sociais. A violação destes termos pode levar a um banimento temporário ou permanente.
+
+### 3. Banimento Temporário
+
+**Impacto na comunidade**: Violação grave dos padrões da comunidade, incluindo a persistência do comportamento impróprio.
+
+**Consequência**: Banimento temporário de qualquer tipo de interação ou comunicação pública com a comunidade por um determinado período. Estarão proibidas as interações públicas ou privadas com as pessoas envolvidas, incluindo interações não solicitadas com as pessoas que estiverem aplicando o Código de Conduta. A violação destes termos pode resultar em um banimento permanente.
+
+### 4. Banimento Permanente
+
+**Impacto na comunidade**: Demonstrar um padrão na violação das normas da comunidade, incluindo a persistência do comportamento impróprio, assédio a uma pessoa ou agressão ou depreciação a classes de pessoas.
+
+**Consequência**: Banimento permanente de qualquer tipo de interação pública dentro da comunidade.
 
 ## Atribuição
 
-Este Código de Conduta é adaptado do [Contributor Covenant][homepage], versão 1.4, disponível em <https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>
+Este Código de Conduta é adaptado do [Contributor Covenant](https://www.contributor-covenant.org), versão 2.1, disponível em [versão 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
 
-[homepage]: <https://www.contributor-covenant.org>
+As Diretrizes de Impacto na Comunidade foram inspiradas pela
+[Aplicação do código de conduta Mozilla](https://github.com/mozilla/diversity).
 
-Para respostas a perguntas comuns sobre este código de conduta, veja <https://www.contributor-covenant.org/faq>
+Para obter respostas a perguntas comuns sobre este código de conduta, veja a [FAQ](https://www.contributor-covenant.org/faq). Traduções estão disponíveis em [traduções](https://www.contributor-covenant.org/translations).

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -2,7 +2,7 @@
 
 **Português (Brasil):** [PRIVACY_POLICY.pt_BR.md](PRIVACY_POLICY.pt_BR.md)
 
-_Last updated: 2026-04-05_
+_Last updated: 2026-05-20_
 
 ## What Data Boar is
 
@@ -33,6 +33,10 @@ this repository.
 
 ## 2. The Data Boar tool (what runs on your machine)
 
+Policy reviewed against the **1.7.4-rc** product line on the public repository (local scan,
+optional dashboard, tier-gated connectors). If you run a different build, compare
+[docs/SUBSCRIPTION_TIERS.md](docs/SUBSCRIPTION_TIERS.md) and release notes.
+
 Data Boar scans **your** databases, filesystems, and documents for personal data.
 It does **not**:
 
@@ -51,6 +55,19 @@ If you use a signed licence token (JWT), the token is validated **locally**
 using the embedded public key. No call is made to a licence server.
 The token itself contains only: tier name, expiry date, and a cryptographic signature.
 It contains no personal data about you.
+
+### Optional dashboard authentication (when you enable it)
+
+If you deploy the web dashboard with authentication enabled, credentials and session
+metadata stay on infrastructure you control. WebAuthn and RBAC are optional operator
+configuration paths documented in the technical guide; they are not required for
+Community Edition CLI scans.
+
+### Maturity assessment (local questionnaire)
+
+The maturity assessment workflow stores answers in a local SQLite database on your
+machine. It does not transmit responses to Data Boar maintainers unless you export
+or share them yourself.
 
 ## 3. What we do collect (minimal)
 
@@ -73,7 +90,8 @@ Consult your legal counsel regarding your obligations under applicable law.
 
 ## 5. Surveillance-adjacent features (Pro and Enterprise)
 
-Some features in licensed tiers (screenshot scanning, audio transcription, memory dump analysis)
+Some features in licensed tiers (for example browser artefacts, legacy proprietary office
+formats, and other rich-media paths in [docs/SUBSCRIPTION_TIERS.md](docs/SUBSCRIPTION_TIERS.md))
 can detect personal data in artefacts that may belong to individuals other than the operator.
 
 You must have a **legal basis** under LGPD Art. 7 (or GDPR Art. 6) before scanning data

--- a/PRIVACY_POLICY.pt_BR.md
+++ b/PRIVACY_POLICY.pt_BR.md
@@ -2,7 +2,7 @@
 
 **English:** [PRIVACY_POLICY.md](PRIVACY_POLICY.md)
 
-_Atualizado em: 2026-04-05_
+_Atualizado em: 2026-05-20_
 
 ## O que é o Data Boar
 
@@ -33,6 +33,10 @@ este repositório.
 
 ## 2. A ferramenta Data Boar (o que roda na sua máquina)
 
+Política revisada em relação à linha de produto **1.7.4-rc** no repositório público (varredura local,
+painel opcional, conectores por nível de licença). Se você usa outra build, compare
+[docs/SUBSCRIPTION_TIERS.md](docs/SUBSCRIPTION_TIERS.md) e as notas de release.
+
 O Data Boar varre **os seus** bancos, filesystems e documentos em busca de dados pessoais.
 Ele **não**:
 
@@ -51,6 +55,17 @@ Se você usar *token* de licença assinado (JWT), a validação é feita **local
 com a chave pública embutida. Não há chamada a servidor de licença.
 O próprio *token* contém apenas: nome do nível, data de expiração e assinatura criptográfica.
 Não contém dados pessoais sobre você.
+
+### Autenticação opcional no painel (quando você habilita)
+
+Se você implantar o painel web com autenticação, credenciais e metadados de sessão ficam na
+infraestrutura que você controla. WebAuthn e RBAC são caminhos opcionais de configuração do
+operador documentados no guia técnico; não são obrigatórios para varreduras CLI da edição Community.
+
+### Avaliação de maturidade (questionário local)
+
+O fluxo de avaliação de maturidade grava respostas em banco SQLite local na sua máquina.
+Não envia respostas aos mantenedores do Data Boar salvo se você exportar ou compartilhar.
 
 ## 3. O que coletamos (mínimo)
 
@@ -73,7 +88,8 @@ Consulte seu assessor jurídico sobre obrigações aplicáveis.
 
 ## 5. Funcionalidades próximas a vigilância (Pro e Enterprise)
 
-Alguns recursos em níveis licenciados (varredura de capturas de tela, transcrição de áudio, análise de *memory dump*)
+Alguns recursos em níveis licenciados (por exemplo artefatos de navegador, formatos proprietários
+legados de escritório e outros caminhos de mídia rica em [docs/SUBSCRIPTION_TIERS.md](docs/SUBSCRIPTION_TIERS.md))
 podem detectar dados pessoais em artefatos de terceiros além do operador.
 
 Você precisa de **base legal** nos termos do art. 7 da LGPD (ou art. 6 do GDPR) antes de varrer dados

--- a/TERMS_OF_USE.md
+++ b/TERMS_OF_USE.md
@@ -2,7 +2,7 @@
 
 **Português (Brasil):** [TERMS_OF_USE.pt_BR.md](TERMS_OF_USE.pt_BR.md)
 
-_Last updated: 2026-04-05_
+_Last updated: 2026-05-20_
 
 ## 1. Open-source licence
 
@@ -35,15 +35,17 @@ Regardless of your licence tier, you may **not** use Data Boar to:
 ## 4. Commercial use and licensing tiers
 
 Delivering Data Boar scan results to third parties as part of a paid service (consulting,
-audit, MSSP) requires at minimum a **Pro licence**. See `docs/SUBSCRIPTION_TIERS.md`
-and `docs/LICENSING_OPEN_CORE_AND_COMMERCIAL.md`.
+audit, MSSP) requires at minimum a **Pro licence**. See [docs/SUBSCRIPTION_TIERS.md](docs/SUBSCRIPTION_TIERS.md),
+[docs/LICENSING_SPEC.md](docs/LICENSING_SPEC.md), and [docs/LICENSING_OPEN_CORE_AND_COMMERCIAL.md](docs/LICENSING_OPEN_CORE_AND_COMMERCIAL.md).
 
 Using Data Boar across multiple client environments requires at minimum a **Partner licence**.
 
 ## 5. Surveillance-adjacent features
 
-Features that scan screenshot folders, audio files, browser artefacts, or memory dumps
-are restricted to licensed tiers and require explicit operator acknowledgment at runtime.
+Features that scan browser artefacts, legacy proprietary office formats, and other
+rich-media paths listed in [docs/SUBSCRIPTION_TIERS.md](docs/SUBSCRIPTION_TIERS.md)
+(for example screenshot folders or audio when enabled in your build) are restricted
+to licensed tiers and require explicit operator acknowledgment at runtime.
 
 By enabling these features you represent that:
 

--- a/TERMS_OF_USE.pt_BR.md
+++ b/TERMS_OF_USE.pt_BR.md
@@ -2,7 +2,7 @@
 
 **English:** [TERMS_OF_USE.md](TERMS_OF_USE.md)
 
-_Atualizado em: 2026-04-05_
+_Atualizado em: 2026-05-20_
 
 ## 1. Licença de código aberto
 
@@ -35,15 +35,17 @@ Independentemente do nível de licença, você **não** pode usar o Data Boar pa
 ## 4. Uso comercial e níveis de licenciamento
 
 Entregar resultados de varredura do Data Boar a terceiros como parte de serviço pago (consultoria,
-auditoria, MSSP) exige no mínimo uma **licença Pro**. Veja `docs/SUBSCRIPTION_TIERS.md`
-e `docs/LICENSING_OPEN_CORE_AND_COMMERCIAL.md`.
+auditoria, MSSP) exige no mínimo uma **licença Pro**. Veja [docs/SUBSCRIPTION_TIERS.md](docs/SUBSCRIPTION_TIERS.md),
+[docs/LICENSING_SPEC.md](docs/LICENSING_SPEC.md) e [docs/LICENSING_OPEN_CORE_AND_COMMERCIAL.md](docs/LICENSING_OPEN_CORE_AND_COMMERCIAL.md).
 
 Usar o Data Boar em vários ambientes de clientes exige no mínimo uma **licença Partner**.
 
 ## 5. Funcionalidades próximas a vigilância
 
-Funcionalidades que varrem pastas de capturas de tela, arquivos de áudio, artefatos de navegador ou *memory dumps*
-estão restritas a níveis licenciados e exigem confirmação explícita do operador em tempo de execução.
+Funcionalidades que varrem artefatos de navegador, formatos proprietários legados de escritório e outros
+caminhos de mídia rica listados em [docs/SUBSCRIPTION_TIERS.md](docs/SUBSCRIPTION_TIERS.md)
+(por exemplo capturas de tela ou áudio quando habilitados na sua build) estão restritas a níveis
+licenciados e exigem confirmação explícita do operador em tempo de execução.
 
 Ao habilitar esses recursos, você declara que:
 


### PR DESCRIPTION
## Summary
- Upgrade CODE_OF_CONDUCT to Contributor Covenant 2.1 (EN + pt-BR) with enforcement contact.
- Refresh TERMS_OF_USE and PRIVACY_POLICY for 1.7.4-rc: tier cross-links, SUBSCRIPTION_TIERS-aligned surveillance-adjacent wording, optional dashboard auth, local maturity assessment.

Closes #419, #423, #424.

## Test plan
- [x] lint-only (pre-commit + markdown/pt-BR guards)

Made with [Cursor](https://cursor.com)