### PR TITLE
chore(adr): retrofit ADR-0061/0062 to UMADR + audit 0046-0058 + ADR-0065 NIST stub

### DIFF
--- a/docs/adr/ADR-0052-yaml-plugin-system-centralized-schema.md
+++ b/docs/adr/ADR-0052-yaml-plugin-system-centralized-schema.md
@@ -1,10 +1,17 @@
-# ADR-0052 — YAML-Based Plugin System: Centralized Schema and Unified Plugin File
+# ADR 0052 — YAML-Based Plugin System: Centralized Schema and Unified Plugin File
 
-**Date:** 2026-05-14
-**Status:** Accepted
-**Deciders:** Operator / Maintainer
+- **Date (UTC):** 2026-05-14
+- **Authors:** Fabio Leitao
+- **Deciders:** Fabio Leitao
 
----
+## Status
+
+Accepted
+
+### Status history
+
+- 2026-05-14 — Accepted
+- 2026-06-11 — Amended: retrofit to ADR-0045 UMADR format (metadata list, Authors, Status history) — GitHub #675
 
 ## Context
 

--- a/docs/adr/ADR-0055-orthogonal-priority-axes-anti-collision-contract.md
+++ b/docs/adr/ADR-0055-orthogonal-priority-axes-anti-collision-contract.md
@@ -1,7 +1,17 @@
-# ADR 0055 - Orthogonal priority axes (H/U/A/P/G/S/M) anti-collision contract
+# ADR 0055 — Orthogonal priority axes (H/U/A/P/G/S/M) anti-collision contract
 
-**Status:** Accepted
-**Date:** 2026-05-19
+- **Date (UTC):** 2026-05-19
+- **Authors:** Fabio Leitao
+- **Deciders:** Fabio Leitao
+
+## Status
+
+Accepted
+
+### Status history
+
+- 2026-05-19 — Accepted
+- 2026-06-11 — Amended: retrofit to ADR-0045 UMADR format (metadata list, Authors, Status history) — GitHub #675
 
 ## Context
 

--- a/docs/adr/ADR-0056-cryptographic-adr-inventory-inv-adr-ssh-attestation.md
+++ b/docs/adr/ADR-0056-cryptographic-adr-inventory-inv-adr-ssh-attestation.md
@@ -1,7 +1,17 @@
-# ADR 0056 - Cryptographic ADR inventory (inv-adr.ps1 + SSH ed25519 attestation)
+# ADR 0056 — Cryptographic ADR inventory (inv-adr.ps1 + SSH ed25519 attestation)
 
-**Status:** Accepted
-**Date:** 2026-05-20
+- **Date (UTC):** 2026-05-20
+- **Authors:** Fabio Leitao
+- **Deciders:** Fabio Leitao
+
+## Status
+
+Accepted
+
+### Status history
+
+- 2026-05-20 — Accepted
+- 2026-06-11 — Amended: retrofit to ADR-0045 UMADR format (metadata list, Authors, Status history) — GitHub #675
 
 ## Context
 

--- a/docs/adr/ADR-0057-lightweight-hub-index-co-located-links.md
+++ b/docs/adr/ADR-0057-lightweight-hub-index-co-located-links.md
@@ -1,7 +1,17 @@
-# ADR 0057 - Lightweight hub index (co-located links, no file moves)
+# ADR 0057 — Lightweight hub index (co-located links, no file moves)
 
-**Status:** Accepted
-**Date:** 2026-05-20
+- **Date (UTC):** 2026-05-20
+- **Authors:** Fabio Leitao
+- **Deciders:** Fabio Leitao
+
+## Status
+
+Accepted
+
+### Status history
+
+- 2026-05-20 — Accepted
+- 2026-06-11 — Amended: retrofit to ADR-0045 UMADR format (metadata list, Authors, Status history) — GitHub #675
 
 ## Context
 

--- a/docs/adr/ADR-0058-primer-hub-registration-ritual.md
+++ b/docs/adr/ADR-0058-primer-hub-registration-ritual.md
@@ -1,7 +1,17 @@
-# ADR 0058 - Primer hub registration ritual
+# ADR 0058 — Primer hub registration ritual
 
