### PR TITLE
feat(grc): optional nist_csf_function_hint (CSF 2.0)

### DIFF
--- a/docs/GRC_EXECUTIVE_REPORT_SCHEMA.md
+++ b/docs/GRC_EXECUTIVE_REPORT_SCHEMA.md
@@ -32,7 +32,7 @@
 | **`detailed_findings`** | Array of **risk-matrix rows** (see §3). |
 | **`recommendations`** | Prioritised actions: **`id`**, **`priority`** (e.g. P0–P3), **`action`**, **`estimated_effort`**, **`regulatory_impact_note`** (worded as **hypothesis** for DPO workshop, not a sanction prediction). |
 
-Optional future blocks (non-breaking additions): **`data_lineage_notes`**, **`tooling_limits`**, **`operator_attestation`**, **`integrity_reference`** (hash of config + session).
+Optional future blocks (non-breaking additions): **`data_lineage_notes`**, **`tooling_limits`**, **`operator_attestation`**, **`integrity_reference`** (hash of config + session). A shipped, **non-breaking** per-finding **`nist_csf_function_hint`** (plus the matching `compliance_mapping` disclaimer keys) is described in **§3.3**.
 
 ---
 
@@ -54,6 +54,7 @@ Each element should be sufficient for a **CISO one-pager row** and a **DPO triag
 | **`location_summary`** | string | Column, file path pattern, or API field class — **metadata**. |
 | **`violation_desc`** | string | **Technical** description (e.g. “high-density CPF-like tokens without field-level encryption signal in this scan configuration”). Avoid stating legal breach as fact. |
 | **`norm_tags`** | array of strings | Pass-through from findings / config (see [COMPLIANCE_METHODOLOGY.md](COMPLIANCE_METHODOLOGY.md)). |
+| **`nist_csf_function_hint`** | array of strings | **Optional, non-breaking.** Short **NIST CSF 2.0** codes (e.g. `"GV"`, `"ID.AM"`, `"PR.DS"`) derived from `norm_tags` via a **versioned shipped table** (`report/nist_csf_mapping.yaml`). **Heuristic hint, not a compliance determination** (see §3.3 and [ADR 0025](adr/ADR-0025-compliance-positioning-evidence-inventory-not-legal-conclusion-engine.md)). **Omitted** when no `norm_tag` maps — never an empty array. |
 | **`remediation_priority`** | string | e.g. `CRITICAL` / `HIGH` / `MEDIUM` / `LOW` — mapped from **adjusted** `risk_score` and operator overrides. |
 | **`regulatory_impact`** | string | **Business / legal workshop wording** for this row (e.g. candidate articles, administrative-risk framing). **Not** an automated legal conclusion; **counsel / DPO** must validate. Empty string is allowed when the integrator has no vetted sentence yet. |
 
