### PR TITLE
fix(licensing): license-pub-v1.pem + ocr_images PRO tier (#701 #702)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ tmp_completao_*.yaml
 # Cryptographic material (never track)
 *.key
 *.pem
+!core/licensing/license-pub-v1.pem
 *.p12
 *.pfx
 *.jks

--- a/core/licensing/license-pub-v1.pem
+++ b/core/licensing/license-pub-v1.pem
@@ -1,0 +1,3 @@
+-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEArk71OUyF78XTwvywt+9HLr7odY/wovF77NUguZp+go8=
+-----END PUBLIC KEY-----

--- a/core/licensing/tier_features.py
+++ b/core/licensing/tier_features.py
@@ -52,9 +52,9 @@ FEATURE_TIER_MAP: dict[str, Tier] = {
     "ansible_deploy": Tier.COMMUNITY,
     "compressed_files": Tier.COMMUNITY,
     "content_type_detection": Tier.COMMUNITY,
-    "ocr_images": Tier.COMMUNITY,
     "synthetic_data_testing": Tier.COMMUNITY,
     # Pro features (PDF report, advanced connectors, scheduling)
+    "ocr_images": Tier.PRO,
     "report_pdf": Tier.PRO,  # see PLAN_PDF_GRC_REPORT.md
     "report_pdf_custom_branding": Tier.ENTERPRISE,
     "connector_snowflake": Tier.PRO,


### PR DESCRIPTION
## Summary

- **#701:** Add tracked verification public key `core/licensing/license-pub-v1.pem` (ed25519) with `.gitignore` exception for this file only.
- **#702:** Move `ocr_images` from `Tier.COMMUNITY` to `Tier.PRO` in `FEATURE_TIER_MAP`.

Closes #701
Closes #702

## Test plan

- [x] `load_pem_public_key` on `license-pub-v1.pem` returns ok
- [x] `pytest tests/test_licensing_tier_gates.py tests/test_licensing.py tests/test_licensing_fingerprint.py` (23 passed)
- [ ] CI green on PR