### PR TITLE
fix(ci): resolve zizmor online findings — Zizmor green on main (#388)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,8 @@ updates:
       # chardet 6+ is incompatible with cyclonedx-bom until upstream relaxes chardet<6.0.
       - dependency-name: "chardet"
         update-types: ["version-update:semver-major"]
+    cooldown:
+      default-days: 7
 
   # GitHub Actions (workflows and action versions)
   - package-ecosystem: "github-actions"
@@ -44,3 +46,5 @@ updates:
     labels: ["dependencies", "github-actions"]
     commit-message:
       prefix: "ci(actions)"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,12 +35,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           languages: ${{ matrix.language }}
           # Keep broad default coverage for "just in case" findings.
@@ -48,6 +48,6 @@ jobs:
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -41,7 +41,7 @@ jobs:
     name: cargo check / test / clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/slack-ops-digest.yml
+++ b/.github/workflows/slack-ops-digest.yml
@@ -42,7 +42,7 @@ jobs:
             echo "SLACK_WEBHOOK_URL is unset; downstream steps will skip cleanly."
           fi
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: steps.webhook.outputs.present == 'true'
         with:
           fetch-depth: 0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -38,7 +38,7 @@ jobs:
       ENFORCE_ZIZMOR: ${{ github.event_name == 'workflow_dispatch' && (inputs.enforce && 'true' || 'false') || (vars.ZIZMOR_ENFORCE == 'false' && 'false' || 'true') }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Closes the 8 online-only zizmor findings that survived #777: 6x ref-version-mismatch (pin comments aligned to exact resolved tags) + 2x dependabot-cooldown (cooldown added to uv + github-actions updates). Validated ONLINE (GH_TOKEN, no --no-online-audits). Completes #388 — Zizmor green on main.

Made with [Cursor](https://cursor.com)