### PR TITLE
fix(security): mask credential env names in validate-config warnings (#730)

### DIFF
--- a/main.py
+++ b/main.py
@@ -57,6 +57,21 @@ _ENV_FIELDS_TARGET = (
     "api_key_from_env",
 )
 _ENV_FIELDS_AUTH = ("client_secret_from_env",)
+_SENSITIVE_FIELDS = frozenset(
+    {
+        "pass_from_env",
+        "token_from_env",
+        "api_key_from_env",
+        "client_secret_from_env",
+    }
+)
+
+
+def _mask_env_name(field: str, env_name: str) -> str:
+    """Return env var name for logs, masking credential field references."""
+    if field in _SENSITIVE_FIELDS:
+        return "***"
+    return env_name
 
 
 def _validate_config_and_exit(config: dict[str, Any], config_path: str) -> None:
@@ -97,7 +112,7 @@ def _validate_config_and_exit(config: dict[str, Any], config_path: str) -> None:
             env_name = target.get(field)
             if env_name and not os.environ.get(env_name):
                 warnings.append(
-                    f'target "{name}": {field}={env_name!r} — env var not set'
+                    f'target "{name}": {field}={_mask_env_name(field, env_name)!r} — env var not set'
                 )
 
         auth = target.get("auth") or {}
@@ -105,7 +120,7 @@ def _validate_config_and_exit(config: dict[str, Any], config_path: str) -> None:
             env_name = auth.get(field)
             if env_name and not os.environ.get(env_name):
                 warnings.append(
-                    f'target "{name}": auth.{field}={env_name!r} — env var not set'
+                    f'target "{name}": auth.{field}={_mask_env_name(field, env_name)!r} — env var not set'
                 )
 
         kind = target.get("type", "?")

--- a/tests/test_main_validate_config.py
+++ b/tests/test_main_validate_config.py
@@ -96,8 +96,51 @@ def test_validate_config_missing_required_key(tmp_path):
     assert 'required key "path" missing' in r.stdout
 
 
+def test_mask_env_name_sensitive_vs_non_sensitive() -> None:
+    repo = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo))
+    import main as main_module
+
+    assert main_module._mask_env_name("pass_from_env", "PG_SECRET") == "***"
+    assert main_module._mask_env_name("api_key_from_env", "API_KEY") == "***"
+    assert main_module._mask_env_name("user_from_env", "DB_USER") == "DB_USER"
+
+
 def test_validate_config_unset_env_var_warns_but_ok(tmp_path):
-    env_name = "PG_PASS_TEST_VALIDATE_CONFIG_UNUSED"
+    env_name = "DB_USER_TEST_VALIDATE_CONFIG_UNUSED"
+    cfg = _base_config(
+        tmp_path,
+        f"""  - name: prod-postgres
+    type: database
+    driver: postgresql+psycopg2
+    user_from_env: {env_name}""",
+    )
+    child_env = os.environ.copy()
+    child_env.pop(env_name, None)
+    repo = Path(__file__).resolve().parents[1]
+    r = subprocess.run(
+        [
+            sys.executable,
+            str(repo / "main.py"),
+            "--config",
+            str(cfg),
+            "--validate-config",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo),
+        timeout=60,
+        check=False,
+        env=child_env,
+    )
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "[OK] 1 target(s) valid" in r.stdout
+    assert env_name in r.stdout
+    assert "WARN" in r.stdout
+
+
+def test_validate_config_masks_sensitive_env_name_in_warning(tmp_path):
+    env_name = "PG_PASS_TEST_VALIDATE_CONFIG_MASK"
     cfg = _base_config(
         tmp_path,
         f"""  - name: prod-postgres
@@ -124,8 +167,8 @@ def test_validate_config_unset_env_var_warns_but_ok(tmp_path):
         env=child_env,
     )
     assert r.returncode == 0, r.stdout + r.stderr
-    assert "[OK] 1 target(s) valid" in r.stdout
-    assert env_name in r.stdout
+    assert "pass_from_env='***'" in r.stdout
+    assert env_name not in r.stdout
     assert "WARN" in r.stdout
 
 


### PR DESCRIPTION
## Summary
- Add `_SENSITIVE_FIELDS` and `_mask_env_name()` in `main.py`.
- Mask `pass_from_env`, `token_from_env`, `api_key_from_env`, and `client_secret_from_env` warnings as `'***'` in `--validate-config` output.
- Unit + CLI tests for sensitive vs non-sensitive fields.

Closes #730

## Test plan
- [x] `uv run pytest tests/test_main_validate_config.py` -q
