### PR TITLE
fix(ci): resolve zizmor workflow-security findings (#388)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           # Full history required for scripts/pii_history_guard.py --full-history (PII in old commits).
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install libmariadb-dev (mariadb PyPI connector builds from source on Linux)
         run: sudo apt-get update && sudo apt-get install -y libmariadb-dev pkg-config
@@ -78,6 +79,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install libmariadb-dev (mariadb PyPI connector builds from source on Linux)
         run: sudo apt-get update && sudo apt-get install -y libmariadb-dev pkg-config
@@ -102,6 +104,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install libmariadb-dev (mariadb PyPI connector builds from source on Linux)
         run: sudo apt-get update && sudo apt-get install -y libmariadb-dev pkg-config
@@ -128,6 +132,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install libmariadb-dev (mariadb PyPI connector builds from source on Linux)
         run: sudo apt-get update && sudo apt-get install -y libmariadb-dev pkg-config
@@ -165,6 +171,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install libmariadb-dev (mariadb PyPI connector builds from source on Linux)
         run: sudo apt-get update && sudo apt-get install -y libmariadb-dev pkg-config
@@ -203,3 +210,17 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           # SonarQube Server only: set SONAR_HOST_URL in repo secrets
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+
+  slack-notify-on-failure:
+    name: Slack CI failure notify
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    needs: [test, lint, bandit, audit, sonar]
+    uses: ./.github/workflows/slack-ci-failure-notify.yml
+    with:
+      run_name: CI
+      head_branch: ${{ github.head_ref || github.ref_name }}
+      event: ${{ github.event_name }}
+      html_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    secrets:
+      SLACK_WEBHOOK_URL:
+        required: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4

--- a/.github/workflows/dependabot-sync.yml
+++ b/.github/workflows/dependabot-sync.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   sync-requirements:
     name: Regenerate requirements.txt
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -31,6 +31,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -49,7 +50,25 @@ jobs:
             git config user.name "github-actions[bot]"
             git add requirements.txt
             git commit -m "chore(deps): auto-regenerate requirements.txt after uv.lock update"
-            git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
+            git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}" \
+              "HEAD:${GITHUB_EVENT_PULL_REQUEST_HEAD_REF}"
           else
             echo "No changes to requirements.txt"
           fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_EVENT_PULL_REQUEST_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+
+  slack-notify-on-failure:
+    name: Slack CI failure notify
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    needs: [sync-requirements]
+    uses: ./.github/workflows/slack-ci-failure-notify.yml
+    with:
+      run_name: Dependabot requirements.txt sync
+      head_branch: ${{ github.head_ref || github.ref_name }}
+      event: ${{ github.event_name }}
+      html_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    secrets:
+      SLACK_WEBHOOK_URL:
+        required: false

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -43,3 +43,17 @@ jobs:
         env:
           # GITLEAKS_LICENSE only needed for org features; OSS works without.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  slack-notify-on-failure:
+    name: Slack CI failure notify
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    needs: [scan]
+    uses: ./.github/workflows/slack-ci-failure-notify.yml
+    with:
+      run_name: Gitleaks
+      head_branch: ${{ github.head_ref || github.ref_name }}
+      event: ${{ github.event_name }}
+      html_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    secrets:
+      SLACK_WEBHOOK_URL:
+        required: false

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -42,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       # PyO3 needs a Python interpreter visible at link time; setup-python
       # exports PYO3_PYTHON-compatible env via PATH so cargo builds find it.

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -46,6 +46,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -56,6 +57,7 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.11.2"
+          enable-cache: false
 
       # mariadb / mysqlclient PyPI packages may build from source when no wheel matches;
       # provide Connector/C and libmysqlclient headers (same class of fix as local Docker/dev docs).
@@ -127,10 +129,11 @@ jobs:
           }}
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "release" ]; then
-            TAG="${{ github.event.release.tag_name }}"
+            TAG="${GITHUB_EVENT_RELEASE_TAG_NAME}"
           else
             TAG="${GITHUB_REF#refs/tags/}"
           fi
@@ -140,3 +143,17 @@ jobs:
           fi
           gh release upload "$TAG" sbom-python.cdx.json sbom-docker-image.cdx.json build-digest.txt release-manifest.json \
             --clobber --repo "${{ github.repository }}"
