### PR TITLE
[G0·S] chore(hooks): agent safety hardening — beforeShellExecution + pre-commit ADR boundary

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      { "command": ".cursor/hooks/adr-protection.sh" }
+    ]
+  }
+}

--- a/.cursor/hooks/adr-protection.sh
+++ b/.cursor/hooks/adr-protection.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# beforeShellExecution hook — ADR file protection
+# G0·S — agent safety hardening 2026-05-21
+COMMAND="$*"
+if echo "$COMMAND" | grep -qE "git (add|commit|stage)"; then
+  STAGED=$(git diff --cached --name-only 2>/dev/null | grep "docs/adr/ADR-.*\.md" | head -1)
+  if [ -n "$STAGED" ]; then
+    echo "BLOCKED [G0·S]: staging/commit includes ADR file: $STAGED"
+    echo "ADR modification requires explicit operator authorization (ADR-0056)."
+    exit 1
+  fi
+fi
+exit 0

--- a/.cursor/hooks/pre-commit
+++ b/.cursor/hooks/pre-commit
@@ -1,0 +1,10 @@
+#!/bin/sh
+# pre-commit hook — defense-in-depth (git level)
+# G0·S — agent safety hardening 2026-05-21
+STAGED_ADRS=$(git diff --cached --name-only | grep "docs/adr/ADR-.*\.md")
+if [ -n "$STAGED_ADRS" ]; then
+  echo "BLOCKED [G0·S]: commit includes ADR file(s): $STAGED_ADRS"
+  echo "ADR modification requires explicit operator authorization (ADR-0056)."
+  exit 1
+fi
+exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,3 +151,21 @@ Examples: `docs(homelab):`, `docs(private-layout):`, `docs(feedback-inbox):`, `c
 - **`audit.ps1` vs `check-all`:** Root **`audit.ps1`** tees **`check-all`** into **`logs/audit-*.log`**—intended as optional **manual Maestro/completão preflight** on the Windows dev PC; **`Maestro.ps1`** and **`lab-completao-orchestrate.ps1`** are **not** wired to call it yet. Commits and PRs use **`check-all`** / **`lint-only`** per slice—not **`audit.ps1`** on every commit.
 - **Maestro persona taxonomy:** Canonical term is **`handler`** (`Handle-<persona>.ps1`); avoid musical-metaphor labels (e.g. Capo/soloist) in scripts, tables, or docs.
 - **Public `databoar.com.br` contact aliases:** Tracked CoC/compliance surfaces use **`conduct@databoar.com.br`** and **`contact@databoar.com.br`**—no personal **`outlook.com`** in the public tree; provider-side mailbox setup remains an operator-manual step.
+
+## Known platform limitations and active workarounds (confirmed 2026-05-21)
+
+Cursor Support (Nathan) confirmed three agent-safety gaps; forum thread: [Three confirmed agent safety failures](https://forum.cursor.com/t/bug-three-confirmed-agent-safety-failures-file-deletion-protection-inoperative-slack-stop-signals-ignored-no-beforeshellexecution-hard-boundary/161253). Priority per **ADR-0055** (**G0·H·U·A·S**). Implementation: **#646**.
+
+- **Bug 1 — File-Deletion Protection inoperative:** Platform failure. Compensating control: git **`pre-commit`** hook in **`.cursor/hooks/pre-commit`** (ADR staging guard) plus normal review discipline.
+- **Bug 2 — Slack STOP signals ignored:** Platform failure; Slack messages are not cancel signals. Workaround: use the **Stop** control on [cursor.com/agents](https://cursor.com/agents) (or IDE stop) to halt a run.
+- **Bug 3 — No `beforeShellExecution` hard boundary on stable:** Repo implements **`.cursor/hooks.json`** → **`.cursor/hooks/adr-protection.sh`**, plus **`git config core.hooksPath .cursor/hooks`** (one-time per clone) so the git-level **`pre-commit`** hook runs. ADR edits still require explicit operator authorization (**ADR-0056**); CI **`inv-adr.ps1`** + ed25519 remain the cryptographic enforcement layer.
+
+**Defense layers for `docs/adr/`:**
+
+| Layer | Mechanism | Type |
+| ----- | --------- | ---- |
+| 1 | **`.cursor/rules/`** | LLM steering (suggestion) |
+| 2 | **`beforeShellExecution`** hook | Shell-level intercept |
+| 3 | **`pre-commit`** git hook | Git-level intercept |
+| 4 | **`inv-adr.ps1`** + ed25519 | Cryptographic CI enforcement |
+


### PR DESCRIPTION
## Summary

Implements **#646** (G0·H·U·A·S per ADR-0055): repo-side compensating controls for three Cursor agent-safety gaps confirmed by Cursor Support (2026-05-21).

- **.cursor/hooks.json** — eforeShellExecution → dr-protection.sh
- **.cursor/hooks/adr-protection.sh** — blocks shell git add/commit when staged ADR files present
- **.cursor/hooks/pre-commit** — git-level ADR staging guard (defense in depth)
- **AGENTS.md** — appended section *Known platform limitations and active workarounds* (existing content untouched)

## Operator one-time setup (per clone)

\\\ash
git config core.hooksPath .cursor/hooks
\\\

Already applied on the canonical dev PC for this PR branch.

## Not in scope (per issue)

- Bug 1 / Bug 2: platform failures — documented workarounds only
- No ADR files created or modified
- **No merge** — awaiting operator review

## Defense layers for \docs/adr/\

| Layer | Mechanism |
| ----- | --------- |
| 1 | \.cursor/rules/\ (LLM steering) |
| 2 | \eforeShellExecution\ hook |
| 3 | \pre-commit\ git hook |
| 4 | \inv-adr.ps1\ + ed25519 (CI) |

## Test plan

- [x] \git config core.hooksPath\ → \.cursor/hooks\
- [x] Hook scripts executable (100755)
- [x] \.cursor/hooks.json\ valid JSON
- [x] \AGENTS.md\ append-only
- [ ] Operator: confirm Cursor loads \hooks.json\ on stable channel
- [ ] CI green on PR

Closes #646 when merged.

Forum: https://forum.cursor.com/t/bug-three-confirmed-agent-safety-failures-file-deletion-protection-inoperative-slack-stop-signals-ignored-no-beforeshellexecution-hard-boundary/161253

Made with [Cursor](https://cursor.com)