### PR TITLE
fix(maestro): handle PS7 redirect exception and bypass locale middleware for JSON requests

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1014,6 +1014,8 @@ async def locale_html_middleware(request: Request, call_next):
     set locale preference cookie on successful HTML responses.
     Registered last so it runs first on incoming requests (outermost).
     """
+    if "application/json" in request.headers.get("accept", ""):
+        return await call_next(request)
     path = request.url.path
     if _is_api_or_asset_path(path):
         return await call_next(request)

--- a/docs/assets/diagrams/ADR-0062-diagram.mermaid.txt
+++ b/docs/assets/diagrams/ADR-0062-diagram.mermaid.txt
@@ -1,6 +1,6 @@
 flowchart TD
     OP["🧑 Operador\n(Banda Base — data bus)"]
-    CW["Claude Windows\nSonnet 4.6 — Auditor A\n(L14-Win, WSL2+W11)"]
+    CW["Claude Windows\nSonnet 4.6 — Auditor A\n(Win11-Dev, WSL2)"]
     CL["Claude Linux\nSonnet 4.6 — Auditor B\n(T14-Leitao, LMDE7/tmux)"]
     CT["Consenso Tático\nLinting de Prompt\n(convergência entre auditores)"]
     GG["Google Gemini\nValidador de Arquitetura\n(revisão estrutural independente)"]

--- a/docs/assets/diagrams/databoar-dmbok-diagrams.md
+++ b/docs/assets/diagrams/databoar-dmbok-diagrams.md
@@ -110,9 +110,9 @@ alinhamento da gestão de dados à governança de TI e corporativa.
 
 Esta norma não está ainda em `docs/COMPLIANCE_AND_LEGAL.md` — adicionar na próxima atualização.
 
-- ISO/IEC 38505: https://www.iso.org/standard/56639.html
-- ISO/IEC 38500: https://www.iso.org/standard/62816.html
-- DMBOK (DAMA): https://www.dama.org/cpages/body-of-knowledge
+- [ISO/IEC 38505](https://www.iso.org/standard/56639.html)
+- [ISO/IEC 38500](https://www.iso.org/standard/62816.html)
+- [DMBOK (DAMA)](https://www.dama.org/cpages/body-of-knowledge)
 
 ---
 

--- a/docs/assets/diagrams/databoar-dmbok-diagrams_1.md
+++ b/docs/assets/diagrams/databoar-dmbok-diagrams_1.md
@@ -110,9 +110,9 @@ alinhamento da gestão de dados à governança de TI e corporativa.
 
 Esta norma não está ainda em `docs/COMPLIANCE_AND_LEGAL.md` — adicionar na próxima atualização.
 
-- ISO/IEC 38505: https://www.iso.org/standard/56639.html
-- ISO/IEC 38500: https://www.iso.org/standard/62816.html
-- DMBOK (DAMA): https://www.dama.org/cpages/body-of-knowledge
+- [ISO/IEC 38505](https://www.iso.org/standard/56639.html)
+- [ISO/IEC 38500](https://www.iso.org/standard/62816.html)
+- [DMBOK (DAMA)](https://www.dama.org/cpages/body-of-knowledge)
 
 ---
 

--- a/docs/assets/diagrams/databoar-dmbok-diagrams_1.md
+++ b/docs/assets/diagrams/databoar-dmbok-diagrams_1.md
@@ -147,8 +147,8 @@ O DGA exige que dados compartilhados entre organizações sejam identificados, c
 
 **Para o repo:** adicionar em `docs/COMPLIANCE_AND_LEGAL.md` junto com ISO/IEC 38505 e DMBOK (issue #638).
 
-- DGA: https://digital-strategy.ec.europa.eu/en/policies/data-governance-act
-- EU Regulation 2022/868: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R0868
+- [DGA](https://digital-strategy.ec.europa.eu/en/policies/data-governance-act)
+- [EU Regulation 2022/868](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R0868)
 
 ---
 

--- a/docs/assets/diagrams/flowchart TD.txt
+++ b/docs/assets/diagrams/flowchart TD.txt
@@ -1,6 +1,6 @@
 flowchart TD
     OP["🧑 Operador\n(Banda Base — data bus)"]
-    CW["Claude Windows\nSonnet 4.6 — Auditor A\n(L14-Win, WSL2+W11)"]
+    CW["Claude Windows\nSonnet 4.6 — Auditor A\n(Win11-Dev, WSL2)"]
     CL["Claude Linux\nSonnet 4.6 — Auditor B\n(T14-Leitao, LMDE7/tmux)"]
     CT["Consenso Tático\nLinting de Prompt\n(convergência entre auditores)"]
     GG["Google Gemini\nValidador de Arquitetura\n(revisão estrutural independente)"]

--- a/scripts/maestro/Handle-LicensingMatrix.ps1
+++ b/scripts/maestro/Handle-LicensingMatrix.ps1
@@ -107,8 +107,10 @@ function Invoke-ApiPostStatus {
         -Uri $Url `
         -Method Post `
         -ContentType "application/json; charset=utf-8" `
+        -Headers @{ Accept = "application/json" } `
         -Body $BodyJson `
-        -SkipHttpErrorCheck
+        -SkipHttpErrorCheck `
+        -MaximumRedirection 0
     return [int]$response.StatusCode
 }
 
@@ -194,10 +196,16 @@ function Stop-MatrixApiProcess {
     }
     $proc = $ApiBundle.Process
     if (-not $proc.HasExited) {
-        try { $proc.Kill($true) } catch { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
+        & taskkill /F /T /PID $proc.Id 2>$null
         Start-Sleep -Seconds 2
     }
+    # belt-and-suspenders: kill whatever process still holds the port, then poll until free
     if ($ApiBundle.ApiPort) {
+        $portPid = (Get-NetTCPConnection -LocalPort $ApiBundle.ApiPort -State Listen -ErrorAction SilentlyContinue).OwningProcess
+        if ($portPid) {
+            Stop-Process -Id $portPid -Force -ErrorAction SilentlyContinue
+            Start-Sleep -Seconds 1
+        }
         $portFree = $false
         $deadline = (Get-Date).AddSeconds(8)
         while ((Get-Date) -lt $deadline) {

--- a/scripts/maestro/Handle-LicensingMatrix.ps1
+++ b/scripts/maestro/Handle-LicensingMatrix.ps1
@@ -103,15 +103,22 @@ function Invoke-ApiPostStatus {
         [string]$Url,
         [string]$BodyJson = "{}"
     )
-    $response = Invoke-WebRequest `
-        -Uri $Url `
-        -Method Post `
-        -ContentType "application/json; charset=utf-8" `
-        -Headers @{ Accept = "application/json" } `
-        -Body $BodyJson `
-        -SkipHttpErrorCheck `
-        -MaximumRedirection 0
-    return [int]$response.StatusCode
+    try {
+        $response = Invoke-WebRequest `
+            -Uri $Url `
+            -Method Post `
+            -ContentType "application/json; charset=utf-8" `
+            -Headers @{ Accept = "application/json" } `
+            -Body $BodyJson `
+            -SkipHttpErrorCheck `
+            -MaximumRedirection 0
+        return [int]$response.StatusCode
+    } catch {
+        if ($_.Exception.Message -match "[Rr]edirect") {
+            return 302
+        }
+        throw
+    }
 }
 
 function Test-StatusAllowed {


### PR DESCRIPTION
## Summary
- **Handle-LicensingMatrix.ps1:** wrap Invoke-ApiPostStatus in try/catch so PowerShell 7 returns 302 instead of throwing when -MaximumRedirection 0 hits a redirect.
- **api/routes.py:** early return in locale_html_middleware when Accept includes application/json, so Maestro POST /scan_pdf gets real 403/202 instead of a locale redirect.
- Also includes prior local commit 839395cf (taskkill /F /T process tree + port drain) not yet on origin/main.

Closes the scan_pdf 302 regression in Handle-LicensingMatrix.ps1.

## Test plan
- [ ] uv run pytest tests/test_maestro_scripts.py::test_all_maestro_powershell_scripts_parse -q
- [ ] pwsh -File .\scripts\maestro\Handle-LicensingMatrix.ps1 (with dev license keys present)
- [ ] Confirm POST /scan_pdf returns 403 (community) or 202 (pro/enterprise), not 302 or dashboard HTML

Made with [Cursor](https://cursor.com)