### PR TITLE
docs(conduct): databoar.com.br aliases for CoC and compliance contact

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -38,7 +38,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at fabio.tleitao@outlook.com. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [conduct@databoar.com.br](mailto:conduct@databoar.com.br). All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CODE_OF_CONDUCT.pt_BR.md
+++ b/CODE_OF_CONDUCT.pt_BR.md
@@ -38,7 +38,7 @@ Este Código de Conduta se aplica dentro de todos os espaços da comunidade e ta
 
 ## Aplicação
 
-Ocorrências de comportamentos abusivos, de assédio ou que sejam inaceitáveis por qualquer outro motivo poderão ser reportadas para a liderança da comunidade, responsável pela aplicação, via contato fabio.tleitao@outlook.com. Todas as reclamações serão revisadas e investigadas imediatamente e de maneira justa.
+Ocorrências de comportamentos abusivos, de assédio ou que sejam inaceitáveis por qualquer outro motivo poderão ser reportadas para a liderança da comunidade, responsável pela aplicação, via [conduct@databoar.com.br](mailto:conduct@databoar.com.br). Todas as reclamações serão revisadas e investigadas imediatamente e de maneira justa.
 
 A liderança da comunidade tem a obrigação de respeitar a privacidade e a segurança de quem reportar qualquer incidente.
 

--- a/docs/COMPLIANCE_AND_LEGAL.md
+++ b/docs/COMPLIANCE_AND_LEGAL.md
@@ -76,7 +76,7 @@ When your organization uses **ISO 31000** as its **risk-management framework**, 
 
 Organisations rarely have a single, tidy inventory of every **ingredient** in their **data soup**—shadow copies, legacy exports, BI models, and ad hoc shares are common. **Data Boar** is built to **ingest and digest** what you point it at; **discovering and prioritising** those sources, **tuning** norm tags and recommendation language, and **bridging** legal expectations with technical scope is often a **joint** exercise.
 
-**Contracted services** (consulting and fine-tuning) are available to help: scoping targets, aligning configuration to your **regulatory mix**, and shortening time-to-trust—without replacing your **DPO** or **counsel**. For licensing and commercial boundaries, see [LICENSING_OPEN_CORE_AND_COMMERCIAL.md](LICENSING_OPEN_CORE_AND_COMMERCIAL.md). **Get in touch** via the channels you already use with the maintainer (e.g. GitHub, professional email)—no obligation.
+**Contracted services** (consulting and fine-tuning) are available to help: scoping targets, aligning configuration to your **regulatory mix**, and shortening time-to-trust—without replacing your **DPO** or **counsel**. For licensing and commercial boundaries, see [LICENSING_OPEN_CORE_AND_COMMERCIAL.md](LICENSING_OPEN_CORE_AND_COMMERCIAL.md). **Get in touch** via GitHub or [contact@databoar.com.br](mailto:contact@databoar.com.br) for professional services enquiries—no obligation.
 
 ---
 

--- a/docs/COMPLIANCE_AND_LEGAL.pt_BR.md
+++ b/docs/COMPLIANCE_AND_LEGAL.pt_BR.md
@@ -78,7 +78,7 @@ Quando a empresa adota a **ISO 31000** como **referência de gestão de risco**,
 
 Raramente a organização tem um inventário único e limpo de cada **ingrediente** da **sopa de dados**—cópias sombra, exportações legadas, modelos de BI e compartilhamentos ad hoc são frequentes. O **Data Boar** **ingere e digere** o que você apontar; **descobrir e priorizar** fontes, **afinar** tags de norma e linguagem de recomendação e **alinhar** expectativa jurídica ao escopo técnico costuma ser exercício **conjunto**.
 
