### PR TITLE
feat(maestro): Handle-LicensingMatrix JWT tier matrix smoke (#707)

### DIFF
--- a/api/rbac.py
+++ b/api/rbac.py
@@ -132,6 +132,8 @@ def required_roles_for_route(method: str, path: str) -> frozenset[str] | None:
         return SCAN
     if path == "/scan_database" and m == "POST":
         return SCAN
+    if path == "/scan_pdf" and m == "POST":
+        return REP
     if path in ("/report", "/heatmap") and m in ("GET", "HEAD"):
         return REP
     if path.startswith("/reports/") and m in ("GET", "HEAD"):

--- a/api/routes.py
+++ b/api/routes.py
@@ -1206,6 +1206,17 @@ async def start_scan(
     return {"status": "started", "session_id": session_id}
 
 
+@app.post("/scan_pdf", responses=_RATE_LIMIT_429)
+async def scan_pdf():
+    """Pro+ tier gate for executive PDF export (Maestro licensing-matrix smoke)."""
+    _raise_if_license_blocks_scan()
+    _raise_if_feature_blocked("report_pdf")
+    return JSONResponse(
+        status_code=202,
+        content={"status": "accepted", "feature": "report_pdf"},
+    )
+
+
 @app.get("/status")
 async def get_status():
     """Return running, current_session_id, findings_count, and declarative ``audit_log`` (sampling posture)."""

--- a/docs/plans/PLAN_DASHBOARD_REPORTS_ACCESS_CONTROL.md
+++ b/docs/plans/PLAN_DASHBOARD_REPORTS_ACCESS_CONTROL.md
@@ -137,6 +137,7 @@ See [SECURITY.md](../SECURITY.md), [USAGE.md](../USAGE.md), [TECH_GUIDE.md](../T
 | `GET` | `/logs` | text | Logs listing | `authenticated` |
 | `GET` | `/logs/{session_id}` | text | Session log | `authenticated` |
 | `POST` | `/scan_database` | JSON | DB scan | `scanner`+ |
+| `POST` | `/scan_pdf` | JSON | Pro+ tier gate for executive PDF (`report_pdf`); Maestro licensing-matrix smoke returns **202** when allowed, **403** when blocked | `reports_reader`+ |
 | `GET` | `/findings` | JSON | Latest-session findings export (async `StreamingResponse`, unified schema) | `reports_reader`+ |
 | `GET` | `/findings/csv` | CSV | Latest-session findings export as CSV download | `reports_reader`+ |
 | `GET` | `/findings/{session_id}` | JSON | Findings for a specific session | `reports_reader`+ |

--- a/scripts/maestro/Handle-LicensingMatrix.ps1
+++ b/scripts/maestro/Handle-LicensingMatrix.ps1
@@ -1,0 +1,288 @@
+#Requires -Version 7.6.1
+<#
+.NAME
+ scripts/maestro/Handle-LicensingMatrix.ps1
+
+.SYNOPSIS
+ Maestro capo: validate JWT tier enforcement matrix (community / pro / enterprise).
+
+.DESCRIPTION
+ Issues dev JWTs per tier, starts a short-lived API on loopback with licensing.mode enforced,
+ and asserts Pro+ gates (report_pdf, scheduled_scans) allow or deny as expected.
+ Skips with exit 0 when the lab signing key is missing.
+#>
+
+param(
+    [string]$RepoRoot = "",
+    [int]$Port = 19987,
+    [int]$HealthTimeoutSec = 45
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-MaestroStep {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("PASS", "FAIL", "SKIP", "INFO")]
+        [string]$Status,
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+    $color = switch ($Status) {
+        "PASS" { "Green" }
+        "FAIL" { "Red" }
+        "SKIP" { "Yellow" }
+        default { "Cyan" }
+    }
+    Write-Host "[Maestro:$Status] $Message" -ForegroundColor $color
+}
+
+function Get-RepoRoot {
+    param([string]$Hint)
+    if (-not [string]::IsNullOrWhiteSpace($Hint)) {
+        return (Resolve-Path $Hint).Path
+    }
+    return (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+}
+
+function Convert-ToYamlPath {
+    param([string]$PathValue)
+    return ($PathValue -replace "\\", "/")
+}
+
+function New-LicensingMatrixConfig {
+    param(
+        [string]$ConfigPath,
+        [string]$LicensePath,
+        [string]$PublicKeyPath,
+        [string]$WorkDir,
+        [int]$ApiPort
+    )
+    $sqlite = Join-Path $WorkDir "audit.db"
+    $outDir = Join-Path $WorkDir "reports"
+    New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+    $yaml = @"
+licensing:
+  mode: enforced
+  license_path: $(Convert-ToYamlPath $LicensePath)
+  public_key_path: $(Convert-ToYamlPath $PublicKeyPath)
+targets: []
+sqlite_path: $(Convert-ToYamlPath $sqlite)
+report:
+  output_dir: $(Convert-ToYamlPath $outDir)
+api:
+  port: $ApiPort
+  require_api_key: false
+"@
+    Set-Content -Path $ConfigPath -Value $yaml -Encoding utf8NoBOM
+}
+
+function Wait-ApiHealth {
+    param(
+        [string]$BaseUrl,
+        [int]$TimeoutSec
+    )
+    $deadline = (Get-Date).AddSeconds($TimeoutSec)
+    while ((Get-Date) -lt $deadline) {
+        try {
+            $response = Invoke-WebRequest -Uri "$BaseUrl/health" -Method Get -TimeoutSec 3 -SkipHttpErrorCheck
+            if ($response.StatusCode -eq 200) {
+                return $true
+            }
+        } catch {
+            # retry until timeout
+        }
+        Start-Sleep -Milliseconds 500
+    }
+    return $false
+}
+
+function Invoke-ApiPostStatus {
+    param(
+        [string]$Url,
+        [string]$BodyJson = "{}"
+    )
+    $response = Invoke-WebRequest `
+        -Uri $Url `
+        -Method Post `
+        -ContentType "application/json; charset=utf-8" `
+        -Body $BodyJson `
+        -SkipHttpErrorCheck
+    return [int]$response.StatusCode
+}
+
+function Test-StatusAllowed {
+    param(
+        [int]$StatusCode,
+        [int[]]$Allowed
+    )
+    return ($Allowed -contains $StatusCode)
+}
+
+function Start-MatrixApiProcess {
+    param(
+        [string]$Root,
+        [string]$ConfigPath,
+        [int]$ApiPort,
+        [string]$PublicKeyPath
+    )
+    $env:CONFIG_PATH = $ConfigPath
+    $env:DATA_BOAR_LICENSE_PUBLIC_KEY_PATH = $PublicKeyPath
+    $logPath = Join-Path ([System.IO.Path]::GetTempPath()) ("data-boar-lic-matrix-log-" + [guid]::NewGuid().ToString("n") + ".txt")
+    $args = @(
+        "run", "python", "main.py",
+        "--config", $ConfigPath,
+        "--web",
+        "--host", "127.0.0.1",
+        "--port", "$ApiPort",
+        "--allow-insecure-http"
+    )
+    $proc = Start-Process `
+        -FilePath "uv" `
+        -ArgumentList $args `
+        -WorkingDirectory $Root `
+        -RedirectStandardOutput $logPath `
+        -RedirectStandardError $logPath `
+        -PassThru `
+        -WindowStyle Hidden
+    return [PSCustomObject]@{
+        Process = $proc
+        LogPath = $logPath
+    }
+}
+
+function Stop-MatrixApiProcess {
+    param($ApiBundle)
+    if ($null -eq $ApiBundle -or $null -eq $ApiBundle.Process) {
+        return
+    }
+    $proc = $ApiBundle.Process
+    if (-not $proc.HasExited) {
+        Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds 1
+    }
+    if ($ApiBundle.LogPath -and (Test-Path $ApiBundle.LogPath)) {
+        Remove-Item -Path $ApiBundle.LogPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Add-MatrixAssertion {
+    param(
+        [ref]$FailureList,
+        [string]$Tier,
+        [string]$CaseName,
+        [bool]$Ok,
+        [string]$Detail
+    )
+    if ($Ok) {
+        Write-MaestroStep INFO "tier=$Tier case=$CaseName ok ($Detail)"
+        return
+    }
+    $msg = "tier=$Tier case=$CaseName $Detail"
+    $FailureList.Value += $msg
+    Write-MaestroStep INFO "tier=$Tier case=$CaseName FAIL ($Detail)"
+}
+
+$RepoRoot = Get-RepoRoot -Hint $RepoRoot
+$homeRoot = if ($env:USERPROFILE) { $env:USERPROFILE } else { $env:HOME }
+if ([string]::IsNullOrWhiteSpace($homeRoot)) {
+    Write-MaestroStep FAIL "cannot resolve USERPROFILE or HOME for keys path"
+    exit 1
+}
+
+$keysDir = Join-Path $homeRoot ".keys/data-boar"
+$signKey = $env:DATA_BOAR_LICENSE_ISSUER_PRIVATE_KEY_PEM_FILE
+if ([string]::IsNullOrWhiteSpace($signKey)) {
+    $signKey = Join-Path $keysDir "license-signing-v1-pkcs8.pem"
+}
+if (-not (Test-Path -LiteralPath $signKey)) {
+    Write-MaestroStep SKIP "no signing key"
+    exit 0
+}
+
+$pubKey = Join-Path $keysDir "license-pub-v1.pem"
+if (-not (Test-Path -LiteralPath $pubKey)) {
+    Write-MaestroStep SKIP "no public key at $(Convert-ToYamlPath $pubKey)"
+    exit 0
+}
+
+$issuerScript = Join-Path $RepoRoot "scripts/issue_dev_license_jwt.py"
+if (-not (Test-Path -LiteralPath $issuerScript)) {
+    Write-MaestroStep FAIL "missing issuer script at $(Convert-ToYamlPath $issuerScript)"
+    exit 1
+}
+
+New-Item -ItemType Directory -Force -Path $keysDir | Out-Null
+$env:DATA_BOAR_LICENSE_ISSUER_PRIVATE_KEY_PEM_FILE = $signKey
+
+$tierLicenses = @{
+    community  = Join-Path $keysDir "dev-community.lic"
+    pro        = Join-Path $keysDir "dev-pro.lic"
+    enterprise = Join-Path $keysDir "dev-enterprise.lic"
+}
+
+foreach ($tier in @("community", "pro", "enterprise")) {
+    $outPath = $tierLicenses[$tier]
+    & uv run python $issuerScript `
+        --dbtier $tier `
+        --sub "maestro-$tier" `
+        --out $outPath `
+        --private-key-pem-file $signKey
+    if ($LASTEXITCODE -ne 0) {
+        Write-MaestroStep FAIL "JWT issue failed for tier=$tier"
+        exit 1
+    }
+}
+
+$failures = [System.Collections.Generic.List[string]]::new()
+$workRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("data-boar-lic-matrix-" + [guid]::NewGuid().ToString("n"))
+New-Item -ItemType Directory -Force -Path $workRoot | Out-Null
+
+try {
+    foreach ($tier in @("community", "pro", "enterprise")) {
+        $tierDir = Join-Path $workRoot $tier
+        New-Item -ItemType Directory -Force -Path $tierDir | Out-Null
+        $cfgPath = Join-Path $tierDir "config.yaml"
+        New-LicensingMatrixConfig `
+            -ConfigPath $cfgPath `
+            -LicensePath $tierLicenses[$tier] `
+            -PublicKeyPath $pubKey `
+            -WorkDir $tierDir `
+            -ApiPort $Port
+
+        $apiBundle = $null
+        try {
+            $apiBundle = Start-MatrixApiProcess -Root $RepoRoot -ConfigPath $cfgPath -ApiPort $Port -PublicKeyPath $pubKey
+            $baseUrl = "http://127.0.0.1:$Port"
+            if (-not (Wait-ApiHealth -BaseUrl $baseUrl -TimeoutSec $HealthTimeoutSec)) {
+                Add-MatrixAssertion -FailureList ([ref]$failures) -Tier $tier -CaseName "health" -Ok $false -Detail "API did not become healthy on $baseUrl"
+                continue
+            }
+
+            $pdfStatus = Invoke-ApiPostStatus -Url "$baseUrl/scan_pdf" -BodyJson "{}"
+            $scanSchedStatus = Invoke-ApiPostStatus -Url "$baseUrl/scan" -BodyJson '{"scheduled":true}'
+            $scanNormalStatus = Invoke-ApiPostStatus -Url "$baseUrl/scan" -BodyJson "{}"
+
+            if ($tier -eq "community") {
+                Add-MatrixAssertion -FailureList ([ref]$failures) -Tier $tier -CaseName "scan_pdf" -Ok ($pdfStatus -eq 403) -Detail "expected 403 got $pdfStatus"
+                Add-MatrixAssertion -FailureList ([ref]$failures) -Tier $tier -CaseName "scan_scheduled" -Ok ($scanSchedStatus -eq 403) -Detail "expected 403 got $scanSchedStatus"
+                Add-MatrixAssertion -FailureList ([ref]$failures) -Tier $tier -CaseName "scan_normal" -Ok (Test-StatusAllowed -StatusCode $scanNormalStatus -Allowed @(200, 202)) -Detail "expected 200/202 got $scanNormalStatus"
+            } else {
+                Add-MatrixAssertion -FailureList ([ref]$failures) -Tier $tier -CaseName "scan_pdf" -Ok (Test-StatusAllowed -StatusCode $pdfStatus -Allowed @(200, 202)) -Detail "expected 200/202 got $pdfStatus"
+                Add-MatrixAssertion -FailureList ([ref]$failures) -Tier $tier -CaseName "scan_scheduled" -Ok (Test-StatusAllowed -StatusCode $scanSchedStatus -Allowed @(200, 202)) -Detail "expected 200/202 got $scanSchedStatus"
+            }
+        } finally {
+            Stop-MatrixApiProcess -ApiBundle $apiBundle
+        }
+    }
+} finally {
+    Remove-Item -Recurse -Force $workRoot -ErrorAction SilentlyContinue
+}
+
+if ($failures.Count -eq 0) {
+    Write-MaestroStep PASS "licensing matrix assertions ok (community/pro/enterprise)"
+    exit 0
+}
+
+Write-MaestroStep FAIL ($failures -join "; ")
+exit 1

--- a/tests/test_api_route_matrix_plan_sync.py
+++ b/tests/test_api_route_matrix_plan_sync.py
@@ -62,6 +62,7 @@ EXPECTED_HTTP_ROUTES: tuple[str, ...] = (
     "POST /auth/webauthn/registration/verify",
     "POST /scan",
     "POST /scan_database",
+    "POST /scan_pdf",
     "POST /start",
     "POST /{locale_slug}/assessment",
     "POST /{locale_slug}/config",


### PR DESCRIPTION
## Summary
- Adds `scripts/maestro/Handle-LicensingMatrix.ps1`: issues community/pro/enterprise dev JWTs, starts a short-lived enforced-mode API per tier, and asserts tier gates on `POST /scan_pdf`, scheduled `POST /scan`, and normal `POST /scan` (community regression).
- Adds `POST /scan_pdf` API probe for `report_pdf` tier enforcement (202 when allowed, 403 when blocked).
- Maps `/scan_pdf` to reports RBAC when dashboard RBAC is enabled.

## Docs
No `docs/maestro/HANDLERS.md` index exists in-tree; handler is documented in the script CBH only.

## Test plan
- [x] `uv run pytest tests/test_maestro_scripts.py tests/test_licensing_feature_enforcement_mvp.py`
- [x] `.\scripts\lint-only.ps1`
- [x] Local handler run skips cleanly when signing key is absent
- [ ] Lab run with signing key under `~/.keys/data-boar/`

Closes #707
