### PR TITLE
fix(maestro): T14 run repairs (#789-792)

### DIFF
--- a/docs/ops/LAB_OP_PRIVILEGED_COLLECTION.md
+++ b/docs/ops/LAB_OP_PRIVILEGED_COLLECTION.md
@@ -133,6 +133,17 @@ Drop-ins under **`/etc/sudoers.d/`** are read in **filename sort order** (C loca
 
 If **`git pull --ff-only origin main`** says **up to date** but **`lab-node-01-ansible-labop-podman-apply.sh --check`** still fails inside **`ansible.builtin.apt`** (or **`labop-share-client-install.sh`** still tries the **`sshfs`** package name on Void), the **canonical fixes are not on the Git remote** the host tracks — e.g. changes only exist on the **operator dev PC** working tree until **committed and pushed**. Confirm on the host: **`git log -1 --oneline`** matches **`main`** on GitHub, then pull again.
 
+### Maestro target NFS / CIFS ensure (`Handle-target_nfs`, `Handle-target_cifs`)
+
+Maestro handlers run **read-only** checks with **`--check`** (default) or **`--apply`** in **`-Deep`** mode:
+
+```bash
+sudo -n bash "$HOME/Projects/dev/data-boar/scripts/labop-nfs-server-ensure.sh" --check
+sudo -n bash "$HOME/Projects/dev/data-boar/scripts/labop-smb-server-ensure.sh" --check
+```
+
+**`Cmnd_Alias`** entries must list **both** **`--check`** and **`--apply`**, and **both** **`/bin/bash`** and **`/usr/bin/bash`**, on the **canonical** repo path (not version-suffixed ephemeral checkouts). Tracked template: **`docs/private.example/homelab/labop-maestro-target-sudoers.example`**. Merge into **`/etc/sudoers.d/z-labop-host-report`** (sort **after** **`wheel`** — see above). Validate: **`sudo visudo -cf /etc/sudoers.d/z-labop-host-report`**.
+
 ## Guardrails
 
 - Prefer removing the sudoers file after the collection window if you don't need it long term.

--- a/docs/ops/LAB_OP_PRIVILEGED_COLLECTION.pt_BR.md
+++ b/docs/ops/LAB_OP_PRIVILEGED_COLLECTION.pt_BR.md
@@ -132,6 +132,17 @@ Os includes em **`/etc/sudoers.d/`** são lidos pela **ordem lexicográfica do n
 
 Se **`git pull --ff-only origin main`** diz **up to date** mas **`lab-node-01-ansible-labop-podman-apply.sh --check`** ainda falha no **`ansible.builtin.apt`** (ou **`labop-share-client-install.sh`** ainda tenta o pacote **`sshfs`** no Void), as **correções canónicas ainda não estão no remoto Git** que o host segue — por exemplo, alterações só no **working tree do PC de desenvolvimento** até **commit + push**. Confirma no host: **`git log -1 --oneline`** igual ao **`main`** no GitHub e volta a fazer pull.
 
+### Maestro — ensure NFS / CIFS (`Handle-target_nfs`, `Handle-target_cifs`)
+
+Os handlers Maestro rodam **`--check`** (padrão) ou **`--apply`** (modo **`-Deep`**):
+
+```bash
+sudo -n bash "$HOME/Projects/dev/data-boar/scripts/labop-nfs-server-ensure.sh" --check
+sudo -n bash "$HOME/Projects/dev/data-boar/scripts/labop-smb-server-ensure.sh" --check
+```
+
+Os **`Cmnd_Alias`** precisam listar **`--check`** e **`--apply`**, **`/bin/bash`** e **`/usr/bin/bash`**, no caminho **canônico** do repo (não checkout efêmero com sufixo de versão). Modelo rastreado: **`docs/private.example/homelab/labop-maestro-target-sudoers.example`**. Mescla em **`/etc/sudoers.d/z-labop-host-report`** (ordena **depois** de **`wheel`** — ver acima). Valida: **`sudo visudo -cf /etc/sudoers.d/z-labop-host-report`**.
+
 ## Guardrails
 
 - Se você não precisar disso no dia a dia, remova o arquivo do sudoers após a janela de coleta.

--- a/docs/plans/PLAN_MAESTRO_BENCHMARK_METRICS_AND_FIX.md
+++ b/docs/plans/PLAN_MAESTRO_BENCHMARK_METRICS_AND_FIX.md
@@ -291,8 +291,14 @@ fusermount -u /tmp/probe_mount_sshfs
 ### New sudoers entries needed (LABOP_NFS_SERVER, LABOP_SMB_SERVER)
 
 ```sudoers
-Cmnd_Alias LABOP_NFS_SERVER = /bin/bash /home/leitao/Projects/dev/data-boar/scripts/labop-nfs-server-ensure.sh --apply
-Cmnd_Alias LABOP_SMB_SERVER = /bin/bash /home/leitao/Projects/dev/data-boar/scripts/labop-smb-server-ensure.sh --apply
+Cmnd_Alias LABOP_NFS_SERVER = /bin/bash /home/leitao/Projects/dev/data-boar/scripts/labop-nfs-server-ensure.sh --check, \
+                              /usr/bin/bash /home/leitao/Projects/dev/data-boar/scripts/labop-nfs-server-ensure.sh --check, \
+                              /bin/bash /home/leitao/Projects/dev/data-boar/scripts/labop-nfs-server-ensure.sh --apply, \
+                              /usr/bin/bash /home/leitao/Projects/dev/data-boar/scripts/labop-nfs-server-ensure.sh --apply
+Cmnd_Alias LABOP_SMB_SERVER = /bin/bash /home/leitao/Projects/dev/data-boar/scripts/labop-smb-server-ensure.sh --check, \
+                              /usr/bin/bash /home/leitao/Projects/dev/data-boar/scripts/labop-smb-server-ensure.sh --check, \
+                              /bin/bash /home/leitao/Projects/dev/data-boar/scripts/labop-smb-server-ensure.sh --apply, \
+                              /usr/bin/bash /home/leitao/Projects/dev/data-boar/scripts/labop-smb-server-ensure.sh --apply
 leitao ALL=(root) NOPASSWD: LABOP_NFS_SERVER, LABOP_SMB_SERVER
 ```
 

--- a/docs/private.example/homelab/labop-maestro-target-sudoers.example
+++ b/docs/private.example/homelab/labop-maestro-target-sudoers.example
@@ -1,0 +1,20 @@
+# Example: narrow sudoers for Maestro Handle-target_nfs / Handle-target_cifs
+# Copy fragments into /etc/sudoers.d/z-labop-host-report (or merge with existing LAB-OP drop-in).
+# Replace REPO_PATH and USER with operator values. Validate: sudo visudo -cf /etc/sudoers.d/z-labop-host-report
+#
+# Handlers invoke exactly:
+#   sudo -n bash REPO_PATH/scripts/labop-nfs-server-ensure.sh --check|--apply
+#   sudo -n bash REPO_PATH/scripts/labop-smb-server-ensure.sh --check|--apply
+# List BOTH /bin/bash and /usr/bin/bash (Void Linux may resolve bash to /usr/bin/bash).
+
+Cmnd_Alias LABOP_NFS_SERVER = /bin/bash REPO_PATH/scripts/labop-nfs-server-ensure.sh --check, \
+                              /usr/bin/bash REPO_PATH/scripts/labop-nfs-server-ensure.sh --check, \
+                              /bin/bash REPO_PATH/scripts/labop-nfs-server-ensure.sh --apply, \
+                              /usr/bin/bash REPO_PATH/scripts/labop-nfs-server-ensure.sh --apply
+
+Cmnd_Alias LABOP_SMB_SERVER = /bin/bash REPO_PATH/scripts/labop-smb-server-ensure.sh --check, \
+                              /usr/bin/bash REPO_PATH/scripts/labop-smb-server-ensure.sh --check, \
+                              /bin/bash REPO_PATH/scripts/labop-smb-server-ensure.sh --apply, \
+                              /usr/bin/bash REPO_PATH/scripts/labop-smb-server-ensure.sh --apply
+
+USER ALL=(root) NOPASSWD: LABOP_NFS_SERVER, LABOP_SMB_SERVER

--- a/ops/automation/ansible/roles/t14_labop_sudoers/defaults/main.yml
+++ b/ops/automation/ansible/roles/t14_labop_sudoers/defaults/main.yml
@@ -2,6 +2,9 @@
 # Opt-in: writing sudoers is sensitive; keep disabled by default.
 lab-node-01_labop_sudoers_enable: false
 
+# Include Maestro NFS/CIFS ensure scripts (LABOP_NFS_SERVER / LABOP_SMB_SERVER).
+lab-node-01_labop_sudoers_maestro_targets: true
+
 # Target sudoers include path.
 lab-node-01_labop_sudoers_include_path: /etc/sudoers.d/labop-host-report
 

--- a/ops/automation/ansible/roles/t14_labop_sudoers/tasks/main.yml
+++ b/ops/automation/ansible/roles/t14_labop_sudoers/tasks/main.yml
@@ -28,7 +28,19 @@
                                         /usr/bin/bash {{ lab-node-01_labop_repo_path }}/scripts/lab-node-01-ansible-labop-podman-apply.sh --apply, \
                                         /bin/bash {{ lab-node-01_labop_repo_path }}/scripts/lab-node-01-ansible-labop-podman-apply.sh --check, \
                                         /usr/bin/bash {{ lab-node-01_labop_repo_path }}/scripts/lab-node-01-ansible-labop-podman-apply.sh --check
+{% if lab-node-01_labop_sudoers_maestro_targets | bool %}
+      Cmnd_Alias LABOP_NFS_SERVER = /bin/bash {{ lab-node-01_labop_repo_path }}/scripts/labop-nfs-server-ensure.sh --check, \
+                                    /usr/bin/bash {{ lab-node-01_labop_repo_path }}/scripts/labop-nfs-server-ensure.sh --check, \
+                                    /bin/bash {{ lab-node-01_labop_repo_path }}/scripts/labop-nfs-server-ensure.sh --apply, \
+                                    /usr/bin/bash {{ lab-node-01_labop_repo_path }}/scripts/labop-nfs-server-ensure.sh --apply
+      Cmnd_Alias LABOP_SMB_SERVER = /bin/bash {{ lab-node-01_labop_repo_path }}/scripts/labop-smb-server-ensure.sh --check, \
+                                    /usr/bin/bash {{ lab-node-01_labop_repo_path }}/scripts/labop-smb-server-ensure.sh --check, \
+                                    /bin/bash {{ lab-node-01_labop_repo_path }}/scripts/labop-smb-server-ensure.sh --apply, \
+                                    /usr/bin/bash {{ lab-node-01_labop_repo_path }}/scripts/labop-smb-server-ensure.sh --apply
+      {{ lab-node-01_labop_sudoers_user }} ALL=(root) NOPASSWD: LABOP_HOST_REPORT, LABOP_ANSIBLE_PODMAN, LABOP_NFS_SERVER, LABOP_SMB_SERVER
+{% else %}
       {{ lab-node-01_labop_sudoers_user }} ALL=(root) NOPASSWD: LABOP_HOST_REPORT, LABOP_ANSIBLE_PODMAN
+{% endif %}
   failed_when: false
 
 - name: Validate sudoers include syntax (visudo -c)

--- a/scripts/lab-completao-host-smoke.sh
+++ b/scripts/lab-completao-host-smoke.sh
@@ -5,8 +5,8 @@
 # See docs/ops/LAB_COMPLETAO_RUNBOOK.md and docs/ops/LAB_SMOKE_MULTI_HOST.md.
 #
 # Exit codes (DATA_BOAR_COMPLETAO_EXIT_v1 -- same contract as docs/ops/LAB_COMPLETAO_RUNBOOK.md):
-#   0 -- completed diagnostic bundle (success; individual steps may log FAILED inside the transcript).
-#   1 -- reserved for future infra-hard-fail fast-path (network/tool missing when a gate requires it).
+#   0 -- completed diagnostic bundle (baremetal scan/import OK when not --skip-engine-import).
+#   1 -- baremetal scan or engine import failed (no DONE_SUCCESS_BAREMETAL).
 #   2 -- invalid invocation / unknown CLI argument (contract violation).
 #   3 -- reserved for compliance-violation signals when a scanner hook is wired to this script.
 #
@@ -145,6 +145,35 @@ _lc_sudo() {
   sudo -n "$@" 2>/dev/null || echo "(sudo -n failed or denied for: $*)"
 }
 
+_lc_prepare_baremetal_runtime() {
+  if [[ ! -f "$LC_REPO_ROOT/pyproject.toml" ]] || ! _lc_cmd uv; then
+    return 1
+  fi
+  echo "Preparing baremetal venv (uv sync)..."
+  if ! (cd "$LC_REPO_ROOT" && uv sync); then
+    echo "uv sync: FAILED"
+    return 1
+  fi
+  if (cd "$LC_REPO_ROOT" && uv run maturin develop --release >/dev/null 2>&1); then
+    echo "maturin develop --release: OK"
+  else
+    echo "maturin develop --release: skipped or failed (Python fallback may still run)"
+  fi
+  return 0
+}
+
+_lc_run_engine_import_probe() {
+  if ! _lc_prepare_baremetal_runtime; then
+    echo "import core.engine: FAILED (uv sync)"
+    return 1
+  fi
+  if (cd "$LC_REPO_ROOT" && uv run python -c "import core.engine; print('import core.engine: OK')" 2>&1); then
+    return 0
+  fi
+  echo "import core.engine: FAILED"
+  return 1
+}
+
 _lc_init_bench_workdir() {
   if [[ -z "$LC_BENCH_TRACK" ]]; then
     return 0
@@ -279,10 +308,14 @@ else
 fi
 
 _lc_section "Python import (engine)"
+LC_ENGINE_IMPORT_OK=0
 if [[ "$LC_SKIP_ENGINE" == "1" ]]; then
   echo "(skipped: container-only host -- expect Data Boar via Docker / Podman / Swarm stack, not bare-metal uv; see docs/ops/LAB_COMPLETAO_RUNBOOK.md)"
+  LC_ENGINE_IMPORT_OK=1
 elif [[ -f "$LC_REPO_ROOT/pyproject.toml" ]] && _lc_cmd uv; then
-  (cd "$LC_REPO_ROOT" && uv run python -c "import core.engine; print('import core.engine: OK')" 2>&1) || echo "import core.engine: FAILED"
+  if _lc_run_engine_import_probe; then
+    LC_ENGINE_IMPORT_OK=1
+  fi
 else
   echo "(skip: no uv or no pyproject.toml)"
 fi
@@ -292,17 +325,26 @@ _lc_section "Data Boar Engine (Baremetal RC)"
 CONFIG_RC="${LC_BENCH_CONFIG:-tests/config/benchmark-rc.yaml}"
 _lc_capture_metrics_snapshot "pre_scan"
 _scan_start_epoch="$(date +%s 2>/dev/null || echo 0)"
+LC_BAREMETAL_SCAN_OK=0
 
-if [[ -f "$LC_REPO_ROOT/$CONFIG_RC" ]] && _lc_cmd uv; then
-  do_log_ INFO "Iniciando Scan de Performance Baremetal com $CONFIG_RC..."
-
-  # SRE FIX: Avisa o Maestro que o motor pesado iniciou
+if [[ "$LC_SKIP_ENGINE" == "1" ]]; then
+  echo "(skipped baremetal scan: container-only host)"
+  LC_BAREMETAL_SCAN_OK=1
+elif [[ -f "$LC_REPO_ROOT/$CONFIG_RC" ]] && _lc_cmd uv; then
+  echo "Iniciando scan baremetal com $CONFIG_RC via main.py..."
   echo "SCANNING_BAREMETAL_RC at $(date +'%H:%M:%S')" > "${HOME}/.labop-status"
-
-  (cd "$LC_REPO_ROOT" && uv run data-boar scan --config "$CONFIG_RC")
+  if _lc_prepare_baremetal_runtime && (cd "$LC_REPO_ROOT" && uv run python main.py --config "$CONFIG_RC"); then
+    LC_BAREMETAL_SCAN_OK=1
+    echo "BAREMETAL_SCAN: OK"
+  else
+    echo "BAREMETAL_SCAN: FAILED"
+  fi
+elif [[ -f "$LC_REPO_ROOT/pyproject.toml" ]] && _lc_cmd uv; then
+  if _lc_run_engine_import_probe; then
+    LC_BAREMETAL_SCAN_OK=1
+  fi
 else
-  # Fallback para o smoke original se não houver config de benchmark
-  (cd "$LC_REPO_ROOT" && uv run python -c "import core.engine; print('import core.engine: OK')" 2>&1) || echo "import core.engine: FAILED"
+  echo "(skip baremetal scan: missing config or uv)"
 fi
 _scan_end_epoch="$(date +%s 2>/dev/null || echo 0)"
 if [[ "$_scan_start_epoch" -gt 0 && "$_scan_end_epoch" -ge "$_scan_start_epoch" ]]; then
@@ -407,8 +449,16 @@ _lc_bench_compare
 
 _lc_section "Telemetria"
 FINAL_TS=$(date +"%H:%M:%S")
-echo "DONE_SUCCESS_BAREMETAL at ${FINAL_TS}" > "${HOME}/.labop-status"
-echo "Status persistido em ${HOME}/.labop-status"
+if [[ "$LC_BAREMETAL_SCAN_OK" == "1" ]]; then
+  echo "DONE_SUCCESS_BAREMETAL at ${FINAL_TS}" > "${HOME}/.labop-status"
+  echo "Status persistido em ${HOME}/.labop-status (DONE_SUCCESS_BAREMETAL)"
+else
+  echo "DONE_FAILED_BAREMETAL at ${FINAL_TS}" > "${HOME}/.labop-status"
+  echo "Status persistido em ${HOME}/.labop-status (DONE_FAILED_BAREMETAL)"
+fi
 
 echo "=== lab-completao-host-smoke END ==="
+if [[ "$LC_BAREMETAL_SCAN_OK" != "1" ]]; then
+  exit 1
+fi
 exit 0

--- a/scripts/maestro/Build-ContainerArtefact.ps1
+++ b/scripts/maestro/Build-ContainerArtefact.ps1
@@ -18,16 +18,52 @@ $freshThresholdHours = 1
 $staleWarnHours = 24
 
 function Test-ContainerEngineReady {
-    foreach ($cmd in @("docker", "podman")) {
+    if ($env:DOCKER_HOST -match "podman" -and (Get-Command podman -ErrorAction SilentlyContinue)) {
+        $null = & podman info --format "{{.Host.Os}}" 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            return [PSCustomObject]@{ Cmd = "podman"; Ready = $true; IsPodman = $true }
+        }
+    }
+    foreach ($cmd in @("podman", "docker")) {
         if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) {
             continue
         }
         $null = & $cmd info --format '{{.ServerVersion}}' 2>$null
         if ($LASTEXITCODE -eq 0) {
-            return [PSCustomObject]@{ Cmd = $cmd; Ready = $true }
+            $isPodman = ($cmd -eq "podman")
+            return [PSCustomObject]@{ Cmd = $cmd; Ready = $true; IsPodman = $isPodman }
         }
     }
-    return [PSCustomObject]@{ Cmd = $null; Ready = $false }
+    return [PSCustomObject]@{ Cmd = $null; Ready = $false; IsPodman = $false }
+}
+
+function Invoke-ContainerImageBuild {
+    param(
+        [string]$EngineCmd,
+        [bool]$IsPodman,
+        [string]$FullImage,
+        [string]$Context
+    )
+    if ($IsPodman -or $EngineCmd -eq "podman") {
+        & podman build -q -t $FullImage $Context
+        return $LASTEXITCODE
+    }
+    if ($env:DOCKER_HOST -match "podman" -and (Get-Command podman -ErrorAction SilentlyContinue)) {
+        & podman build -q -t $FullImage $Context
+        return $LASTEXITCODE
+    }
+    $prevBuildKit = $env:DOCKER_BUILDKIT
+    $env:DOCKER_BUILDKIT = "0"
+    try {
+        & docker build -q -t $FullImage $Context
+        return $LASTEXITCODE
+    } finally {
+        if ($null -eq $prevBuildKit) {
+            Remove-Item Env:DOCKER_BUILDKIT -ErrorAction SilentlyContinue
+        } else {
+            $env:DOCKER_BUILDKIT = $prevBuildKit
+        }
+    }
 }
 
 $tarExists = Test-Path -LiteralPath $tarPath
@@ -52,9 +88,9 @@ if ($engine.Ready) {
 
     if ($shouldBuild) {
         Write-Host "   [Pre-flight] Compilando $fullImage e gerando artefato SRE..." -ForegroundColor Yellow
-        $null = & $engineCmd build -q -t $fullImage "$PSScriptRoot/../../"
-        if ($LASTEXITCODE -ne 0) {
-            Write-Error "Falha no $engineCmd build para $fullImage."
+        $buildExit = Invoke-ContainerImageBuild -EngineCmd $engineCmd -IsPodman $engine.IsPodman -FullImage $fullImage -Context "$PSScriptRoot/../../"
+        if ($buildExit -ne 0) {
+            Write-Error "Falha no build da imagem $fullImage (engine=$engineCmd)."
             exit 7
         }
         $null = & $engineCmd save $fullImage -o $tarPath

--- a/scripts/maestro/Sync-WorkingTree.ps1
+++ b/scripts/maestro/Sync-WorkingTree.ps1
@@ -92,7 +92,7 @@ if ($Ref -eq "WorkingTree") {
     # Remove stale origin if present from a previous ephemeral checkout (local or remote URL),
     # then re-add origin (per-node git_origin override or canonical GitHub) before fetching the ref.
     $gitOrigin = "git@github.com:FabioLeitao/data-boar.git"
-    if ($Node.git_origin) {
+    if ($Node.PSObject.Properties['git_origin'] -and $Node.git_origin) {
         $gitOrigin = $Node.git_origin
     }
     $gitCmd = "cd $finalPath && git init && (git remote remove origin 2>/dev/null || true) && git remote add origin $gitOrigin && git fetch origin $Ref --depth=1 && git checkout FETCH_HEAD"

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -163,7 +163,7 @@ def test_sync_working_tree_uses_explicit_sync_result() -> None:
     assert "ConnectTimeout=15" in text
     assert "if ($IsWindows)" in text
     assert "bash -c" in text
-    assert '$Node.git_origin' in text
+    assert "PSObject.Properties['git_origin']" in text
     assert "if ($syncOk) {" in text
     assert "tmux new-session -d -s completao" in text
     assert "> $null 2>&1" in text
@@ -307,7 +307,9 @@ def test_build_container_artefact_has_container_engine_fallback_policy() -> None
         encoding="utf-8", errors="replace"
     )
     assert "Test-ContainerEngineReady" in text
+    assert "Invoke-ContainerImageBuild" in text
     assert '"podman"' in text
+    assert "DOCKER_BUILDKIT" in text
     assert "Container engine indisponivel" in text
     assert "rebuild" in text.lower() or "Rebuild" in text
     assert "lessons learned" in text
@@ -340,6 +342,19 @@ def test_container_handlers_enable_lab_stack_up_in_deep_mode() -> None:
         assert "lab-completao-host-smoke.sh $smokeArgText" in body
 
 
+def test_lab_completao_host_smoke_uses_main_py_not_data_boar_scan() -> None:
+    """Baremetal RC must invoke python main.py --config (no fictional data-boar scan subcommand)."""
+    root = _project_root()
+    text = (root / "scripts" / "lab-completao-host-smoke.sh").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "uv run python main.py --config" in text
+    assert "uv run data-boar scan" not in text
+    assert "DONE_FAILED_BAREMETAL" in text
+    assert 'LC_BAREMETAL_SCAN_OK' in text
+    assert "maturin develop --release" in text
+
+
 def test_lab_completao_host_smoke_parses_bench_config_flag() -> None:
     """Maestro --bench-config must be a real flag (not positional $1) so Deep argv parses."""
     root = _project_root()
@@ -348,6 +363,19 @@ def test_lab_completao_host_smoke_parses_bench_config_flag() -> None:
     )
     assert "    --bench-config)" in text
     assert 'CONFIG_RC="${LC_BENCH_CONFIG:-tests/config/benchmark-rc.yaml}"' in text
+
+
+def test_labop_maestro_target_sudoers_example_lists_check_and_apply() -> None:
+    """Narrow sudoers example covers Maestro --check and --apply for NFS and CIFS."""
+    root = _project_root()
+    path = root / "docs/private.example/homelab/labop-maestro-target-sudoers.example"
+    assert path.is_file(), "missing labop-maestro-target-sudoers.example"
+    text = path.read_text(encoding="utf-8", errors="replace")
+    assert "LABOP_NFS_SERVER" in text
+    assert "LABOP_SMB_SERVER" in text
+    assert "--check" in text
+    assert "--apply" in text
+    assert "/usr/bin/bash" in text
 
 
 def test_maestro_benchmark_ab_has_sleep_before_collect() -> None:


### PR DESCRIPTION
## Summary
Fixes from Maestro run 2026-06-08 on T14 Linux (P1 first, then P2):

- **#789** — `Sync-WorkingTree.ps1`: guard `git_origin` with `$Node.PSObject.Properties['git_origin']` (no `PropertyNotFoundException` on nodes without the field).
- **#790** — `Build-ContainerArtefact.ps1`: prefer native **podman build** when `DOCKER_HOST` points at podman; fall back to `DOCKER_BUILDKIT=0` + `docker build` so `save` works (no buildx cache-only image).
- **#792** — `lab-completao-host-smoke.sh`: baremetal RC uses `uv run python main.py --config`; runs `uv sync` + optional `maturin develop --release`; writes `DONE_FAILED_BAREMETAL` and exits **1** when scan/import fails (no false success).
- **#791** — tracked sudoers template + ops doc + Ansible `t14_labop_sudoers` role: `LABOP_NFS_SERVER` / `LABOP_SMB_SERVER` with **both** `--check` and `--apply` (both bash paths). **Operator still applies** on mini-bt / t14 via `z-labop-host-report`.

Closes #789
Closes #790
Closes #791
Closes #792

## Test plan
- [x] `uv run pytest tests/test_maestro_scripts.py -q` (27 passed)
- [ ] CI green on PR
- [ ] After merge: merge sudoers fragment on **mini-bt** and **t14** from `docs/private.example/homelab/labop-maestro-target-sudoers.example`; re-run Maestro on T14


Made with [Cursor](https://cursor.com)