+
+  slack-notify-on-failure:
+    name: Slack CI failure notify
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    needs: [generate]
+    uses: ./.github/workflows/slack-ci-failure-notify.yml
+    with:
+      run_name: SBOM
+      head_branch: ${{ github.head_ref || github.ref_name }}
+      event: ${{ github.event_name }}
+      html_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    secrets:
+      SLACK_WEBHOOK_URL:
+        required: false

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -17,9 +17,11 @@ jobs:
     name: Semgrep (OSS, Python)
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep
+      image: semgrep/semgrep:1.117.0@sha256:a256468ff217498bfde2f44bd74dd2ffd0460bd08fabbbec009dbdeb4870f4dc
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       # p/python: community Python rules. One rule is excluded — see docs/plans/completed/PLAN_SEMGREP_CI.md
       # (sqlalchemy.text FP where identifiers are validated; CodeQL + tests cover injection).
@@ -28,3 +30,17 @@ jobs:
           semgrep scan --config p/python --metrics=off
           --exclude-rule python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
           --error .
+
+  slack-notify-on-failure:
+    name: Slack CI failure notify
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    needs: [semgrep]
+    uses: ./.github/workflows/slack-ci-failure-notify.yml
+    with:
+      run_name: Semgrep
+      head_branch: ${{ github.head_ref || github.ref_name }}
+      event: ${{ github.event_name }}
+      html_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    secrets:
+      SLACK_WEBHOOK_URL:
+        required: false

--- a/.github/workflows/slack-ci-failure-notify.yml
+++ b/.github/workflows/slack-ci-failure-notify.yml
@@ -1,28 +1,31 @@
-# Posts a short message to Slack when selected workflows fail (workflow_run).
+# Reusable workflow: posts a short message to Slack when a caller workflow fails.
+# Invoked via workflow_call from CI, Semgrep, Gitleaks, SBOM, and Dependabot sync.
 # Requires repository secret SLACK_WEBHOOK_URL (same as Slack operator ping).
 # Skips if secret unset. No checkout needed.
 name: Slack CI failure notify
 
+'on':
+  workflow_call:
+    inputs:
+      run_name:
+        required: true
+        type: string
+      head_branch:
+        required: true
+        type: string
+      event:
+        required: true
+        type: string
+      html_url:
+        required: true
+        type: string
+
 permissions:
   contents: read
-
-'on':
-  workflow_run:
-    workflows:
-      - CI
-      - Semgrep
-      - Gitleaks
-      - SBOM
-      - Dependabot requirements.txt sync
-    types: [completed]
 
 jobs:
   notify:
     runs-on: ubuntu-latest
-    # Only the upstream-conclusion check is at job level (no secrets context).
-    # Webhook presence is detected at step level — placing `secrets.*` in a
-    # job-level `if:` can produce a phantom failed run with 0 jobs.
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:
       - name: Detect Slack webhook
         id: webhook
@@ -41,11 +44,11 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_MENTION_USER_ID: ${{ vars.SLACK_MENTION_USER_ID }}
-          RUN_HTML_URL: ${{ github.event.workflow_run.html_url }}
-          RUN_NAME: ${{ github.event.workflow_run.name }}
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_HTML_URL: ${{ inputs.html_url }}
+          RUN_NAME: ${{ inputs.run_name }}
+          HEAD_BRANCH: ${{ inputs.head_branch }}
           REPO: ${{ github.repository }}
-          EVENT: ${{ github.event.workflow_run.event }}
+          EVENT: ${{ inputs.event }}
         run: |
           python3 <<'PY'
           import json

