### PR TITLE
fix(licensing): TAMPERED tier cap in enforced mode (#712)

### DIFF
--- a/core/licensing/runtime_feature_tier.py
+++ b/core/licensing/runtime_feature_tier.py
@@ -6,10 +6,13 @@ Shared by API routes, RBAC, and maturity POC so tier logic stays in one place.
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import Any
 
 from core.licensing.tier_features import Tier
+
+logger = logging.getLogger("data_boar.licensing")
 
 
 def is_dev_tier_override_env() -> bool:
@@ -53,6 +56,7 @@ def get_runtime_tier_for_features(cfg: dict[str, Any]) -> Tier:
         return env_override
 
     dbtier_claim = ""
+    lc = cfg.get("licensing") if isinstance(cfg.get("licensing"), dict) else {}
     try:
         from core.licensing.guard import get_license_guard
 
@@ -60,9 +64,18 @@ def get_runtime_tier_for_features(cfg: dict[str, Any]) -> Tier:
         c = g.context
         if c.state in ("VALID", "GRACE"):
             dbtier_claim = str(getattr(c, "dbtier", "") or "").strip().lower()
+        elif c.state == "TAMPERED":
+            mode = str(lc.get("mode") or "open").strip().lower()
+            if mode == "enforced":
+                logger.critical(
+                    "LicenseGuard state=TAMPERED in enforced mode — capping effective tier to Community"
+                )
+                return Tier.COMMUNITY
+            logger.critical(
+                "LicenseGuard state=TAMPERED in open mode — unauthorized build detected"
+            )
     except Exception:  # noqa: BLE001
         pass  # license guard may be unavailable during early bootstrap
-    lc = cfg.get("licensing") if isinstance(cfg.get("licensing"), dict) else {}
     yaml_tier = str(lc.get("effective_tier") or "").strip().lower()
     if dbtier_claim:
         return map_dbtier_string_to_tier(dbtier_claim)

--- a/tests/test_runtime_feature_tier.py
+++ b/tests/test_runtime_feature_tier.py
@@ -1,0 +1,45 @@
+"""Runtime tier resolution including TAMPERED state (ADR-0066, #712)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.licensing.guard import reset_license_guard_for_tests
+from core.licensing.runtime_feature_tier import get_runtime_tier_for_features
+from core.licensing.tier_features import Tier
+
+
+@pytest.fixture(autouse=True)
+def _reset_guard():
+    reset_license_guard_for_tests()
+    yield
+    reset_license_guard_for_tests()
+
+
+def _tampered_guard() -> MagicMock:
+    ctx = MagicMock()
+    ctx.state = "TAMPERED"
+    guard = MagicMock()
+    guard.context = ctx
+    return guard
+
+
+@patch("core.licensing.guard.get_license_guard")
+def test_tampered_enforced_returns_community(mock_get_guard):
+    mock_get_guard.return_value = _tampered_guard()
+    cfg = {"licensing": {"mode": "enforced", "effective_tier": "enterprise"}}
+    assert get_runtime_tier_for_features(cfg) == Tier.COMMUNITY
+
+
+@patch("core.licensing.guard.get_license_guard")
+def test_tampered_open_returns_open_and_logs_critical(mock_get_guard, caplog):
+    mock_get_guard.return_value = _tampered_guard()
+    cfg = {"licensing": {"mode": "open"}}
+    with caplog.at_level("CRITICAL", logger="data_boar.licensing"):
+        assert get_runtime_tier_for_features(cfg) == Tier.OPEN
+    assert any(
+        "TAMPERED" in rec.message and "open mode" in rec.message
+        for rec in caplog.records
+    )


### PR DESCRIPTION
## Summary
- Implement ADR-0066 TAMPERED handling in `get_runtime_tier_for_features()`
- **enforced:** CRITICAL log + return `Tier.COMMUNITY` (blocks Pro/Enterprise features)
- **open:** CRITICAL log + fall through (no tier block)
- Add `tests/test_runtime_feature_tier.py` with enforced/open cases

## Test plan
- [x] `uv run pytest tests/test_runtime_feature_tier.py tests/test_tier_features_open_core_subscription.py tests/test_licensing_tier_gates.py`
- [x] `.\scripts\lint-only.ps1`

Closes #712