-**Status:** Accepted
-**Date:** 2026-05-20
+- **Date (UTC):** 2026-05-20
+- **Authors:** Fabio Leitao
+- **Deciders:** Fabio Leitao
+
+## Status
+
+Accepted
+
+### Status history
+
+- 2026-05-20 — Accepted
+- 2026-06-11 — Amended: retrofit to ADR-0045 UMADR format (metadata list, Authors, Status history) — GitHub #675
 
 ## Context
 

--- a/docs/adr/ADR-0061-u-axis-issue-suborder-and-cross-milestone-gate.md
+++ b/docs/adr/ADR-0061-u-axis-issue-suborder-and-cross-milestone-gate.md
@@ -1,36 +1,70 @@
----
-# ADR-0061 — U-axis issue sub-order and cross-milestone gate
-**Status:** Accepted
-**Date:** 2026-05-22
-**Relates to:** ADR-0055 (anti-collision contract)
+# ADR 0061 — U-axis issue sub-order and cross-milestone gate
 
-## Contexto
-ADR-0055 estabelece que os eixos de priorização são ortogonais e não devem ser colapsados. Ele NÃO define como um agente deve usar o eixo U para ordenar issues quando múltiplos issues têm o mesmo P label e milestone. Resultado sem esta ADR: agente pode escolher qualquer P2/v1.7.5-beta em qualquer ordem.
-A rule `.cursor/rules/execution-priority-and-pr-batching.mdc` implementa o comportamento; esta ADR é o contrato formal que lhe dá status de lei no repositório.
+- **Date (UTC):** 2026-05-22
+- **Authors:** Fabio Leitao
+- **Deciders:** Fabio Leitao
 
-## Decisão
-### Sub-ordenação por U dentro do mesmo P+milestone
-| U | Descrição | Comportamento do agente |
-|---|---|---|
-| U0 | security/safety now | Bloqueia todo o restante da sessão até resolver |
-| U1 | high-value / chain blocker / deadline externo | Executa antes de U2/U3/sem-U |
-| U2 | valioso, sem deadline hard | Executa antes de U3/sem-U |
-| U3 | explicitamente diferido | Executa após U0/U1/U2 |
-| sem U | ausência de tag U no body | Tratado como U3 — menor sub-prioridade dentro do milestone |
+## Status
 
-### Gate cross-milestone
-- Issues de milestone posterior (v1.7.5-beta) NÃO iniciam antes do milestone anterior (v1.7.4) ser fechado
-- Marcação `**NÃO INICIAR ANTES DE #N FECHADA**` no body é hard constraint — não advisory
-- Reprioritização cross-milestone requer instrução explícita do operador no início da sessão
+Accepted
 
-## Consequências
-- **Positivo:** Cursor não pode improvisar ordem dentro de P2/v1.7.5-beta; sequenciamento é determinístico
-- **Negativo:** Issues novos sem U são automaticamente U3 — criador deve ser explícito se quiser U1/U2
-- **Watch:** Manter U atualizado quando pressão externa de um issue mudar (ex: parceiro confirma deadline)
+### Status history
 
