### PR TITLE
feat(licensing): enforce JWT tier gates at MVP call sites (#699)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -513,6 +513,9 @@ class ScanStartBody(BaseModel):
     scan_for_stego: bool | None = (
         None  # when True, merge into file_scan for this run only (entropy hints on rich media)
     )
+    scheduled: bool | None = (
+        None  # when True, treat as a scheduled/cron-triggered scan (Pro+ ``scheduled_scans``)
+    )
 
 
 # Load config and create engine at import time (or on startup event)
@@ -683,6 +686,26 @@ def _raise_if_license_blocks_scan() -> None:
             "detail": c.detail,
         },
     )
+
+
+def _raise_if_feature_blocked(feature: str) -> None:
+    """403 when the runtime tier denies a Pro/Enterprise feature."""
+    from core.licensing.errors import FeatureTierBlockedError
+    from core.licensing.feature_gate import require_feature
+
+    try:
+        require_feature(_get_config(), feature)
+    except FeatureTierBlockedError as exc:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error": "feature_tier_blocked",
+                "feature": exc.feature,
+                "message": exc.reason,
+                "required_tier": exc.required_tier,
+                "current_tier": exc.current_tier,
+            },
+        ) from exc
 
 
 def _validate_webauthn_startup(cfg: dict) -> None:
