### PR TITLE
fix(plugins): validate ml/dl pattern files (ADR-0052, #433)

### DIFF
--- a/core/detector.py
+++ b/core/detector.py
@@ -765,10 +765,23 @@ def _load_ml_patterns(
     path: str | None,
     encoding: str = "utf-8",
     errors: str = "replace",
+    *,
+    plugin_type: str = "ml_patterns",
 ) -> list[tuple[str, int]]:
     """Load (text, label) from YAML/JSON; label 1=sensitive, 0=non_sensitive. Uses given encoding."""
     if not path or not Path(path).exists():
         return []
+    import warnings
+
+    from config.plugin_validator import PluginValidationWarning, validate_plugin_file
+
+    result = validate_plugin_file(path, plugin_type=plugin_type)
+    for issue in result.issues:
+        warnings.warn(
+            f"Plugin file '{path}': {issue}",
+            PluginValidationWarning,
+            stacklevel=2,
+        )
     raw = read_text_with_encoding(path, encoding=encoding, errors=errors)
     if Path(path).suffix.lower() in (".yaml", ".yml"):
         import yaml
@@ -840,7 +853,9 @@ def _load_dl_terms(
                     out.append((text, label))
         if out:
             return out
-    return _load_ml_patterns(path, encoding=encoding, errors=errors)
+    return _load_ml_patterns(
+        path, encoding=encoding, errors=errors, plugin_type="dl_patterns"
+    )
 
 
 def _detect_possible_minor(

--- a/tests/test_plugin_schema.py
+++ b/tests/test_plugin_schema.py
@@ -187,6 +187,38 @@ def test_ml_plugin_invalid_label_value(tmp_path):
     assert any("label" in issue for issue in result.issues)
 
 
+def test_ml_patterns_invalid_file_emits_warning(tmp_path):
+    """Loading invalid ml_patterns via detector emits PluginValidationWarning."""
+    from config.plugin_validator import PluginValidationWarning
+    from core.detector import _load_ml_patterns
+
+    path = _write_yaml(
+        tmp_path,
+        "bad_ml_load.yaml",
+        """
+        - label: "sensitive"
+        """,
+    )
+    with pytest.warns(PluginValidationWarning, match="text"):
+        _load_ml_patterns(path)
+
+
+def test_dl_patterns_invalid_file_emits_warning(tmp_path):
+    """Loading invalid dl_patterns via detector emits PluginValidationWarning."""
+    from config.plugin_validator import PluginValidationWarning
+    from core.detector import _load_dl_terms
+
+    path = _write_yaml(
+        tmp_path,
+        "bad_dl_load.yaml",
+        """
+        - label: "sensitive"
+        """,
+    )
+    with pytest.warns(PluginValidationWarning, match="text"):
+        _load_dl_terms(path, inline=None)
+
+
 # ---------------------------------------------------------------------------
 # validate_plugin_file — unified_plugin_file
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Call \alidate_plugin_file\ when loading \ml_patterns_file\ and \dl_patterns_file\ in \core/detector.py\ (same pattern as regex overrides).
- Add pytest coverage for warning emission on invalid files.

## Test plan
- [x] \	ests/test_plugin_schema.py\ (new warning tests)
- [x] pre-commit on commit
- [x] CI green

Closes #433

Made with [Cursor](https://cursor.com)