@@ -83,6 +84,26 @@ When the Python consolidator is called with **`lgpd_density=LgpdDensityRiskConfi
 **Extra JSON fields (density mode only):** **`risk_density_raw`**, **`risk_density_scaled_cap`**, **`risk_density_breakdown`** (per-type lines: `pii_type`, `count`, **`risk_category`** (`IDENTIFIER` / `FINANCIAL` / `SENSITIVE` / `CHILD_DATA` — from ``core.intelligence``), `taxonomy`, `weight`, `line_score`), **`risk_density_taxonomy_version`**, **`dominant_risk_taxonomy`**. These fields justify *why* an asset scores high without embedding raw values.
 
 **Not legal classification:** substring mapping from detector labels is a **starting taxonomy**; operators may override weights or caps per engagement in future versions.
+
+### 3.3 Optional **NIST CSF 2.0** function hint (non-breaking)
+
+CISOs often reason in **NIST CSF 2.0** *Functions* (Govern, Identify, Protect, Detect, Respond, Recover). To let a dashboard or PDF **filter findings by CSF function** without bumping the contract, each `detailed_findings[]` row **may** carry an **optional** array of short CSF codes:
+
+| Field | Type | Notes |
+| ----- | ---- | ----- |
+| **`nist_csf_function_hint`** | array of strings | Short CSF 2.0 codes — **Function** (`"GV"`, `"ID"`, …) or **Function.Category** (`"ID.AM"`, `"PR.DS"`). Sorted in canonical order **GV, ID, PR, DE, RS, RC**. Present only when at least one `norm_tag` maps. |
+
+**Where the mapping lives (versioned, shipped — not hard-coded):** `report/nist_csf_mapping.yaml` (`mapping_version`, e.g. `nist_csf_2_0_hint_v1`). It maps `norm_tag` substrings to CSF codes — same model as the **article hints** (§4) and the [compliance-samples/](compliance-samples/) profiles. The reference consolidator `report/grc_reporter.py` derives the hint from `norm_tags`; the loader is `report/nist_csf_hints.py`.
+
+**Disclaimer location (ADR-0025):** so each row stays a plain array of codes, the heuristic disclaimer and mapping version are surfaced **once** in `compliance_mapping` (emitted only when at least one finding carries the hint):
+
+| `compliance_mapping` key | Meaning |
+| ----- | ----- |
+| **`nist_csf_function_hint_method`** | e.g. `heuristic_norm_tag_to_csf_v1`. |
+| **`nist_csf_mapping_version`** | Version string from the shipped table. |
+| **`nist_csf_function_hint_disclaimer`** | Plain-language **hint, not a compliance determination or control attestation** ([ADR 0025](adr/ADR-0025-compliance-positioning-evidence-inventory-not-legal-conclusion-engine.md)); CISO/DPO validates. |
+
+**Non-breaking:** this is an **additive optional** field — `schema_version` stays `data_boar_grc_executive_report_v1`; consumers that ignore unknown keys are unaffected. **Scope:** NIST CSF 2.0 **only** (no COBIT/SOC 2/ISO mapping here). For the **prose** tri-level positioning (NIST CSF / SANS / ISO 27035) see the related documentation discussion; this field is the **structured** complement that makes the artefact *carry* the CSF tag.
 
 ---
 

--- a/docs/GRC_EXECUTIVE_REPORT_SCHEMA.pt_BR.md
+++ b/docs/GRC_EXECUTIVE_REPORT_SCHEMA.pt_BR.md
@@ -49,6 +49,7 @@ Cada elemento deve bastar para **uma linha do one-pager do CISO** e para **fila 
 | **`heatmap_quadrant`** | string | Um de `impact_high_likelihood_high`, `impact_high_likelihood_low`, `impact_low_likelihood_high`, `impact_low_likelihood_low` — limiar **50** em cada eixo na implementação de referência. |
 | **`pii_types`** | vetor | `type`, `count`, `exposure` — só metadados. |
 | **`location_summary`**, **`violation_desc`**, **`norm_tags`**, **`remediation_priority`** | — | Igual à versão EN; `violation_desc` permanece **técnica**, sem afirmar ilícito como fato. |
+| **`nist_csf_function_hint`** | vetor de strings | **Opcional, non-breaking.** Códigos curtos do **NIST CSF 2.0** (ex.: `"GV"`, `"ID.AM"`, `"PR.DS"`) derivados de `norm_tags` por uma **tabela versionada e shipped** (`report/nist_csf_mapping.yaml`). **Indício heurístico, não conclusão de conformidade** (ver §3.3 e [ADR 0025](adr/ADR-0025-compliance-positioning-evidence-inventory-not-legal-conclusion-engine.md)). **Omitido** quando nenhum `norm_tag` mapeia — nunca vetor vazio. |
 | **`regulatory_impact`** | string | Frase de **negócio / oficina jurídica** por linha (ex.: artigos candidatos, enquadramento de risco administrativo). **Não** é conclusão jurídica automática; **jurídico / DPO** valida. Pode ser string vazia. |
 
 **Severidade sensível ao contexto:** o mesmo perfil de **`pii_types`** pode implicar **`risk_score`** diferente quando **`asset_class`** é log *append-only* versus repositório de identidade — ver **[`COMPLETAO_OPERATOR_PROMPT_LIBRARY.pt_BR.md`](ops/COMPLETAO_OPERATOR_PROMPT_LIBRARY.pt_BR.md)**.
@@ -60,6 +61,26 @@ Cada elemento deve bastar para **uma linha do one-pager do CISO** e para **fila 
 ### 3.2 Densidade de risco alinhada à LGPD (campos opcionais por linha)
 
 Com **`lgpd_density=LgpdDensityRiskConfig(...)`** em **`GRCReporter.add_finding`** / **`add_detailed_finding`**, o **`risk_score`** vem de **`report.grc_risk_taxonomy`**: tabela **identificadores (10)** / **financeiros_gov (30)** / **sensitive (80)** / **infantil (100)** por unidade contada, fórmula **Σ(count × peso)**, escala 0–100 com **`cap_raw`** padrão **2500** (ajustável). Campos extras: **`risk_density_raw`**, **`risk_density_scaled_cap`**, **`risk_density_breakdown`** (inclui **`risk_category`**: ``IDENTIFIER`` / ``FINANCIAL`` / ``SENSITIVE`` / ``CHILD_DATA`` vindo de **`core/intelligence`**), **`risk_density_taxonomy_version`**, **`dominant_risk_taxonomy`** — ver tabela e fórmulas na versão EN (§3.2). **Não** é classificação jurídica automática; **DPO/jurídico** valida rótulos e pesos por contrato.
+
+### 3.3 *Hint* opcional de função **NIST CSF 2.0** (non-breaking)
+
+CISOs costumam raciocinar pelas *Functions* do **NIST CSF 2.0** (Govern, Identify, Protect, Detect, Respond, Recover). Para um *dashboard* ou PDF **filtrar findings por função CSF** sem alterar o contrato, cada linha de `detailed_findings[]` **pode** carregar um vetor **opcional** de códigos curtos:
+
+| Campo | Tipo | Notas |
+| ----- | ---- | ----- |
+| **`nist_csf_function_hint`** | vetor de strings | Códigos CSF 2.0 — **Function** (`"GV"`, `"ID"`, …) ou **Function.Category** (`"ID.AM"`, `"PR.DS"`). Ordem canônica **GV, ID, PR, DE, RS, RC**. Presente só quando ao menos um `norm_tag` mapeia. |
+
+**Onde fica o mapeamento (versionado e shipped — não hard-coded):** `report/nist_csf_mapping.yaml` (`mapping_version`, ex.: `nist_csf_2_0_hint_v1`). Mapeia substrings de `norm_tag` para códigos CSF — mesmo modelo dos **article hints** (§4) e dos perfis [compliance-samples/](compliance-samples/). O consolidador `report/grc_reporter.py` deriva o *hint* de `norm_tags`; o *loader* é `report/nist_csf_hints.py`.
+
+**Local do disclaimer (ADR-0025):** para cada linha continuar um vetor simples de códigos, o disclaimer heurístico e a versão da tabela aparecem **uma vez** em `compliance_mapping` (emitidos só quando ao menos um finding carrega o *hint*):
+
+| Chave em `compliance_mapping` | Significado |
+| ----- | ----- |
+| **`nist_csf_function_hint_method`** | Ex.: `heuristic_norm_tag_to_csf_v1`. |
+| **`nist_csf_mapping_version`** | Versão da tabela shipped. |
+| **`nist_csf_function_hint_disclaimer`** | Em linguagem clara: **indício, não conclusão de conformidade nem atestado de controle** ([ADR 0025](adr/ADR-0025-compliance-positioning-evidence-inventory-not-legal-conclusion-engine.md)); CISO/DPO valida. |
+
+**Non-breaking:** campo **opcional aditivo** — `schema_version` continua `data_boar_grc_executive_report_v1`; consumidores que ignoram chaves desconhecidas não são afetados. **Escopo:** apenas NIST CSF 2.0 (sem COBIT/SOC 2/ISO aqui). O posicionamento tri-nível em **prosa** (NIST CSF / SANS / ISO 27035) é o complemento textual; este campo é o complemento **estruturado** que faz o artefato *carregar* a tag CSF.
 
 ---
 

--- a/report/grc_reporter.py
+++ b/report/grc_reporter.py
@@ -17,6 +17,7 @@ from typing import Any, Literal
 
 from core.about import get_about_info
 
+from report import nist_csf_hints
 from report.grc_risk_taxonomy import (
     DENSITY_TAXONOMY_VERSION,
     LgpdDensityRiskConfig,
@@ -25,6 +26,8 @@ from report.grc_risk_taxonomy import (
 
 SCHEMA_VERSION = "data_boar_grc_executive_report_v1"
 COMPLIANCE_SCORE_METHOD = "heuristic_v1_weighted_excess_risk"
+# Method label for the optional NIST CSF 2.0 function-hint block (see issue #760).
+NIST_CSF_HINT_METHOD = "heuristic_norm_tag_to_csf_v1"
 
 RiskLevel = Literal["LOW", "MEDIUM", "HIGH", "CRITICAL"]
 RemediationPriority = Literal["CRITICAL", "HIGH", "MEDIUM", "LOW"]
@@ -323,7 +326,32 @@ class GRCReporter:
             "regulatory_impact": str(regulatory_impact or ""),
         }
         row.update(density_meta)
+        # Optional, non-breaking NIST CSF 2.0 function hint (issue #760): derived from
+        # ``norm_tags`` via the shipped, versioned mapping table. Heuristic only, never a
+        # compliance determination (ADR-0025); omit the field entirely when nothing maps.
+        csf_hint = nist_csf_hints.csf_functions_for_norm_tags(row["norm_tags"])
+        if csf_hint:
+            row["nist_csf_function_hint"] = csf_hint
+            self._ensure_nist_csf_hint_meta()
         self._detailed_findings.append(row)
+
+    def _ensure_nist_csf_hint_meta(self) -> None:
+        """
+        Surface the CSF-hint disclaimer + mapping version once in ``compliance_mapping``.
+
+        Keeps each ``detailed_findings`` row a plain array of short codes while the
+        ADR-0025 disclaimer stays visible next to the other framework hints. Called only
+        when at least one finding carries a ``nist_csf_function_hint``.
+        """
+        if "nist_csf_mapping_version" in self._compliance_mapping:
+            return
+        self._compliance_mapping["nist_csf_function_hint_method"] = NIST_CSF_HINT_METHOD
+        self._compliance_mapping["nist_csf_mapping_version"] = (
+            nist_csf_hints.mapping_version()
+        )
+        self._compliance_mapping["nist_csf_function_hint_disclaimer"] = (
+            nist_csf_hints.disclaimer()
+        )
 
     def add_finding(
         self,

--- a/report/nist_csf_hints.py
+++ b/report/nist_csf_hints.py
@@ -1,0 +1,110 @@
+"""
+Heuristic NIST CSF 2.0 *function hints* for GRC findings (CISO/DPO-facing).
+
+Maps finding ``norm_tag`` strings to short NIST CSF 2.0 codes (e.g. ``"GV"``,
+``"ID.AM"``, ``"PR.DS"``) using a **versioned, shipped** mapping table
+(``report/nist_csf_mapping.yaml``) — never hard-coded "truth" in code.
+
+These are **hints**, not a compliance determination, control attestation, or legal
+conclusion (ADR-0025). The CISO/DPO validates applicability and maturity. The mapping
+complements the article hints documented in ``docs/GRC_EXECUTIVE_REPORT_SCHEMA.md`` and
+the tri-level positioning discussion in issue #749 (NIST CSF / SANS / ISO 27035).
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_MAPPING_PATH = Path(__file__).resolve().parent / "nist_csf_mapping.yaml"
+
+# Fallbacks used only when the YAML cannot be read; keep behaviour safe (no hints)
+# rather than raising into the report pipeline.
+_FALLBACK_MAPPING_VERSION = "nist_csf_2_0_hint_v1"
+_FALLBACK_DISCLAIMER = (
+    "NIST CSF 2.0 function codes are heuristic hints derived from finding norm tags, "
+    "not a compliance determination or control attestation (ADR-0025). "
+    "CISO/DPO validates applicability and maturity."
+)
+
+# Canonical CSF 2.0 Function ordering for stable, reviewable output.
+_FUNCTION_ORDER = {"GV": 0, "ID": 1, "PR": 2, "DE": 3, "RS": 4, "RC": 5}
+
+
+def _csf_sort_key(code: str) -> tuple[int, str]:
+    """Sort CSF codes by Function order (GV, ID, PR, DE, RS, RC), then alphabetically."""
+    function = code.split(".", 1)[0].upper()
+    return (_FUNCTION_ORDER.get(function, 99), code.upper())
+
+
+@lru_cache(maxsize=1)
+def _load_mapping() -> dict[str, Any]:
+    """Load and cache the shipped YAML mapping table (safe defaults on failure)."""
+    try:
+        raw = _MAPPING_PATH.read_text(encoding="utf-8")
+        data = yaml.safe_load(raw)
+    except (OSError, yaml.YAMLError):
+        return {
+            "mapping_version": _FALLBACK_MAPPING_VERSION,
+            "disclaimer": "",
+            "rules": [],
+        }
+    if not isinstance(data, dict):
+        return {
+            "mapping_version": _FALLBACK_MAPPING_VERSION,
+            "disclaimer": "",
+            "rules": [],
+        }
+
+    rules_out: list[tuple[str, list[str]]] = []
+    for item in data.get("rules") or []:
+        if not isinstance(item, dict):
+            continue
+        match = str(item.get("match", "")).strip().lower()
+        codes = item.get("csf")
+        if not match or not isinstance(codes, list):
+            continue
+        clean_codes = [str(c).strip() for c in codes if str(c).strip()]
+        if clean_codes:
+            rules_out.append((match, clean_codes))
+
+    version = str(data.get("mapping_version") or _FALLBACK_MAPPING_VERSION)
+    disclaimer = str(data.get("disclaimer") or _FALLBACK_DISCLAIMER).strip()
+    return {"mapping_version": version, "disclaimer": disclaimer, "rules": rules_out}
+
+
+def mapping_version() -> str:
+    """Return the shipped mapping table version (e.g. ``nist_csf_2_0_hint_v1``)."""
+    return str(_load_mapping()["mapping_version"])
+
+
+def disclaimer() -> str:
+    """Return the ADR-0025 heuristic disclaimer for the CSF hint block."""
+    text = str(_load_mapping()["disclaimer"]).strip()
+    return text or _FALLBACK_DISCLAIMER
+
+
+def csf_functions_for_norm_tags(norm_tags: list[str] | None) -> list[str]:
+    """
+    Return heuristic NIST CSF 2.0 codes for the given ``norm_tags`` (sorted, de-duplicated).
+
+    Returns an empty list when no norm_tag matches a mapping rule — callers should then
+    **omit** the ``nist_csf_function_hint`` field rather than emit an empty array.
+    """
+    if not norm_tags:
+        return []
+    rules = _load_mapping()["rules"]
+    if not rules:
+        return []
+    found: set[str] = set()
+    for tag in norm_tags:
+        norm = str(tag or "").strip().lower()
+        if not norm:
+            continue
+        for match, codes in rules:
+            if match in norm:
+                found.update(codes)
+    return sorted(found, key=_csf_sort_key)

--- a/report/nist_csf_mapping.yaml
+++ b/report/nist_csf_mapping.yaml
@@ -1,0 +1,87 @@
+# NIST CSF 2.0 function hint mapping (heuristic, non-authoritative)
+#
+# Maps Data Boar finding ``norm_tag`` strings to short NIST CSF 2.0 codes
+# (Function or Function.Category), e.g. "GV", "ID.AM", "PR.DS".
+#
+# IMPORTANT (ADR-0025): these are *hints for CISO/DPO workshop use*, derived from
+# finding metadata only. They are NOT a compliance determination, control
+# attestation, or legal conclusion. The CISO/DPO validates applicability.
+#
+# Why this table is versioned and shipped (not hard-coded): same model as the
+# ``docs/compliance-samples/*.yaml`` profiles and the article-hint tables referenced
+# in ``docs/GRC_EXECUTIVE_REPORT_SCHEMA.md`` (section 4). Counsel-facing "truth" must
+# never live in code comments; mapping decisions live here so they can be reviewed,
+# diffed, and re-versioned without touching the consolidator.
+#
+# Alignment with #749 (tri-level NIST CSF / SANS / ISO 27035 positioning):
+#   - Discovering where personal data lives is primarily an **Identify** activity
+#     (ID.AM — Asset Management: build the data inventory before an incident).
+#   - Protecting that data maps to **Protect** (PR.DS — Data Security).
+#   - Special-category / minor data raises **Govern** attention (GV — policy,
+#     oversight, risk acceptance) on top of inventory and data security.
+#
+# Matching contract (see report/nist_csf_hints.py):
+#   - ``match`` is a case-insensitive substring tested against each norm_tag.
+#   - All rules whose ``match`` is contained in a norm_tag contribute their codes.
+#   - Codes are de-duplicated and sorted in canonical CSF order (GV, ID, PR, DE, RS, RC).
+#   - A norm_tag that matches no rule contributes nothing; a finding with no matched
+#     code omits ``nist_csf_function_hint`` entirely (never emit an empty array).
+
+mapping_version: "nist_csf_2_0_hint_v1"
+
+# Short, human-readable disclaimer surfaced once in compliance_mapping by the reporter.
+disclaimer: >-
+  NIST CSF 2.0 function codes here are heuristic hints derived from finding norm tags,
+  not a compliance determination or control attestation (ADR-0025). CISO/DPO validates
+  applicability and maturity.
+
+rules:
+  # --- Ordinary personal data (inventory + data security) ---
+  - match: "lgpd art"
+    csf: ["ID.AM", "PR.DS"]
+  - match: "gdpr art"
+    csf: ["ID.AM", "PR.DS"]
+  - match: "personal data"
+    csf: ["ID.AM", "PR.DS"]
+  - match: "dados pessoais"
+    csf: ["ID.AM", "PR.DS"]
+
+  # --- Special-category / sensitive data (add Govern attention) ---
+  - match: "art. 11"
+    csf: ["GV", "ID.AM", "PR.DS"]
+  - match: "sensitive"
+    csf: ["GV", "ID.AM", "PR.DS"]
+  - match: "health"
+    csf: ["GV", "ID.AM", "PR.DS"]
+  - match: "saude"
+    csf: ["GV", "ID.AM", "PR.DS"]
+  - match: "biometric"
+    csf: ["GV", "ID.AM", "PR.DS"]
+  - match: "genetic"
+    csf: ["GV", "ID.AM", "PR.DS"]
+  - match: "religio"
+    csf: ["GV", "ID.AM", "PR.DS"]
+  - match: "politic"
+    csf: ["GV", "ID.AM", "PR.DS"]
+  - match: "racial"
+    csf: ["GV", "ID.AM", "PR.DS"]
+  - match: "sexual"
+    csf: ["GV", "ID.AM", "PR.DS"]
+
+  # --- Minor / child data (heightened governance) ---
+  - match: "minor"
+    csf: ["GV", "ID.AM", "PR.DS"]
+  - match: "child"
+    csf: ["GV", "ID.AM", "PR.DS"]
+  - match: "infantil"
+    csf: ["GV", "ID.AM", "PR.DS"]
+  - match: "coppa"
+    csf: ["GV", "ID.AM", "PR.DS"]
+
+  # --- Ambiguous / needs manual confirmation (inventory hint only) ---
+  - match: "ambiguous"
+    csf: ["ID.AM"]
+  - match: "suggested review"
+    csf: ["ID.AM"]
+  - match: "confirm manually"
+    csf: ["ID.AM"]

--- a/tests/test_nist_csf_hints.py
+++ b/tests/test_nist_csf_hints.py
@@ -1,0 +1,94 @@
+"""
+Tests for ``report.nist_csf_hints`` and the optional ``nist_csf_function_hint`` field
+emitted by ``report.grc_reporter.GRCReporter`` (issue #760).
+
+Scope: NIST CSF 2.0 **only**, heuristic hints (ADR-0025) derived from a versioned,
+shipped mapping table (``report/nist_csf_mapping.yaml``). The field is non-breaking and
+omitted when no norm_tag maps.
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from report import nist_csf_hints
+from report.grc_reporter import NIST_CSF_HINT_METHOD, GRCReporter
+
+
+def test_mapping_version_and_disclaimer() -> None:
+    assert nist_csf_hints.mapping_version() == "nist_csf_2_0_hint_v1"
+    disc = nist_csf_hints.disclaimer()
+    assert disc
+    assert "ADR-0025" in disc
+
+
+def test_shipped_mapping_yaml_is_well_formed() -> None:
+    raw = nist_csf_hints._MAPPING_PATH.read_text(encoding="utf-8")
+    data = yaml.safe_load(raw)
+    assert isinstance(data, dict)
+    assert data["mapping_version"] == "nist_csf_2_0_hint_v1"
+    assert isinstance(data["rules"], list) and data["rules"]
+    for rule in data["rules"]:
+        assert "match" in rule and str(rule["match"]).strip()
+        assert isinstance(rule["csf"], list) and rule["csf"]
+
+
+@pytest.mark.parametrize(
+    "norm_tags, expected",
+    [
+        (["LGPD Art. 5"], ["ID.AM", "PR.DS"]),
+        (["GDPR Art. 4(1)"], ["ID.AM", "PR.DS"]),
+        (["Personal data context"], ["ID.AM", "PR.DS"]),
+        (["Health/insurance context"], ["GV", "ID.AM", "PR.DS"]),
+        (["PII_AMBIGUOUS"], ["ID.AM"]),
+        (["TAG_A"], []),
+        ([], []),
+        (None, []),
+    ],
+)
+def test_csf_functions_for_norm_tags(
+    norm_tags: list[str] | None, expected: list[str]
+) -> None:
+    assert nist_csf_hints.csf_functions_for_norm_tags(norm_tags) == expected
+
+
+def test_csf_codes_dedup_and_canonical_order() -> None:
+    # Union of personal (ID.AM, PR.DS) + sensitive (GV, ID.AM, PR.DS), sorted GV<ID<PR.
+    result = nist_csf_hints.csf_functions_for_norm_tags(
+        ["LGPD Art. 5", "Health/insurance context"]
+    )
+    assert result == ["GV", "ID.AM", "PR.DS"]
+
+
+def test_reporter_emits_csf_hint_when_mapped() -> None:
+    r = GRCReporter("scope", report_id="DB-CSF01")
+    r.add_finding(
+        "db:lab:dbo.clients",
+        [{"type": "CPF", "count": 3}],
+        80.0,
+        norm_tags=["LGPD Art. 5"],
+    )
+    data = r.to_dict()
+    row = data["detailed_findings"][0]
+    assert row["nist_csf_function_hint"] == ["ID.AM", "PR.DS"]
+    cm = data["compliance_mapping"]
+    assert cm["nist_csf_mapping_version"] == "nist_csf_2_0_hint_v1"
+    assert cm["nist_csf_function_hint_method"] == NIST_CSF_HINT_METHOD
+    assert "ADR-0025" in cm["nist_csf_function_hint_disclaimer"]
+
+
+def test_reporter_omits_csf_hint_when_unmapped() -> None:
+    r = GRCReporter("scope", report_id="DB-CSF02")
+    r.add_finding(
+        "db:lab:dbo.misc",
+        [{"type": "EMAIL", "count": 1}],
+        40.0,
+        norm_tags=["TAG_A"],
+    )
+    data = r.to_dict()
+    row = data["detailed_findings"][0]
+    assert "nist_csf_function_hint" not in row
+    cm = data["compliance_mapping"]
+    assert "nist_csf_mapping_version" not in cm
+    assert "nist_csf_function_hint_disclaimer" not in cm


### PR DESCRIPTION
## Summary
Adds an **optional, non-breaking** per-finding `nist_csf_function_hint` to the `data_boar_grc_executive_report_v1` contract (issue #760). Array of short **NIST CSF 2.0** codes (e.g. `GV`, `ID.AM`, `PR.DS`) derived from `norm_tags` via a **versioned, shipped** mapping table - never hard-coded.

## What changed
- `report/nist_csf_mapping.yaml` - versioned table (`mapping_version: nist_csf_2_0_hint_v1`), `norm_tag` substring -> CSF codes + disclaimer. Same model as `docs/compliance-samples/*.yaml` / article hints.
- `report/nist_csf_hints.py` - loader: dedup + canonical CSF order (GV, ID, PR, DE, RS, RC); safe no-op on load failure.
- `report/grc_reporter.py` - emits `nist_csf_function_hint` per finding **when the table maps**, **omits** otherwise; surfaces ADR-0025 disclaimer + `nist_csf_mapping_version` **once** in `compliance_mapping`.
- `tests/test_nist_csf_hints.py` - mapping, dedup/order, emit-when-mapped, omit-when-unmapped.
- `docs/GRC_EXECUTIVE_REPORT_SCHEMA.md` (+ `.pt_BR.md`) - new section 3.3 documenting the field as non-breaking.

## Constraints honored
- **ADR-0025**: heuristic hint, never a compliance determination (disclaimer visible in `compliance_mapping`).
- **#749 alignment**: prose = tri-level positioning; this PR = the *structured* CSF tag in JSON (complementary, not duplicated).
- **Out of scope**: only NIST CSF 2.0 (no COBIT/SOC2/ISO); `schema_version` unchanged; existing consumers unaffected (field omitted when empty).

## Validation
- `tests/test_nist_csf_hints.py` (13), `test_grc_reporter.py`, `test_executive_report.py`, `test_compliance_samples.py`, `test_markdown_lint.py`, `test_docs_pt_br_locale.py` - all green.
- `pre-commit run --files` (ruff, markdown, pt-BR, PII gates) + `mypy` - green.

Closes #760
Refs #749