@@ -1106,8 +1129,10 @@ _SESSION_RESPONSES = {
 async def start_scan(
     background_tasks: BackgroundTasks, body: ScanStartBody | None = None
 ):
-    """Start audit in background. Optional body: tenant, technician, scan_compressed, content_type_check, scan_for_stego, jurisdiction_hint. Returns session_id."""
+    """Start audit in background. Optional body: tenant, technician, scan_compressed, content_type_check, scan_for_stego, scheduled, jurisdiction_hint. Returns session_id."""
     _raise_if_license_blocks_scan()
+    if body and getattr(body, "scheduled", None) is True:
+        _raise_if_feature_blocked("scheduled_scans")
     engine = _get_engine()
     if engine.is_running:
         raise HTTPException(status_code=409, detail="Audit already in progress.")
@@ -1564,6 +1589,9 @@ async def download_log_for_session(session_id: str):
 async def scan_database(config: DatabaseConfig, background_tasks: BackgroundTasks):
     """One-off scan of a single database (body: name, host, port, user, password, database, optional driver). Starts in background; returns session_id."""
     _raise_if_license_blocks_scan()
+    driver_key = (config.driver or "").split("+")[0].strip().lower()
+    if driver_key == "snowflake":
+        _raise_if_feature_blocked("connector_snowflake")
     engine = _get_engine()
     if engine.is_running:
         raise HTTPException(status_code=409, detail="Audit already in progress.")

--- a/core/connector_registry.py
+++ b/core/connector_registry.py
@@ -58,6 +58,25 @@ def _resolve_database_connector(
     return None
 
 
+_CONNECTOR_TIER_FEATURES: dict[str, str] = {
+    "snowflake": "connector_snowflake",
+    "s3": "connector_s3_object_storage",
+    "azure_blob": "connector_azure_blob",
+    "gcs": "connector_gcs",
+}
+
+
+def tier_feature_for_target(target: dict[str, Any]) -> str | None:
+    """Return the tier feature name for Pro+ cloud connectors, or None when not gated."""
+    t = (target.get("type") or "").strip().lower()
+    if t in _CONNECTOR_TIER_FEATURES:
+        return _CONNECTOR_TIER_FEATURES[t]
+    if t == "database":
+        driver = (target.get("driver") or "").split("+")[0].strip().lower()
+        return _CONNECTOR_TIER_FEATURES.get(driver)
+    return None
+
+
 def connector_for_target(target: dict[str, Any]) -> tuple[Type[Any], list[str]] | None:
     """
     Resolve connector from target config. Target may have type='database' with driver='postgresql+psycopg2'.

--- a/core/engine.py
+++ b/core/engine.py
@@ -265,6 +265,19 @@ class AuditEngine:
 
     def _run_target(self, target: dict[str, Any]) -> None:
         """Run one target: resolve connector, instantiate, run()."""
+        from core.connector_registry import tier_feature_for_target
+        from core.licensing.errors import FeatureTierBlockedError
+        from core.licensing.feature_gate import require_feature
+
+        tier_feature = tier_feature_for_target(target)
+        if tier_feature:
+            try:
+                require_feature(self.config, tier_feature)
+            except FeatureTierBlockedError as exc:
+                tname = target.get("name", "unknown")
+                self.db_manager.save_failure(tname, "tier_blocked", exc.reason)
+                return
+
         resolved = connector_for_target(target)
         if not resolved:
             tname = target.get("name", "unknown")

--- a/core/licensing/errors.py
+++ b/core/licensing/errors.py
@@ -24,4 +24,6 @@ class FeatureTierBlockedError(RuntimeError):
         self.reason = reason
         self.required_tier = required_tier
         self.current_tier = current_tier
-        super().__init__(reason or f"Feature '{feature}' is not available for this tier.")
+        super().__init__(
+            reason or f"Feature '{feature}' is not available for this tier."
+        )

--- a/core/licensing/errors.py
+++ b/core/licensing/errors.py
@@ -1,4 +1,4 @@
-"""Licensing errors raised when enforcement blocks a scan."""
+"""Licensing errors raised when enforcement blocks a scan or tier-gated feature."""
 
 
 class LicenseBlockedError(RuntimeError):
@@ -7,3 +7,21 @@ class LicenseBlockedError(RuntimeError):
     def __init__(self, state: str, message: str) -> None:
         self.state = state
         super().__init__(message)
+
+
+class FeatureTierBlockedError(RuntimeError):
+    """Raised when the runtime tier does not include a Pro/Enterprise feature."""
+
+    def __init__(
+        self,
+        feature: str,
+        reason: str,
+        *,
+        required_tier: str = "",
+        current_tier: str = "",
+    ) -> None:
+        self.feature = feature
+        self.reason = reason
+        self.required_tier = required_tier
+        self.current_tier = current_tier
+        super().__init__(reason or f"Feature '{feature}' is not available for this tier.")

--- a/core/licensing/feature_gate.py
+++ b/core/licensing/feature_gate.py
@@ -7,7 +7,9 @@ Use :func:`check_feature` before activating tier-gated product behaviour.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
+from core.licensing.errors import FeatureTierBlockedError
 from core.licensing.tier_features import (
     Tier,
     get_required_tier,
@@ -62,4 +64,23 @@ def check_feature(feature: str, current_tier: Tier) -> FeatureCheckResult:
         feature=name,
         required_tier=required.value,
         current_tier=current_tier.value,
+    )
+
+
+def require_feature(cfg: dict[str, Any], feature: str) -> None:
+    """
+    Raise :class:`FeatureTierBlockedError` when *feature* is denied for the runtime tier.
+
+    Uses :func:`core.licensing.guard.get_license_guard` so JWT ``dbtier`` wins in enforced mode.
+    """
+    from core.licensing.guard import get_license_guard
+
+    result = get_license_guard(cfg).check_feature(feature)
+    if result.allowed:
+        return
+    raise FeatureTierBlockedError(
+        result.feature,
+        result.reason,
+        required_tier=result.required_tier,
+        current_tier=result.current_tier,
     )

--- a/report/grc_export_multiformat.py
+++ b/report/grc_export_multiformat.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
+
+from core.licensing.feature_gate import require_feature
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
@@ -38,8 +40,15 @@ def _p(text: str) -> str:
     return html.escape(str(text or ""), quote=False).replace("\n", "<br/>")
 
 
-def export_grc_executive_pdf(data: dict[str, Any], path: Path) -> None:
+def export_grc_executive_pdf(
+    data: dict[str, Any],
+    path: Path,
+    *,
+    config: dict[str, Any] | None = None,
+) -> None:
     """Short board-ready PDF: metadata, executive summary, asset summary, recommendations."""
+    if config is not None:
+        require_feature(config, "report_pdf")
     path.parent.mkdir(parents=True, exist_ok=True)
     meta = data["report_metadata"]
     exe = data["executive_summary"]

--- a/tests/test_licensing_feature_enforcement_mvp.py
+++ b/tests/test_licensing_feature_enforcement_mvp.py
@@ -1,0 +1,176 @@
+"""JWT tier enforcement at Pro/Enterprise feature call sites (#699 MVP)."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from fastapi.testclient import TestClient
+
+from app.grc_dashboard_model import load_grc_json
+from core.licensing.errors import FeatureTierBlockedError
+from core.licensing.guard import reset_license_guard_for_tests
+from report.grc_export_multiformat import export_grc_executive_pdf
+
+_REPO = Path(__file__).resolve().parents[1]
+_GRC_EXAMPLE = _REPO / "schemas" / "grc_executive_report.v1.example.json"
+
+
+def _pem_public(priv: Ed25519PrivateKey) -> str:
+    pub = priv.public_key()
+    return (
+        pub.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("ascii")
+        .strip()
+    )
+
+
+def _make_token(priv: Ed25519PrivateKey, *, dbtier: str) -> str:
+    now = datetime.now(timezone.utc)
+    payload = {
+        "sub": "mvp-tier-enforcement",
+        "iat": int(now.timestamp()),
+        "exp": int((now + timedelta(days=7)).timestamp()),
+        "dbcid": "cust-test",
+        "dbcname": "Tier Test",
+        "dbenv": "qa",
+        "dbissuer": "pytest",
+        "dbkid": "k1",
+        "dbtier": dbtier,
+    }
+    return jwt.encode(payload, priv, algorithm="EdDSA")
+
+
+@pytest.fixture
+def ed25519_priv() -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.generate()
+
+
+@pytest.fixture(autouse=True)
+def _clean_license_env():
+    reset_license_guard_for_tests()
+    keys = (
+        "DATA_BOAR_LICENSE_PUBLIC_KEY_PEM",
+        "DATA_BOAR_LICENSE_PUBLIC_KEY_PATH",
+        "DATA_BOAR_LICENSE_PATH",
+        "DATA_BOAR_LICENSE_MODE",
+    )
+    saved = {k: os.environ.get(k) for k in keys}
+    yield
+    reset_license_guard_for_tests()
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+def _enforced_community_cfg(tmp_path: Path, priv: Ed25519PrivateKey) -> dict:
+    lic = tmp_path / "community.lic"
+    lic.write_text(_make_token(priv, dbtier="community"), encoding="utf-8")
+    return {
+        "targets": [],
+        "sqlite_path": str(tmp_path / "audit.db"),
+        "report": {"output_dir": str(tmp_path)},
+        "api": {"port": 8099, "require_api_key": False},
+        "licensing": {
+            "mode": "enforced",
+            "license_path": str(lic),
+        },
+    }
+
+
+def _setup_routes(tmp_path: Path, cfg: dict, monkeypatch: pytest.MonkeyPatch):
+    import yaml
+
+    import api.routes as routes
+
+    p = tmp_path / "cfg.yaml"
+    p.write_text(yaml.dump(cfg), encoding="utf-8")
+    reset_license_guard_for_tests()
+    monkeypatch.setattr(routes, "_config_path", str(p))
+    routes._config = None
+    routes._audit_engine = None
+    return routes, TestClient(routes.app)
+
+
+def test_report_pdf_blocked_for_community_tier(
+    tmp_path: Path, ed25519_priv: Ed25519PrivateKey, monkeypatch: pytest.MonkeyPatch
+):
+    os.environ["DATA_BOAR_LICENSE_PUBLIC_KEY_PEM"] = _pem_public(ed25519_priv)
+    cfg = _enforced_community_cfg(tmp_path, ed25519_priv)
+    data = load_grc_json(_GRC_EXAMPLE)
+    pdf = tmp_path / "out.pdf"
+    with pytest.raises(FeatureTierBlockedError) as exc_info:
+        export_grc_executive_pdf(data, pdf, config=cfg)
+    assert exc_info.value.feature == "report_pdf"
+    assert not pdf.exists()
+
+
+def test_scheduled_scans_blocked_for_community_tier_api(
+    tmp_path: Path, ed25519_priv: Ed25519PrivateKey, monkeypatch: pytest.MonkeyPatch
+):
+    os.environ["DATA_BOAR_LICENSE_PUBLIC_KEY_PEM"] = _pem_public(ed25519_priv)
+    cfg = _enforced_community_cfg(tmp_path, ed25519_priv)
+    routes, client = _setup_routes(tmp_path, cfg, monkeypatch)
+    try:
+        r = client.post("/scan", json={"scheduled": True})
+        assert r.status_code == 403
+        detail = r.json().get("detail", {})
+        assert detail.get("error") == "feature_tier_blocked"
+        assert detail.get("feature") == "scheduled_scans"
+    finally:
+        routes._audit_engine = None
+        routes._config = None
+
+
+def test_snowflake_scan_database_blocked_for_community_tier_api(
+    tmp_path: Path, ed25519_priv: Ed25519PrivateKey, monkeypatch: pytest.MonkeyPatch
+):
+    os.environ["DATA_BOAR_LICENSE_PUBLIC_KEY_PEM"] = _pem_public(ed25519_priv)
+    cfg = _enforced_community_cfg(tmp_path, ed25519_priv)
+    routes, client = _setup_routes(tmp_path, cfg, monkeypatch)
+    try:
+        r = client.post(
+            "/scan_database",
+            json={
+                "name": "sf-lab",
+                "host": "example.snowflakecomputing.com",
+                "port": 443,
+                "user": "user",
+                "password": "secret",
+                "database": "DB",
+                "driver": "snowflake",
+            },
+        )
+        assert r.status_code == 403
+        detail = r.json().get("detail", {})
+        assert detail.get("error") == "feature_tier_blocked"
+        assert detail.get("feature") == "connector_snowflake"
+    finally:
+        routes._audit_engine = None
+        routes._config = None
+
+
+def test_community_tier_manual_scan_still_allowed(
+    tmp_path: Path, ed25519_priv: Ed25519PrivateKey, monkeypatch: pytest.MonkeyPatch
+):
+    """Regression: community JWT must not block a normal (non-scheduled) scan start."""
+    os.environ["DATA_BOAR_LICENSE_PUBLIC_KEY_PEM"] = _pem_public(ed25519_priv)
+    cfg = _enforced_community_cfg(tmp_path, ed25519_priv)
+    routes, client = _setup_routes(tmp_path, cfg, monkeypatch)
+    try:
+        r = client.post("/scan", json={})
+        assert r.status_code == 200
+        assert r.json().get("session_id")
+    finally:
+        routes._audit_engine = None
+        routes._config = None


### PR DESCRIPTION
## Summary
- Add `require_feature()` + `FeatureTierBlockedError` for runtime JWT tier gates via `LicenseGuard.check_feature()`
- Wire MVP Pro+ enforcement at call sites:
  - `report_pdf` — `export_grc_executive_pdf(..., config=...)`
  - `scheduled_scans` — `POST /scan` when body `scheduled: true`
  - `connector_snowflake` — `POST /scan_database` with Snowflake driver + `AuditEngine._run_target()` (connector loader path)
- Map cloud connector types/drivers in `connector_registry.tier_feature_for_target()`

## Tests
- [x] `tests/test_licensing_feature_enforcement_mvp.py` (community JWT + enforced mode: PDF, scheduled scan, Snowflake blocked; manual scan still OK)
- [x] Existing GRC export + licensing tests pass

## Not in this MVP slice
- Sidecar silo segregation, numeric JWT caps (`dbmax_*`), LICENSING_SPEC/ADR-0027 doc refresh (full #699 scope)

Closes #699
