### PR TITLE
docs(adr): normalize Related docs to table format (#572)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -83,12 +83,14 @@ Short, durable notes that capture **why** the project chose an approach—not on
 
 ## Related docs
 
-- [CONTRIBUTING.md](../../CONTRIBUTING.md) — contributor workflow; links MD029 and the fix script.
-- [SECURITY.md](../../SECURITY.md) · [docs/TECH_GUIDE.md](../TECH_GUIDE.md) — operator entry points ([ADR 0002](ADR-0002-operator-facing-security-and-technical-docs.md)).
-- [QUALITY_WORKFLOW_RECOMMENDATIONS.md](../QUALITY_WORKFLOW_RECOMMENDATIONS.md) — §6 (MD029), §7 (ADRs), SBOM.
-- [docs/ops/WORKFLOW_DEFERRED_FOLLOWUPS.md](../ops/WORKFLOW_DEFERRED_FOLLOWUPS.md) — deferred workflow/supply-chain notes ([ADR 0005](ADR-0005-ci-github-actions-supply-chain-pins.md) for Action/uv pinning).
-- [.cursor/rules/markdown-lint.mdc](../../.cursor/rules/markdown-lint.mdc) — when to run `fix_markdown_sonar.py` and post-script renumbering.
-- [.cursor/rules/audience-segmentation-docs.mdc](../../.cursor/rules/audience-segmentation-docs.mdc) — external vs internal doc links; [ADR 0004](ADR-0004-external-docs-no-markdown-links-to-plans.md).
+| Doc | Notes |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| [CONTRIBUTING.md](../../CONTRIBUTING.md) | contributor workflow; links MD029 and the fix script. |
+| [SECURITY.md](../../SECURITY.md) · [docs/TECH_GUIDE.md](../TECH_GUIDE.md) | operator entry points ([ADR 0002](ADR-0002-operator-facing-security-and-technical-docs.md)). |
+| [QUALITY_WORKFLOW_RECOMMENDATIONS.md](../QUALITY_WORKFLOW_RECOMMENDATIONS.md) | §6 (MD029), §7 (ADRs), SBOM. |
+| [docs/ops/WORKFLOW_DEFERRED_FOLLOWUPS.md](../ops/WORKFLOW_DEFERRED_FOLLOWUPS.md) | deferred workflow/supply-chain notes ([ADR 0005](ADR-0005-ci-github-actions-supply-chain-pins.md) for Action/uv pinning). |
+| [.cursor/rules/markdown-lint.mdc](../../.cursor/rules/markdown-lint.mdc) | when to run `fix_markdown_sonar.py` and post-script renumbering. |
+| [.cursor/rules/audience-segmentation-docs.mdc](../../.cursor/rules/audience-segmentation-docs.mdc) | external vs internal doc links; [ADR 0004](ADR-0004-external-docs-no-markdown-links-to-plans.md). |
 
 ## Documentation index
 


### PR DESCRIPTION
## What

Normalize the **Related docs** section of `docs/adr/README.md` from a bullet list to a GFM pipe table, matching the table style already used by the **Index** table in the same file.

Closes #572

## Scope self-check

Scope check: edited only adr/README.md ✅ | content unchanged ✅ | format-only ✅

- Diff is **bullet → table conversion only** (8 insertions / 6 deletions).
- Every link target and description text preserved **verbatim** (CONTRIBUTING, SECURITY · TECH_GUIDE, QUALITY_WORKFLOW_RECOMMENDATIONS, WORKFLOW_DEFERRED_FOLLOWUPS, markdown-lint.mdc, audience-segmentation-docs.mdc).
- **No reorder:** the Index table sorts by ADR number; that ordering does not apply to Related docs (they are topical, not ADRs), so the original bullet order was kept.
- Verified against the doc-format ADR (**ADR-0045**, *ADR metadata and format standardization*): it governs ADR **file** structure, not this README section, so no convention conflict.

## Headers note (for reviewer awareness)

The task asked for "same headers" as the Index table. The Index headers are `ADR | Title | Status`, which are semantically specific to the ADR list — reusing them for Related docs would require inventing ADR numbers/statuses for non-ADR docs, which **would alter content**. To respect "do not alter content", I matched the **table format / alignment style** (GFM pipe table, left-aligned, header + separator row) with content-appropriate headers `Doc | Notes`. Flagging explicitly per the scope contract.

## Content issues noticed but NOT touched (operator triage)

These are pre-existing in the file and intentionally left untouched (out of scope for a format-only PR):

1. **Index numbering gaps:** `0058 → 0061` (no 0059, 0060) and `0062 → 0066` (no 0063, 0064, 0065). Either some ADRs are unlisted or numbers were skipped.
2. **Title duplication for 0061 / 0062 / 0066:** those rows repeat the number inside the Title cell (e.g. `[ADR-0061 U-axis ...]`, `[ADR-0062 Agent containment ...]`), unlike all other rows whose titles omit the leading `ADR-NNNN`.
3. **Index separator padding drift:** earlier rows use heavily padded separators; rows from ~0024 onward use compact ones (cosmetic only).
4. **EOF / table-style lint (editor):** IDE markdownlint reports `MD060/table-column-style` on the existing Convention + Index tables and a possible trailing-blank `MD012` at EOF. These are pre-existing and **not** enforced by CI `tests/test_markdown_lint.py` (which does not check table pipe alignment).

## CI / lint

`tests/test_markdown_lint.py` does not check table pipe alignment (`_check_table_pipe_space` is a no-op; its MD060 covers code-fence markers, not tables), so this change introduces no new markdown-lint failures. The new table follows the same style as the existing Index table.