--- a/.github/workflows/slack-ops-digest.yml
+++ b/.github/workflows/slack-ops-digest.yml
@@ -46,6 +46,7 @@ jobs:
         if: steps.webhook.outputs.present == 'true'
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Build digest payload
         if: steps.webhook.outputs.present == 'true'

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Run zizmor
         id: zizmor

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -1,7 +1,7 @@
 """Offline guards on tracked ``.github/workflows/*.yml`` (and two wrapper scripts).
 
 **Slack:** Parses all shipped ``slack-*.yml`` including ``slack-ci-failure-notify.yml``
-(``workflow_run`` on upstream failures). A private snapshot may live at
+(``workflow_call`` reusable workflow; upstream workflows invoke it on failure). A private snapshot may live at
 ``docs/private/raw_pastes/cursor-incident/slack-ci-failure-notify.yml.old`` for
 pause drills — see **``docs/ops/OPERATOR_NOTIFICATION_CHANNELS.md`` §4.1.1**
 (pt-BR: ``OPERATOR_NOTIFICATION_CHANNELS.pt_BR.md``).
@@ -43,17 +43,47 @@ def test_slack_ci_failure_notify_workflow_present_and_valid() -> None:
     data = _load_workflow("slack-ci-failure-notify.yml")
     assert data.get("name")
     on = data.get("on") or {}
-    assert "workflow_run" in on
-    wr = on["workflow_run"]
-    assert isinstance(wr, dict)
-    assert wr.get("workflows") == [
-        "CI",
-        "Semgrep",
-        "Gitleaks",
-        "SBOM",
-        "Dependabot requirements.txt sync",
-    ]
+    assert "workflow_call" in on
+    wc = on["workflow_call"]
+    assert isinstance(wc, dict)
+    inputs = wc.get("inputs") or {}
+    for key in ("run_name", "head_branch", "event", "html_url"):
+        assert key in inputs
+        assert inputs[key].get("required") is True
     assert "notify" in (data.get("jobs") or {})
+
+
+def test_upstream_workflows_invoke_slack_ci_failure_notify_on_failure() -> None:
+    """Failure Slack ping is workflow_call from upstream CI workflows (not workflow_run)."""
+    callers = (
+        ("ci.yml", "CI", ("test", "lint", "bandit", "audit", "sonar")),
+        ("semgrep.yml", "Semgrep", ("semgrep",)),
+        ("gitleaks.yml", "Gitleaks", ("scan",)),
+        ("sbom.yml", "SBOM", ("generate",)),
+        (
+            "dependabot-sync.yml",
+            "Dependabot requirements.txt sync",
+            ("sync-requirements",),
+        ),
+    )
+    for filename, run_name, needs_jobs in callers:
+        data = _load_workflow(filename)
+        jobs = data.get("jobs") or {}
+        slack_jobs = [
+            (jid, job)
+            for jid, job in jobs.items()
+            if isinstance(job, dict)
+            and str(job.get("uses", "")).endswith("slack-ci-failure-notify.yml")
+        ]
+        assert len(slack_jobs) == 1, (
+            f"{filename}: expected one slack notify reusable job, found {len(slack_jobs)}"
+        )
+        _jid, job = slack_jobs[0]
+        job_if = str(job.get("if") or "").lower()
+        assert "failure" in job_if
+        assert set(job.get("needs") or []) == set(needs_jobs)
+        with_block = job.get("with") or {}
+        assert with_block.get("run_name") == run_name
 
 
 def test_slack_release_published_notify_workflow_present_and_valid() -> None:
@@ -216,6 +246,8 @@ def test_gitleaks_yml_pins_actions_to_shas() -> None:
         code = line.split("#", 1)[0]
         if "uses:" not in code or "docker://" in code:
             continue
+        if "./.github/workflows/" in code:
+            continue
         if not any(p in code for p in ("actions/", "github/", "gitleaks/")):
             continue
         assert sha_40.search(code), (
@@ -271,6 +303,8 @@ def test_sbom_yml_pins_actions_to_shas() -> None:
         code = line.split("#", 1)[0]
         if "uses:" not in code or "docker://" in code:
             continue
+        if "./.github/workflows/" in code:
+            continue
         if not any(p in code for p in ("actions/", "github/", "astral-sh/")):
             continue
         assert sha_40.search(code), (
@@ -288,6 +322,8 @@ def test_ci_yml_pins_actions_and_uv_cli() -> None:
     for line in text.splitlines():
         code = line.split("#", 1)[0]
         if "uses:" not in code or "docker://" in code:
+            continue
+        if "./.github/workflows/" in code:
             continue
         if not any(
             p in code for p in ("actions/", "github/", "astral-sh/", "SonarSource/")
@@ -321,6 +357,8 @@ def test_dependabot_sync_workflow_present_and_valid() -> None:
     for line in text.splitlines():
         code = line.split("#", 1)[0]
         if "uses:" not in code or "docker://" in code:
+            continue
+        if "./.github/workflows/" in code:
             continue
         if not any(p in code for p in ("actions/", "github/", "astral-sh/")):
             continue


### PR DESCRIPTION
## Summary
- Apply zizmor auto-fixes (template-injection, bot-conditions, artipacked, persist-credentials) across tracked workflows.
- Pin `semgrep/semgrep` container image with digest; replace `workflow_run` Slack failure notify with `workflow_call` from CI/Semgrep/Gitleaks/SBOM/Dependabot sync (fixes `dangerous-triggers`).
- Keep `dependabot-sync` push working: `persist-credentials: false` + explicit `x-access-token` push.
- Update `tests/test_github_workflows.py` for the new reusable-workflow shape.

## Test plan
- [x] `uvx zizmor --no-online-audits .github/workflows/` → No findings
- [x] `uv run pytest tests/test_github_workflows.py` → 19 passed
- [ ] CI + Zizmor check green on this PR

Fixes the 6 errors + 12 warnings Zizmor flags on main (enforced since #735). dependabot-sync push kept working via explicit token auth (persist-credentials:false + x-access-token). Closes #388 when green.

Made with [Cursor](https://cursor.com)