-## Referências
-- ADR-0055 — anti-collision contract
-- `.cursor/rules/execution-priority-and-pr-batching.mdc` — implementação da rule
-- Issue #655 — origem desta ADR
+- 2026-05-22 — Accepted
+- 2026-06-11 — Amended: retrofit to ADR-0045 UMADR format (metadata list, EN sections, Status history, Rationale, Alternatives Considered, Related Decisions) — GitHub #674
+
+## Context
+
+ADR-0055 establishes that prioritisation axes are orthogonal and must not be collapsed. It does **not** define how an agent should use the U axis to order issues when multiple issues share the same P label and milestone. Without this ADR, an agent could pick any P2/v1.7.5-beta issue in any order.
+
+The rule `.cursor/rules/execution-priority-and-pr-batching.mdc` implements the behaviour; this ADR is the formal contract that gives it binding status in the repository.
+
+## Decision
+
+### U-axis sub-ordering within the same P+milestone
+
+| U      | Description                               | Agent behaviour                               |
+|--------|-------------------------------------------|-----------------------------------------------|
+| U0     | security/safety now                       | Blocks the entire session until resolved      |
+| U1     | high-value / chain blocker / ext deadline | Executes before U2/U3/no-U                    |
+| U2     | valuable, no hard external deadline       | Executes before U3/no-U                       |
+| U3     | explicitly deferred within milestone      | Executes after U0/U1/U2                       |
+| no-U   | U tag absent from issue body              | Treated as U3 — lowest sub-priority in milestone |
+
+### Cross-milestone gate
+
+- Issues in a later milestone (e.g. v1.7.5-beta) **must not start** before the earlier milestone (e.g. v1.7.4) is fully closed.
+- The annotation `**NÃO INICIAR ANTES DE #N FECHADA**` in an issue body is a **hard constraint** — not advisory.
+- Cross-milestone reprioritisation requires **explicit operator instruction** at the start of the session.
+
+## Rationale
+
+Agents operating on a large backlog without a deterministic sub-ordering rule introduce variance: different sessions pick different P2 issues first, making progress non-reproducible. The U axis provides a single, auditable ordering key within a P+milestone slice without collapsing it with the H (horizon), A (band), or G (gravity) axes. Chain-blocker issues (U1) stall the batch if skipped; hard-safety issues (U0) warrant session-wide suspension.
+
+The cross-milestone gate prevents agents from starting work on features that depend on a completed, tested baseline. It mirrors the reasoning behind feature-branch sequencing in CI — merging an untested milestone's issues into the next one's scope creates debt that is hard to isolate.
+
+## Alternatives Considered
+
+| Alternative | Why not |
+|-------------|---------|
+| FIFO (creation date) | Does not capture urgency or chain dependencies |
+| Random within P+milestone | Non-reproducible; agent picks cheapest or most-familiar item |
+| Single global priority number | Collapses orthogonal axes — explicitly rejected by ADR-0055 |
+| Operator-specified order each session | Too much toil; defeats the purpose of autonomous U-axis ordering |
+
+## Consequences
+
+- **Positive:** Deterministic sequencing within P+milestone; agents cannot improvise order.
+- **Negative:** New issues without a U tag are automatically treated as U3 — creators must be explicit when U1/U2 is intended.
+- **Watch:** Update U tag when external deadline pressure changes (e.g. partner confirms deadline).
+
+## Related Decisions
+
+- [ADR-0055](ADR-0055-orthogonal-priority-axes-anti-collision-contract.md) — anti-collision contract (orthogonal axes)
+- [ADR-0062](ADR-0062-agent-containment-triple-audit-offband-pingpong.md) — agent containment (context for sequencing governance)
+
+## References
+
+- `.cursor/rules/execution-priority-and-pr-batching.mdc` — rule implementation
+- Issue #655 — origin of this ADR
 - Issue #654 — `docs/ops/ISSUE_QUEUE_SEQUENCING_MAP.md` (Mermaid queue map)
----

--- a/docs/adr/ADR-0062-agent-containment-triple-audit-offband-pingpong.md
+++ b/docs/adr/ADR-0062-agent-containment-triple-audit-offband-pingpong.md
@@ -1,56 +1,105 @@
----
-# ADR-0062 — Agent containment: triple-audit offband pattern (A.I.I.D.C.O.B.P.P.)
-**Status:** Accepted
-**Date:** 2026-05-22
-**Relates to:** ADR-0046 (guardrails não-negociáveis), AGENTS.md
+# ADR 0062 — Agent containment: triple-audit offband pattern (A.I.I.D.C.O.B.P.P.)
 
