### PR TITLE
fix(security): pii_history_guard three-dot diff when branch behind main

### DIFF
--- a/scripts/pii_history_guard.py
+++ b/scripts/pii_history_guard.py
@@ -1,8 +1,9 @@
 """
 History-focused PII anti-recurrence guard.
 
-Default mode scans added lines in `origin/main..HEAD` diffs to block new
-sensitive patterns before commit/PR.
+Default mode scans added lines in `origin/main...HEAD` diffs (three-dot / merge-base)
+to block new sensitive patterns before commit/PR. The logical range label remains
+`origin/main..HEAD` for rev-list semantics; `git diff` uses three-dot syntax.
 
 Optional `--full-history` scans added lines across full git history.
 """
@@ -125,7 +126,14 @@ def _collect_lines_to_scan(scan_range: str, max_diff_size_mb: int) -> list[str]:
     if scan_range == "--all":
         proc = _git(["log", "--all", "-p", "--unified=0", "--no-color", "--", "."])
     else:
-        proc = _git(["diff", "--unified=0", "--no-color", scan_range, "--", "."])
+        scan_range_for_diff = (
+            scan_range.replace("..HEAD", "...HEAD")
+            if not scan_range.startswith("-")
+            else scan_range
+        )
+        proc = _git(
+            ["diff", "--unified=0", "--no-color", scan_range_for_diff, "--", "."]
+        )
     if proc.returncode != 0:
         raise RuntimeError(f"git patch scan failed: {proc.stderr.strip()}")
     diff_bytes = len(proc.stdout.encode("utf-8", errors="replace"))
@@ -145,7 +153,7 @@ def main() -> int:
     parser.add_argument(
         "--full-history",
         action="store_true",
-        help="scan complete git history instead of origin/main..HEAD range",
+        help="scan complete git history instead of origin/main...HEAD range",
     )
     parser.add_argument(
         "--max-diff-size-mb",
@@ -178,7 +186,7 @@ def main() -> int:
                 violations.append(f"{label} :: line#{idx} :: {snippet}")
 
     if violations:
-        scope = "full history" if args.full_history else "origin/main..HEAD"
+        scope = "full history" if args.full_history else "origin/main...HEAD"
         print("PII history guard failed. Found forbidden patterns in git history:")
         print(f"  scope: {scope}")
         for violation in violations[:20]:
@@ -191,7 +199,7 @@ def main() -> int:
         )
         return 1
 
-    scope = "full history" if args.full_history else DEFAULT_SCAN_RANGE
+    scope = "full history" if args.full_history else "origin/main...HEAD"
     print(f"PII history guard: OK (no forbidden literals in {scope}).")
     return 0
 

--- a/tests/test_pii_guard.py
+++ b/tests/test_pii_guard.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -298,7 +299,7 @@ _GRATITUDE_ALLOWED_PATHS = {
 def test_plan_and_usecase_files_no_gratitude_attribution():
     """
     Plan Motivation/Context sections must not contain gratitude phrases that
-    attribute real people (e.g. 'thanks to Fulana', 'agradecemos a João').
+    attribute real people (e.g. 'thanks to a named contact', 'agradecemos a <nome>').
 
     Scans PLAN_*.md and docs/use-cases/**/*.md tracked files only — avoids
     false positives in generic docs where similar phrasing is legitimate.
@@ -331,3 +332,62 @@ def test_plan_and_usecase_files_no_gratitude_attribution():
         "Plan/use-case PII guard failed — gratitude attribution with real name:\n"
         + "\n".join(violations)
     )
+
+
+def test_pii_history_guard_diff_uses_three_dot_range(monkeypatch) -> None:
+    """Regression #805: git diff must use merge-base (three-dot), not tree compare."""
+    import scripts.pii_history_guard as guard
+
+    calls: list[list[str]] = []
+
+    def fake_git(args: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(guard, "_git", fake_git)
+    guard._collect_lines_to_scan("origin/main..HEAD", 500)
+    assert calls == [
+        ["diff", "--unified=0", "--no-color", "origin/main...HEAD", "--", "."]
+    ]
+
+
+def test_pii_history_guard_ok_when_branch_is_ancestor_of_main(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """When HEAD has no commits ahead of origin/main, guard must not false-positive."""
+    import scripts.pii_history_guard as guard
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            check=check,
+            capture_output=True,
+            text=True,
+        )
+
+    git("init", "-b", "main")
+    git("config", "user.email", "guard@test.example")
+    git("config", "user.name", "Guard Test")
+    sample = repo / "sample.md"
+    sample.write_text(
+        '"git_origin": "ssh://operator@lab-host-not-example/home/dev/data-boar"\n',
+        encoding="utf-8",
+    )
+    git("add", "sample.md")
+    git("commit", "-m", "base with ssh url")
+    git("checkout", "-b", "feature-behind")
+    git("checkout", "main")
+    sample.write_text("git_origin placeholder only\n", encoding="utf-8")
+    git("add", "sample.md")
+    git("commit", "-m", "fix on main")
+    main_sha = git("rev-parse", "main").stdout.strip()
+    git("update-ref", "refs/remotes/origin/main", main_sha)
+    git("checkout", "feature-behind")
+
+    monkeypatch.setattr(guard, "REPO_ROOT", repo)
+    monkeypatch.setattr(sys, "argv", ["pii_history_guard.py"])
+    assert guard.main() == 0


### PR DESCRIPTION
## Summary
- Use `git diff origin/main...HEAD` (merge-base) instead of two-dot tree compare in `_collect_lines_to_scan`.
- Keeps `DEFAULT_SCAN_RANGE = "origin/main..HEAD"` for rev-list semantics; output labels use three-dot form.
- Adds regression tests for three-dot diff args and ancestor-of-main OK path.

## Test plan
- [x] `./scripts/check-all.sh`
- [x] `pytest tests/test_pii_guard.py::test_pii_history_guard_diff_uses_three_dot_range`
- [x] `pytest tests/test_pii_guard.py::test_pii_history_guard_ok_when_branch_is_ancestor_of_main`

Closes #805

Made with [Cursor](https://cursor.com)