### PR TITLE
chore(scripts): accept --dbtier community in dev JWT issuer (#706)

### DIFF
--- a/scripts/issue_dev_license_jwt.py
+++ b/scripts/issue_dev_license_jwt.py
@@ -43,7 +43,10 @@ def main() -> None:
     )
     p.add_argument("--sub", default="dev-lic-1", help="JWT sub (license id)")
     p.add_argument(
-        "--dbtier", default="pro", help="dbtier claim (e.g. pro, enterprise)"
+        "--dbtier",
+        default="pro",
+        choices=["community", "pro", "enterprise"],
+        help="dbtier claim (community, pro, or enterprise)",
     )
     p.add_argument("--days", type=int, default=7, help="Validity in days from now")
     p.add_argument("--out", help="Write token to this file (.lic); default stdout")


### PR DESCRIPTION
## Summary
- Add `community` to `--dbtier` argparse `choices` alongside `pro` and `enterprise` in `scripts/issue_dev_license_jwt.py`
- Update `--help` text to list all three valid tiers
- Community JWT uses the same payload shape; runtime `LicenseGuard` enforces tier caps

## Tests
- [x] Local smoke: `--dbtier community` emits JWT with `dbtier: community`
- [x] `uv run pytest tests/test_scripts.py::test_issue_dev_license_jwt_py_compiles`
- No dedicated `test_issue_dev_license_jwt.py` exists — only compile guard in `test_scripts.py`; no new test file in this PR (scope kept tight per issue)

Closes #706
