### PR TITLE
fix(ci): declare SLACK_WEBHOOK_URL on slack workflow_call (#795)

### DIFF
--- a/.github/workflows/slack-ci-failure-notify.yml
+++ b/.github/workflows/slack-ci-failure-notify.yml
@@ -19,6 +19,9 @@ name: Slack CI failure notify
       html_url:
         required: true
         type: string
+    secrets:
+      SLACK_WEBHOOK_URL:
+        required: false
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Add `secrets.SLACK_WEBHOOK_URL` with `required: false` to the `workflow_call` interface in `slack-ci-failure-notify.yml`.
- Fixes workflow scheduling failure (0 jobs) on ci, semgrep, gitleaks, sbom, dependabot-sync since callers pass the secret but the reusable workflow did not declare it.

Closes #795

## Test plan
- [x] `uv run pytest tests/test_github_workflows.py::test_slack_ci_failure_notify_workflow_present_and_valid -q`
- [ ] CI schedules jobs on this PR (validates the fix end-to-end)


Made with [Cursor](https://cursor.com)