### PR TITLE
docs(workflow): today-mode 2026-05-29 + #756 lab-disk carryover

### DIFF
--- a/docs/ops/today-mode/OPERATOR_TODAY_MODE_2026-05-29.md
+++ b/docs/ops/today-mode/OPERATOR_TODAY_MODE_2026-05-29.md
@@ -1,0 +1,69 @@
+# Operator today mode — 2026-05-29 (carryover + effective focus)
+
+**Português (Brasil):** [OPERATOR_TODAY_MODE_2026-05-29.pt_BR.md](OPERATOR_TODAY_MODE_2026-05-29.pt_BR.md)
+
+**Note:** Drafted at **eod-sync** after **2026-05-28** — a lab node's disk is the first thing to size before product work. Host-specific detail lives in a **gitignored** private homelab note.
+
+**`main` anchor:** `2fdfbb11` — **#751** maestro PS7 redirect + locale-bypass merged; pitch 30/60/90 deploy-vs-maturity copy on **`main`**. Open PRs: **#664 #663 #662 #661 #660** (Dependabot), **#365** (kill-switch, draft), **#348** (Dependabot hatchling).
+
+---
+
+## Block 0 — Morning reality (10–15 min)
+
+Run **`carryover-sweep`** or **`.\scripts\operator-day-ritual.ps1 -Mode Morning`**. Then:
+
+1. **`origin/main`:** `git fetch` · `git status -sb` · `git pull origin main` when behind — confirm **`ci.yml`** green on **`main`** before deep work.
+2. **Open PRs:** `gh pr list --state open` — Dependabot batch (#660–#664) merge when green per **`.\scripts\pr-merge-when-green.ps1`**; skip **#365** while **DRAFT**.
+3. **Private stack:** evidence pushed at **2026-05-28 eod-sync** (lab disk note + complete_eval reports). If `docs/private/` changed overnight: **`.\scripts\private-git-sync.ps1 -Push`**.
+
+**Rolling queue:** [CARRYOVER.md](CARRYOVER.md) · **Published:** [PUBLISHED_SYNC.md](PUBLISHED_SYNC.md)
+
+---
+
+## START HERE — lab node disk — #756
+
+> **Begin with `du`/snapper sizing before any cleanup.** Host name + device + findings are in the **gitignored** private note (dated **2026-05-28**) under `docs/private/homelab/`.
+
+| Step | Action |
+| ---- | ------ |
+| 1 | SSH the lab node (host in the private manifest); `/` is **btrfs**, root **~90%** (~10 G free). `btrfs filesystem df /` → Data ~78.8 GiB used. |
+| 2 | **Needs sudo TTY** (`ssh -tt <node>` or local): `sudo snapper list-configs` · `sudo snapper -c root list` · `sudo btrfs subvolume list -t /`. |
+| 3 | If snapper snapshots are the bulk: review dates, `sudo snapper -c root delete <range>`; also clear the distro package cache (Void: `sudo xbps-remove -O`). |
+| 4 | Target **≥ 20 G free**; re-check `btrfs filesystem df /`; `btrfs balance start -dusage=50 /` if Data total stays inflated. |
+
+---
+
+## Carryover #756 (two pending items from 2026-05-28)
+
+| # | Item | State | Next |
+| - | ---- | ----- | ---- |
+| 1 | **bw CLI on a lab host** | Installed manually via `npm --prefix ~/.local` | Add to **Ansible playbook** (idempotent reprovision) — not yet done |
+| 2 | **lab node disk ~90%** | Sized: btrfs, ~78.8 GiB Data, ~10 G free | Snapper/subvolume diagnosis (sudo) → clean to ≥ 20 G — see private note |
+
+**See also #753** — `docs/plans/PLAN_CMDB_CI_RELATIONSHIP_IMPORT.md` **pending file creation** (confirmed absent on `main`). Scaffold and run **`python scripts/plans_hub_sync.py --write`** when picked up.
+
+---
+
+## Suggested focus (after lab disk)
+
+| Priority | Item | Notes |
+| -------- | ---- | ----- |
+| **Lab** | #756 disk | Free space before any completão/benchmark on that node |
+| **Ops** | #756 bw CLI | Ansible idempotence — small, closes the loop |
+| **Plans** | #753 | Create `PLAN_CMDB_CI_RELATIONSHIP_IMPORT.md`; run `python scripts/plans_hub_sync.py --write` |
+| **Deps** | #660–#664 | Dependabot batch — merge when green |
+
+---
+
+## End of day (**2026-05-29**)
+
+- **`eod-sync`** + **`private-stack-sync`** if private or social hub changed.
+- Tomorrow checklist path: **`OPERATOR_TODAY_MODE_2026-05-30.md`** (create at next **eod-sync** if missing).
+
+---
+
+## Quick references
+
+- Session keywords: **`.cursor/rules/session-mode-keywords.mdc`** (**`completao`**, **`eod-sync`**, **`private-stack-sync`**, **`homelab`**)
+- Private rhythm: `docs/private/TODAY_MODE_CARRYOVER_AND_FOUNDER_RHYTHM.md`
+- Lab disk note: gitignored under `docs/private/homelab/` (dated 2026-05-28)

--- a/docs/ops/today-mode/OPERATOR_TODAY_MODE_2026-05-29.pt_BR.md
+++ b/docs/ops/today-mode/OPERATOR_TODAY_MODE_2026-05-29.pt_BR.md
@@ -1,0 +1,69 @@
+# Modo de hoje do operador — 2026-05-29 (carryover + foco efetivo)
+
+**English:** [OPERATOR_TODAY_MODE_2026-05-29.md](OPERATOR_TODAY_MODE_2026-05-29.md)
+
+**Nota:** Rascunhado no **eod-sync** após **2026-05-28** — o disco de um nó do lab é a primeira coisa a dimensionar antes do trabalho de produto. Detalhes específicos do host ficam numa nota privada **gitignored**.
+
+**Âncora da `main`:** `2fdfbb11` — **#751** (maestro: redirect PS7 + bypass de locale) mergeado; texto de pitch 30/60/90 (deploy vs maturidade) na **`main`**. PRs abertos: **#664 #663 #662 #661 #660** (Dependabot), **#365** (kill-switch, draft), **#348** (Dependabot hatchling).
+
+---
+
+## Bloco 0 — Realidade da manhã (10–15 min)
+
+Rode **`carryover-sweep`** ou **`.\scripts\operator-day-ritual.ps1 -Mode Morning`**. Depois:
+
+1. **`origin/main`:** `git fetch` · `git status -sb` · `git pull origin main` se estiver atrás — confirme **`ci.yml`** verde na **`main`** antes de trabalho profundo.
+2. **PRs abertos:** `gh pr list --state open` — lote Dependabot (#660–#664) mergear quando verde via **`.\scripts\pr-merge-when-green.ps1`**; pular **#365** enquanto **DRAFT**.
+3. **Stack privado:** evidências enviadas no **eod-sync de 2026-05-28** (nota do disco do lab + relatórios complete_eval). Se `docs/private/` mudar durante a noite: **`.\scripts\private-git-sync.ps1 -Push`**.
+
+**Fila contínua:** [CARRYOVER.md](CARRYOVER.md) · **Publicado:** [PUBLISHED_SYNC.md](PUBLISHED_SYNC.md)
+
+---
+
+## COMECE AQUI — disco do nó do lab — #756
+
+> **Comece pelo `du`/snapper (dimensionar) antes de qualquer limpeza.** Nome do host + dispositivo + achados estão na nota privada **gitignored** (datada **2026-05-28**) em `docs/private/homelab/`.
+
+| Passo | Ação |
+| ----- | ---- |
+| 1 | SSH no nó do lab (host no manifesto privado); `/` é **btrfs**, raiz **~90%** (~10 G livres). `btrfs filesystem df /` → Data ~78,8 GiB usados. |
+| 2 | **Precisa sudo com TTY** (`ssh -tt <nó>` ou local): `sudo snapper list-configs` · `sudo snapper -c root list` · `sudo btrfs subvolume list -t /`. |
+| 3 | Se os snapshots do snapper forem o grosso: revisar datas, `sudo snapper -c root delete <faixa>`; também limpar o cache de pacotes da distro (Void: `sudo xbps-remove -O`). |
+| 4 | Meta **≥ 20 G livres**; reconferir `btrfs filesystem df /`; `btrfs balance start -dusage=50 /` se "Data total" continuar inflado. |
+
+---
+
+## Carryover #756 (dois itens pendentes de 2026-05-28)
+
+| # | Item | Estado | Próximo |
+| - | ---- | ------ | ------- |
+| 1 | **bw CLI num host do lab** | Instalado manualmente via `npm --prefix ~/.local` | Adicionar ao **playbook Ansible** (reprovisionamento idempotente) — ainda não feito |
+| 2 | **disco do nó do lab ~90%** | Dimensionado: btrfs, ~78,8 GiB Data, ~10 G livres | Diagnóstico snapper/subvolume (sudo) → limpar para ≥ 20 G — ver nota privada |
+
+**Ver também #753** — `docs/plans/PLAN_CMDB_CI_RELATIONSHIP_IMPORT.md` **pendente de criação** (confirmado ausente na `main`). Criar e rodar **`python scripts/plans_hub_sync.py --write`** quando for retomado.
+
+---
+
+## Foco sugerido (depois do disco do lab)
+
+| Prioridade | Item | Notas |
+| ---------- | ---- | ----- |
+| **Lab** | #756 disco | Liberar espaço antes de qualquer completão/benchmark nesse nó |
+| **Ops** | #756 bw CLI | Idempotência no Ansible — pequeno, fecha o ciclo |
+| **Plans** | #753 | Criar `PLAN_CMDB_CI_RELATIONSHIP_IMPORT.md`; rodar `python scripts/plans_hub_sync.py --write` |
+| **Deps** | #660–#664 | Lote Dependabot — mergear quando verde |
+
+---
+
+## Fim do dia (**2026-05-29**)
+
+- **`eod-sync`** + **`private-stack-sync`** se o stack privado ou o hub social mudarem.
+- Caminho do checklist de amanhã: **`OPERATOR_TODAY_MODE_2026-05-30.md`** (criar no próximo **eod-sync** se faltar).
+
+---
+
+## Referências rápidas
+
+- Palavras-chave de sessão: **`.cursor/rules/session-mode-keywords.mdc`** (**`completao`**, **`eod-sync`**, **`private-stack-sync`**, **`homelab`**)
+- Ritmo privado: `docs/private/TODAY_MODE_CARRYOVER_AND_FOUNDER_RHYTHM.md`
+- Nota do disco do lab: gitignored em `docs/private/homelab/` (datada 2026-05-28)


### PR DESCRIPTION
## Summary
- Adds **OPERATOR_TODAY_MODE_2026-05-29** (EN + pt-BR) prepared at eod-sync after 2026-05-28.
- **START HERE:** lab node btrfs root ~90% full (#756 item 2) — sized via SSH; snapper/subvolume diagnosis pending sudo TTY. Host/device specifics kept in a gitignored private homelab note per PII policy.
- Carryover #756 item 1: bw CLI installed manually on a lab host → add to Ansible playbook.
- References #753 (PLAN_CMDB_CI_RELATIONSHIP_IMPORT.md still pending file creation).

## Test plan
- [x] .\scripts\lint-only.ps1 (markdown, pt-BR locale, PII seed gate all pass)

Made with [Cursor](https://cursor.com)