-Há **serviços contratados** (consultoria e ajustes finos) para apoiar: escopo de alvos, alinhamento de configuração ao **mix regulatório** e redução do tempo até confiança operacional—**sem substituir** DPO ou assessoria jurídica. Limites comerciais e de licenciamento: [LICENSING_OPEN_CORE_AND_COMMERCIAL.md](LICENSING_OPEN_CORE_AND_COMMERCIAL.md). **Contato** pelos canais que já utiliza com o mantenedor (ex.: GitHub, e-mail profissional)—sem obrigação.
+Há **serviços contratados** (consultoria e ajustes finos) para apoiar: escopo de alvos, alinhamento de configuração ao **mix regulatório** e redução do tempo até confiança operacional—**sem substituir** DPO ou assessoria jurídica. Limites comerciais e de licenciamento: [LICENSING_OPEN_CORE_AND_COMMERCIAL.md](LICENSING_OPEN_CORE_AND_COMMERCIAL.md). **Contato** via GitHub ou [contact@databoar.com.br](mailto:contact@databoar.com.br) para serviços profissionais—sem obrigação.
 
 ---
 

--- a/docs/plans/PLANS_TODO.md
+++ b/docs/plans/PLANS_TODO.md
@@ -30,13 +30,13 @@ Use these tags in headings to keep priorities explicit and machine-countable:
 
 Do not edit this block manually; refresh with `python scripts/plans-stats.py --write`.
 
-- **Status rows counted:** 180  (Done: 106 | Incomplete: 74)
-- **Incomplete breakdown:** Pending `⬜`=68, Tracked `🔄` / `Tracked (partially done)`=6, Under consideration=0, Backlog-marked rows=0
+- **Status rows counted:** 180  (Done: 108 | Incomplete: 72)
+- **Incomplete breakdown:** Pending `⬜`=66, Tracked `🔄` / `Tracked (partially done)`=6, Under consideration=0, Backlog-marked rows=0
 
 | Horizon | Total rows | Done | Incomplete |
 | ------- | ----------: | ----: | ----------: |
 | `H0` | 30 | 26 | 4 |
-| `H1` | 37 | 25 | 12 |
+| `H1` | 37 | 27 | 10 |
 | `H2` | 0 | 0 | 0 |
 | `H3` | 108 | 50 | 58 |
 | `H4` | 0 | 0 | 0 |
@@ -374,10 +374,10 @@ Doc-first: buyer/DPO positioning in COMPLIANCE_AND_LEGAL + COMPLIANCE_FRAMEWORKS
 
 | # | To-do | Status |
 | - | ----- | ------ |
-| 1 | SECURITY (EN + pt-BR): single coherent disclosure path | ⬜ Pending |
-| 2 | CODE_OF_CONDUCT pair: escalation matches SECURITY | ✅ Done (Contributor Covenant 2.1, PR **#621**) |
-| 3 | CONTRIBUTING pair: vulnerability reporting points to SECURITY | ⬜ Pending |
-| 4 | Close #483 with file list + plan link | ⬜ Pending |
+| 1 | SECURITY (EN + pt-BR): single coherent disclosure path | ✅ Done (GitHub advisories / Issues; no personal email per [#483](https://github.com/FabioLeitao/data-boar/issues/483)) |
+| 2 | CODE_OF_CONDUCT pair: escalation matches SECURITY | ✅ Done (Contributor Covenant 2.1, PR **#621**; `conduct@databoar.com.br` enforcement contact) |
+| 3 | CONTRIBUTING pair: vulnerability reporting points to SECURITY | ✅ Done ([CONTRIBUTING.md](../../CONTRIBUTING.md) → [SECURITY.md](../../SECURITY.md)) |
+| 4 | Close #483 with file list + plan link | ⬜ Pending (closes with conduct/contact alias PR) |
 
 ### Corporate-Entity-C 2026-03-18 — evolution review (9.1/10) and follow-ups
 


### PR DESCRIPTION
## Summary
- Replace personal Outlook enforcement contact with `conduct@databoar.com.br` in `CODE_OF_CONDUCT.md` and `CODE_OF_CONDUCT.pt_BR.md`.
- Add `contact@databoar.com.br` to professional-services CTA in `COMPLIANCE_AND_LEGAL.md` (+ pt-BR mirror).
- Refresh operating-domain rows in `PLANS_TODO.md` (SECURITY path unchanged: GitHub advisories per #483).

## Out of scope (per #483)
- Email provider alias configuration (operator manual step).
- `security@`, `dpo@`, `founder@` not added to SECURITY/README yet.

## Test plan
- [x] `.\scripts\lint-only.ps1`

Closes #418
Closes #483