-## Contexto
-Durante a execução da wave-656-u0-u1 (PR #658), o agente do Cursor (Composer-2.5) apresentou desvio de sequenciamento de regras (.mdc), ignorando limites imperativos de escopo e gerando risco latente de regressão de código e consumo fantasma de tokens Anthropic off-band. Devido ao não-determinismo crônico das barreiras nativas da IDE, foi necessária a criação de um mecanismo externo de controle de estado.
+- **Date (UTC):** 2026-05-22
+- **Authors:** Fabio Leitao
+- **Deciders:** Fabio Leitao
 
-Este padrão emergiu empiricamente durante a madrugada de 21-22/05/2026 e foi validado por três auditores independentes: Anthropic Sonnet 4.6 (Windows), Anthropic Sonnet 4.6 (Linux), e Google Gemini Pro (validação estrutural).
+## Status
 
-## Topologia real (A.I.I.D.C.O.B.P.P.)
+Accepted
+
+### Status history
+
+- 2026-05-22 — Accepted
+- 2026-05-23 — Amended: quad-audit (4-auditor) variant validated empirically
+- 2026-06-11 — Amended: retrofit to ADR-0045 UMADR format (metadata list, EN sections, Status history, Rationale, Alternatives Considered, Related Decisions, Extensibility) — GitHub #674
+
+## Context
+
+During the execution of wave-656-u0-u1 (PR #658), the Cursor agent (Composer-2.5) exhibited rule-sequencing drift (`.mdc` rules), ignoring imperative scope boundaries and generating latent regression risk and off-band Anthropic token consumption. Because the IDE's native barriers are chronically non-deterministic, an external state-control mechanism became necessary.
+
+This pattern emerged empirically during the night of 2026-05-21/22 and was validated by three independent auditors: Anthropic Claude Sonnet 4.6 (Windows / LAB-NODE-01), Anthropic Claude Sonnet 4.6 (Linux / LAB-NODE-02), and Google Gemini Pro (structural validation).
+
+## Topology (A.I.I.D.C.O.B.P.P.)
 
 ```mermaid
 flowchart TD
-    OP["🧑 Operador\n(Banda Base — data bus)"]
+    OP["🧑 Operator\n(Base Band — data bus)"]
     CW["Claude Windows\nSonnet 4.6 — Auditor A\n(LAB-NODE-01)"]
     CL["Claude Linux\nSonnet 4.6 — Auditor B\n(LAB-NODE-02)"]
-    CT["Consenso Tático\nLinting de Prompt\n(convergência entre auditores)"]
-    GG["Google Gemini\nValidador de Arquitetura\n(revisão estrutural independente)"]
-    TG["Target — Cursor / Git\nTier Composer-2.5\n(executor — labora apenas)"]
+    CT["Tactical Consensus\nPrompt Linting\n(convergence between auditors)"]
+    GG["Google Gemini\nArchitecture Validator\n(independent structural review)"]
+    TG["Target — Cursor / Git\nComposer-2.5 tier\n(executor — works only)"]
 
-    OP -->|"distribui payload"| CW
-    OP -->|"distribui payload"| CL
-    CW -->|"ping: recomendação A"| CT
-    CL -->|"pong: revisão B"| CT
-    CT -->|"payload convergido"| GG
-    GG -->|"sign-off estrutural"| TG
+    OP -->|"distributes payload"| CW
+    OP -->|"distributes payload"| CL
+    CW -->|"ping: recommendation A"| CT
+    CL -->|"pong: review B"| CT
+    CT -->|"converged payload"| GG
+    GG -->|"structural sign-off"| TG
 ```
 
-> **Nota crítica de topologia:** Os dois Claude não se comunicam diretamente. O Operador é o barramento físico (data bus) que roteia os payloads entre os auditores. Uma seta direta entre eles seria uma alucinação de infraestrutura.
+> **Critical topology note:** The two Claude instances do not communicate directly. The Operator is the physical data bus routing payloads between auditors. A direct arrow between them would be an infrastructure hallucination.
 
-## Decisão
-Implementar o padrão de Triangulação de Três Pilares Independentes fora do barramento do agente controlado:
+## Decision
 
-1. **Isolamento de Estado (Camada Tática):** Dois modelos independentes (Claude Sonnet 4.6) operando em OSes distintos. O operador atua como barramento físico realizando ping-pong de prompts até convergência e eliminação de typos/gaps.
-2. **Validação de Fronteira (Camada Estratégica):** Submissão do payload convergido ao terceiro auditor independente (Google Gemini) para validação estrutural.
-3. **Execução Idempotente:** Injeção do prompt final com gatilhos de interrupção síncronos (`git log`, `gh issue list`) antes de qualquer push.
+Implement the Three Independent Pillars Triangulation pattern outside the controlled agent's bus:
 
-## Caso documentado — exemplo negativo
-Durante a elaboração deste ADR, três modelos de IA independentes (Anthropic ×2, Google) convergiram em uma convenção de filename incorreta sem consultar o repositório. O operador humano forçou a verificação dos 59 ADRs existentes. O repositório corrigiu o consenso dos três algoritmos.
+1. **State Isolation (Tactical Layer):** Two independent models (Claude Sonnet 4.6) operating on distinct OSes. The operator acts as the physical data bus, routing prompts in a ping-pong until convergence and elimination of typos/gaps.
+2. **Boundary Validation (Strategic Layer):** Submit the converged payload to a third independent auditor (Google Gemini) for structural validation.
+3. **Idempotent Execution:** Inject the final prompt with synchronous interrupt triggers (`git log`, `gh issue list`) before any push.
 
-> **Consenso de LLMs ≠ fonte da verdade. A fonte da verdade é o repositório.**
+### Documented case — negative example
 
-## Consequências
-- **Positivo:** Risco de regressão reduzido; divergência entre auditores = sinal de ambiguidade no prompt; convergência = verde para executar.
-- **Negativo:** Aumento do toil do operador humano como barramento de sincronização entre instâncias isoladas.
+During the drafting of this ADR, three independent AI models (Anthropic ×2, Google) converged on an incorrect filename convention without consulting the repository. The human operator forced verification of the 59 existing ADRs. The repository corrected the consensus of all three algorithms.
 
-## Referências
-- Issue #656 — wave que originou este padrão
-- PR #658 — wave mergeada com o padrão ativo
-- ADR-0061 — sequenciamento U-axis (Issue #655)
-- PR #648 — arquitetura SoD que motivou auditoria externa
-- Issue #659 — origem desta ADR
-- `AGENTS.md` — política de auditores vs executor
----
+> **LLM consensus ≠ source of truth. The source of truth is the repository.**
+
+## Rationale
+
+Agent containment via external multi-auditor triangulation addresses two distinct failure modes:
+
+1. **Scope drift:** A single model operating in isolation accumulates context decay and "creative" interpretation of constraints. Two independent instances with the operator as bus create a natural diff-check.
+2. **Hallucination convergence:** Multiple LLMs can independently converge on the same incorrect answer. The repository (git log, file listing) serves as the ground-truth arbiter, not model consensus.
+
+The pattern is intentionally asymmetric: auditors review and converge; only the final, operator-validated payload reaches the executor. This preserves the executor's autonomy for in-scope work while bounding blast radius.
+
+## Alternatives Considered
+
+| Alternative | Why not |
+|-------------|---------|
+| Single-model review loop | Does not catch scope drift; same model re-validates its own errors |
+| Automated CI only | CI runs after execution; does not prevent mid-session drift |
+| Operator manual review of every step | Excessive toil; defeats the efficiency rationale for agent assistance |
+| GPT-4 as third auditor | Valid alternative; Google Gemini chosen for provider diversity |
+
+## Extensibility
+
+The pattern generalises to N independent auditors (N ≥ 2). A **quad-audit** variant (4 auditors) was validated empirically on 2026-05-23, extending the triple pattern with a fourth model instance for high-stakes decisions. Scaling guidance:
+
+| N | Use when |
+|---|----------|
+| 2 (dual) | Low-blast-radius chore/docs PRs; one auditor per OS |
+| 3 (triple) | Standard: cross-provider structural validation (original pattern) |
+| 4 (quad) | High-stakes architectural decisions; cross-org model diversity |
+| 5+ | Reserved for security-critical decisions with mandatory human sign-off |
+
+The operator (human-in-the-loop) remains the physical data bus in all variants. No direct inter-auditor communication is assumed.
+
+## Consequences
+
+- **Positive:** Regression risk reduced; auditor divergence signals prompt ambiguity; convergence signals green for execution.
+- **Negative:** Increased toil on the human operator as synchronisation bus between isolated instances.
+
+## Related Decisions
+
+- [ADR-0046](ADR-0046-operator-intent-and-blameless-collaboration.md) — non-negotiable guardrails (context)
+- [ADR-0061](ADR-0061-u-axis-issue-suborder-and-cross-milestone-gate.md) — U-axis sequencing
+- `AGENTS.md` — auditor vs executor policy
+
+## References
+
+- Issue #656 — wave that originated this pattern
+- PR #658 — wave merged with the pattern active
+- PR #648 — SoD architecture that motivated external audit
+- Issue #659 — origin of this ADR

--- a/docs/adr/ADR-0065-nist-sp800228a-api-security-reference.md
+++ b/docs/adr/ADR-0065-nist-sp800228a-api-security-reference.md
@@ -1,0 +1,61 @@
+# ADR 0065 — NIST SP 800-228A as REST API security hardening reference
+
+- **Date (UTC):** 2026-06-11
+- **Authors:** Fabio Leitao
+- **Deciders:** Fabio Leitao
+
+## Status
+
+Deferred
+
+### Status history
+
+- 2026-06-11 — Deferred: NIST SP 800-228A still in public comment (deadline 2026-07-02); ADR to be written post final publication — GitHub #710
+
+## Context
+
+NIST SP 800-228A ("Secure Deployment of RESTful Web APIs") is in public comment until 2026-07-02. When finalised it will be the most current NIST normative reference for REST API security — directly relevant to the Data Boar API, which exposes PII scan findings.
+
+The base document SP 800-228 (final) is already available. The architectural decisions around adopting SP 800-228A have concrete consequences:
+
+- Authentication and authorisation of findings endpoints
+- Required security headers (`Content-Security-Policy`, `Strict-Transport-Security`, etc.)
+- Rate limiting and injection protection
+- PII handling in API responses (masking, pagination, access scope)
+
+Adopting the standard as a hardening reference affects the public API contract and `docs/ENTERPRISE_INTEGRATION_GUIDE.md`.
+
+## Decision
+
+**Deferred** until NIST SP 800-228A final publication (expected Q3/Q4 2026). Do **not** draft the decision based on the Initial Public Draft (IPD) — the final text may change.
+
+Once published, this ADR will be amended to:
+
+1. Adopt SP 800-228A as the primary hardening checklist for `api/routes.py` and the API documentation.
+2. Document which OWASP API Security Top 10 / RFC 9110 controls are already satisfied and which require new work.
+3. Open a follow-up implementation issue with a control-by-control checklist derived from the final text.
+
+## Rationale
+
+Drafting an ADR from an IPD risks locking in controls that change in the final publication, or missing additions that the public comment period introduces. A Deferred ADR records the decision-making intent and prevents duplicate investigation while avoiding premature commitment.
+
+## Alternatives Considered
+
+| Alternative | Why not |
+|-------------|---------|
+| Draft now from IPD | Risk of invalidated controls; rework cost after final publication |
+| OWASP API Security Top 10 only | Less formally normative; no NIST alignment for government/regulated clients |
+| RFC 9110 (HTTP semantics) | Covers semantics, not security hardening posture |
+| No formal reference | Leaves hardening decisions undocumented; harder to audit |
+
+## Related Decisions
+
+- [ADR-0056](ADR-0056-cryptographic-adr-inventory-inv-adr-ssh-attestation.md) — ADR inventory policy
+- Issue #599 — `ENTERPRISE_INTEGRATION_GUIDE.md` (API surface context)
+- Issue #561 — `SECURITY.md` hardening (adjacent scope)
+
+## References
+
+- SP 800-228 (final): <https://csrc.nist.gov/pubs/sp/800/228/final>
+- SP 800-228A (IPD): <https://csrc.nist.gov/pubs/sp/800/228/a/ipd>
+- Public comment deadline: 2026-07-02

--- a/docs/adr/INVENTORY.txt
+++ b/docs/adr/INVENTORY.txt
@@ -55,16 +55,17 @@
 0049 | Accepted | 04A634D892FE07A30560FDBC04F3CEACBD710491B94E3E9B5CEE346417A7B30A | ADR-0049-no-brittle-mitigations-robust-input-handling.md | No brittle mitigations — robust input handling over symptom suppression
 0050 | Accepted | 902D694FAE7CDEF77B48BBA352502BA550F6EE651F265B96012F1FE216DE5401 | ADR-0050-plan-document-metadata-standard.md | Plan document metadata standard
 0051 | Accepted | 28F5BCB170C515F028A747C286420FF2A099EE39B132B9C0D0223BDD2ADF57AB | ADR-0051-incremental-filesystem-scan-file-identity-fingerprint.md | Incremental filesystem scan: file-identity fingerprint contract
-0052 | Accepted | C47D5357C0CDE5FFF8326B5816B48222299E1061B1359C061AEBC70F7A8D59E4 | ADR-0052-yaml-plugin-system-centralized-schema.md | yaml plugin system centralized schema
+0052 | Accepted | 1C946B32D67778A9AE6C2D38AEFC708935E6C983FB2007FC536AB85E77DC5BD2 | ADR-0052-yaml-plugin-system-centralized-schema.md | yaml plugin system centralized schema
 0053 | Accepted | 6873B9285B0C6F4DAAFFD7673FB7A92CA871D5E947CE66120E864228EB1A2CD2 | ADR-0053-ebcdic-direct-upper-bound-and-dependabot-ignore.md | `ebcdic` direct upper-bound pin and Dependabot ignore for blocked semver-major
 0054 | Accepted | C52B8EBA09F06CAB83FD7469F027C8DFDDDE3DE9BFED11F61DA117E78AA638DE | ADR-0054-chardet-pinned-by-cyclonedx-bom.md | Decline `chardet` semver-major bumps while `cyclonedx-bom` pins `chardet<6.0`
-0055 | Accepted | DE6B2635B85053FCA142CD68F35A6F4965349AC6AD2543E9A58CD915D61E5EA1 | ADR-0055-orthogonal-priority-axes-anti-collision-contract.md | Orthogonal priority axes (H/U/A/P/G/S/M) anti-collision contract
-0056 | Accepted | EC1F3BC6E5A1FA0E6269D1A2B4737BDEF2F70FCA159C6D418CA21DC0A3ADFC6F | ADR-0056-cryptographic-adr-inventory-inv-adr-ssh-attestation.md | Cryptographic ADR inventory (inv-adr.ps1 + SSH ed25519 attestation)
-0057 | Accepted | AF0D4B1BAA14506558E87A2EC217B7917DCE1E07F77C2B53915C12797AA0DA7D | ADR-0057-lightweight-hub-index-co-located-links.md | Lightweight hub index (co-located links, no file moves)
-0058 | Accepted | 63ACE70A540BD4CCD755CDC9BD06E38D55ECA7E5CB37F192853CF2E228BFB1B4 | ADR-0058-primer-hub-registration-ritual.md | Primer hub registration ritual
-0061 | Accepted | D249F64FB5E7EFA3C1CF04135D490B6F9EDACF6065B371EA630D5A9124F24A6B | ADR-0061-u-axis-issue-suborder-and-cross-milestone-gate.md | u axis issue suborder and cross milestone gate
-0062 | Accepted | 9390D1D6FF4D6CF59E4C6F207CB9D96282F0905E52137C5F06FCA2EC835A1B43 | ADR-0062-agent-containment-triple-audit-offband-pingpong.md | agent containment triple audit offband pingpong
+0055 | Accepted | C32CF2DF14272B351D0D68360741343027860503CB7EEB46C0768CE1A1E5C7E9 | ADR-0055-orthogonal-priority-axes-anti-collision-contract.md | Orthogonal priority axes (H/U/A/P/G/S/M) anti-collision contract
+0056 | Accepted | 205B720B06316E84CA14EAAEE1D040ADA0E760E58FC69E282F5A1F586B0AE833 | ADR-0056-cryptographic-adr-inventory-inv-adr-ssh-attestation.md | Cryptographic ADR inventory (inv-adr.ps1 + SSH ed25519 attestation)
+0057 | Accepted | 632C02C677BAE045DD1A2F4019819F59A7AE4A175330AEDF87D9673CBF15EB8A | ADR-0057-lightweight-hub-index-co-located-links.md | Lightweight hub index (co-located links, no file moves)
+0058 | Accepted | 5DD2AC80DE6D451FE759703004B368367294B220103FBC5B08C8B579DD68FDAC | ADR-0058-primer-hub-registration-ritual.md | Primer hub registration ritual
+0061 | Accepted | 7B71A874B619ABC8CDC309FCD321C7AF92DB025FB6A744DF6C97650445938146 | ADR-0061-u-axis-issue-suborder-and-cross-milestone-gate.md | u axis issue suborder and cross milestone gate
+0062 | Accepted | 4E9FEB28A8BF9E9B90C11F9D2DAF74BBEFB7C83149F1F7EEB740BEDC2019D399 | ADR-0062-agent-containment-triple-audit-offband-pingpong.md | agent containment triple audit offband pingpong
+0065 | Deferred | 172139DE0BA2891DB126B7058D5EF05B3BF5D7CCEBBA8DBD2D3874BDEBDD6C6C | ADR-0065-nist-sp800228a-api-security-reference.md | NIST SP 800-228A as REST API security hardening reference
 0066 | Accepted | D55D681D1A1F7D46100ADC8236480E6E3ECDE0D00CDC645696C9760C2935AF24 | ADR-0066-tampered-state-behavior.md | TAMPERED state behavior (fail-closed in enforced mode)
 0068 | Proposed | B6DAAE42DF68D58C7CB2B0711345A59099E8EF95FA1829D648131FAA1CC328D5 | ADR-0068-primary-linux-dev-workstation-temporary.md | Primary Linux dev workstation (temporary)
 #
-# InventoryHash: 25938A0823DB24AB2A53CA9AF5BFBC73B005ADD0D49CE5E173B60F533FC0C73D
+# InventoryHash: D98FB4C78D22BBA2F9E8E6C8DFC3A323E19975F5222BA489C04810A1A82666A2

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -79,6 +79,7 @@ Short, durable notes that capture **why** the project chose an approach—not on
 | 0058  | [Primer hub registration ritual](ADR-0058-primer-hub-registration-ritual.md) | Accepted |
 | 0061 | [ADR-0061 U-axis issue sub-order and cross-milestone gate](ADR-0061-u-axis-issue-suborder-and-cross-milestone-gate.md) | Accepted |
 | 0062 | [ADR-0062 Agent containment: triple-audit offband pattern](ADR-0062-agent-containment-triple-audit-offband-pingpong.md) | Accepted |
+| 0065 | [NIST SP 800-228A as REST API security hardening reference](ADR-0065-nist-sp800228a-api-security-reference.md) | Deferred |
 | 0066 | [TAMPERED state behavior — fail-closed in enforced mode](ADR-0066-tampered-state-behavior.md) | Accepted |
 | 0068 | [Primary Linux dev workstation (temporary)](ADR-0068-primary-linux-dev-workstation-temporary.md) | Proposed |
 


### PR DESCRIPTION
## Summary

- **Closes #674** — Retrofit ADR-0061 and ADR-0062 to ADR-0045 UMADR format: remove YAML fence, convert metadata to list format, add Authors/Deciders/Date(UTC)/Status history, translate all sections to EN, add Rationale/Alternatives Considered/Related Decisions. ADR-0062 gains new `Extensibility` section documenting the N-auditor pattern (quad-audit validated 2026-05-23).
- **Closes #675** — Audit ADR-0046–0058 for MADR compliance. ADR-0046 to 0051, 0053, 0054 were already compliant. ADR-0052, 0055, 0056, 0057, 0058 had inline bold metadata (not list format) and missing Authors field — fixed. Body content unchanged.
- **Closes #710** — Create ADR-0065 as a `Deferred` stub for NIST SP 800-228A ("Secure Deployment of RESTful Web APIs"). IPD public comment period closes 2026-07-02; ADR will be finalised post-publication (expected Q3/Q4 2026).

## Notes

- `docs/adr/INVENTORY.txt` updated with new SHA-256 hashes after each commit.
- `docs/adr/README.md` updated with ADR-0065 entry.
- `./scripts/check-all.sh` passed (1272 tests, 0 failures) before push.

Made with [Cursor](https://cursor.com)