### PR TITLE
fix(maestro): Linux-compat redirect + process/port cleanup (#818, #820)

### DIFF
--- a/scripts/maestro/Handle-LicensingMatrix.ps1
+++ b/scripts/maestro/Handle-LicensingMatrix.ps1
@@ -157,6 +157,8 @@ function Start-MatrixApiProcess {
     $childEnv["DATA_BOAR_LICENSE_PATH"] = $LicensePath
     $childEnv["DATA_BOAR_LICENSE_PUBLIC_KEY_PATH"] = $PublicKeyPath
     $childEnv["CONFIG_PATH"] = $ConfigPath
+    # -Environment requires pwsh 7.4+ (guaranteed by #Requires -Version 7.6.1 above).
+    # -WindowStyle Hidden is Windows-only; pwsh silently ignores it on Linux/macOS.
     $proc = Start-Process `
         -FilePath "uv" `
         -ArgumentList $args `
@@ -207,21 +209,32 @@ function Stop-MatrixApiProcess {
     }
     $proc = $ApiBundle.Process
     if (-not $proc.HasExited) {
-        & taskkill /F /T /PID $proc.Id 2>$null
+        # Cross-platform: proc.Kill($true) terminates the entire process tree
+        # (covers child uv/python processes on Linux and Windows alike).
+        # taskkill /F /T is Windows-only and must not be used here.
+        try { $proc.Kill($true) } catch { }
         Start-Sleep -Seconds 2
     }
-    # belt-and-suspenders: kill whatever process still holds the port, then poll until free
+    # belt-and-suspenders: kill whatever process still holds the port, then poll until free.
+    # Get-NetTCPConnection is Windows-only; on Linux use .NET IPGlobalProperties for the poll
+    # and skip the PID-by-port lookup (proc.Kill($true) above covers child processes).
     if ($ApiBundle.ApiPort) {
-        $portPid = (Get-NetTCPConnection -LocalPort $ApiBundle.ApiPort -State Listen -ErrorAction SilentlyContinue).OwningProcess
-        if ($portPid) {
-            Stop-Process -Id $portPid -Force -ErrorAction SilentlyContinue
-            Start-Sleep -Seconds 1
+        if ($IsWindows) {
+            $portPid = (Get-NetTCPConnection -LocalPort $ApiBundle.ApiPort -State Listen -ErrorAction SilentlyContinue).OwningProcess
+            if ($portPid) {
+                Stop-Process -Id $portPid -Force -ErrorAction SilentlyContinue
+                Start-Sleep -Seconds 1
+            }
         }
         $portFree = $false
         $deadline = (Get-Date).AddSeconds(8)
         while ((Get-Date) -lt $deadline) {
-            $conn = Get-NetTCPConnection -LocalPort $ApiBundle.ApiPort -State Listen -ErrorAction SilentlyContinue
-            if (-not $conn) { $portFree = $true; break }
+            # GetActiveTcpListeners() is cross-platform (.NET 5+, covers pwsh 7.4+).
+            $listeners = [System.Net.NetworkInformation.IPGlobalProperties]::GetIPGlobalProperties().GetActiveTcpListeners()
+            if (-not ($listeners | Where-Object { $_.Port -eq $ApiBundle.ApiPort })) {
+                $portFree = $true
+                break
+            }
             Start-Sleep -Milliseconds 300
         }
         if (-not $portFree) {

--- a/scripts/maestro/Handle-LicensingMatrix.ps1
+++ b/scripts/maestro/Handle-LicensingMatrix.ps1
@@ -114,8 +114,12 @@ function Invoke-ApiPostStatus {
             -MaximumRedirection 0
         return [int]$response.StatusCode
     } catch {
-        if ($_.Exception.Message -match "[Rr]edirect") {
-            return 302
+        # Use numeric status code, not locale-dependent exception message text.
+        # PowerShell throws on 3xx when -MaximumRedirection 0; the response
+        # object carries the real status code regardless of system locale.
+        $resp = $_.Exception.Response
+        if ($resp -and [int]$resp.StatusCode -ge 300 -and [int]$resp.StatusCode -lt 400) {
+            return [int]$resp.StatusCode
         }
         throw
     }

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -430,6 +430,33 @@ def test_invoke_api_post_status_uses_numeric_status_not_locale_string() -> None:
     )
 
 
+def test_stop_matrix_api_process_is_cross_platform() -> None:
+    """Anti-regression #820: Stop-MatrixApiProcess must not use Windows-only taskkill
+    or unconditional Get-NetTCPConnection; cross-platform kill and port poll required.
+    """
+    root = _project_root()
+    text = (root / "scripts" / "maestro" / "Handle-LicensingMatrix.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "& taskkill" not in text, (
+        "Stop-MatrixApiProcess must not invoke taskkill (Windows-only); use proc.Kill or Stop-Process"
+    )
+    # Get-NetTCPConnection must be guarded by $IsWindows when present
+    if "Get-NetTCPConnection" in text:
+        assert "$IsWindows" in text, (
+            "Get-NetTCPConnection is Windows-only and must be inside an 'if ($IsWindows)' block"
+        )
+    # Cross-platform port poll must use .NET IPGlobalProperties
+    assert "GetActiveTcpListeners" in text, (
+        "Port-free poll must use .NET GetActiveTcpListeners() which works cross-platform "
+        "instead of Windows-only Get-NetTCPConnection"
+    )
+    # Cross-platform process kill must be present
+    assert "proc.Kill" in text or "Stop-Process" in text, (
+        "Stop-MatrixApiProcess must use proc.Kill($true) or Stop-Process for cross-platform kill"
+    )
+
+
 def test_maestro_no_retired_workstation_codename_token() -> None:
     """Maestro *.ps1 must not embed the retired workstation codename token (guard: test_public_tree_no_*codename*)."""
     root = _project_root()

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -406,6 +406,30 @@ def test_lab_completao_host_smoke_writes_baremetal_scan_sentinel() -> None:
     assert "LC_BENCH_ROOT" in text
 
 
+def test_invoke_api_post_status_uses_numeric_status_not_locale_string() -> None:
+    """Anti-regression #818: redirect detection must use numeric status code, not locale-dependent message text.
+
+    PowerShell throws on 3xx when -MaximumRedirection 0; the exception message is
+    locale-translated on non-English systems (e.g. pt_BR), so matching the word
+    'redirect' in the message text is unreliable.  The fix reads
+    $_.Exception.Response.StatusCode (an integer) instead.
+    """
+    root = _project_root()
+    text = (root / "scripts" / "maestro" / "Handle-LicensingMatrix.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "[Rr]edirect" not in text, (
+        "Invoke-ApiPostStatus must not match the word 'redirect' in the exception message "
+        "(locale-dependent); check numeric StatusCode instead"
+    )
+    assert ".StatusCode -ge 300" in text, (
+        "Invoke-ApiPostStatus must check numeric 3xx lower bound (.StatusCode -ge 300)"
+    )
+    assert ".StatusCode -lt 400" in text, (
+        "Invoke-ApiPostStatus must check numeric 3xx upper bound (.StatusCode -lt 400)"
+    )
+
+
 def test_maestro_no_retired_workstation_codename_token() -> None:
     """Maestro *.ps1 must not embed the retired workstation codename token (guard: test_public_tree_no_*codename*)."""
     root = _project_root()


### PR DESCRIPTION
## Summary

Gate do #704 / release 1.7.4 — compatibilidade Linux para `Handle-LicensingMatrix.ps1`.

### Commit 1 — fix `Invoke-ApiPostStatus` redirect detection (#818)

The catch branch matched the English word `redirect` in the exception message.
On non-English PowerShell hosts (e.g. pt_BR locale) the message is translated and
never matches, so the handler re-threw instead of returning the 3xx status code.

**Fix:** read `$_.Exception.Response.StatusCode` (numeric) and return it when it
is in the 3xx range, independent of system locale.

**Regression test:** `test_invoke_api_post_status_uses_numeric_status_not_locale_string`
asserts no `[Rr]edirect` string match and that `.StatusCode -ge 300 / -lt 400` guards exist.

### Commit 2 — cross-platform process/port cleanup in `Stop-MatrixApiProcess` (#820)

`& taskkill /F /T` and `Get-NetTCPConnection` are Windows-only. On Linux the process
was not killed and the port stayed bound, causing tier-to-tier port collisions
(`community -> pro -> enterprise` all reuse `$Port`).

**Fixes:**
- Replace `& taskkill /F /T /PID` with `$proc.Kill($true)` — kills full process tree via .NET `Process.Kill(entireProcessTree)`, cross-platform.
- Wrap `Get-NetTCPConnection` PID-by-port lookup in `if ($IsWindows)`.
- Replace the port-free poll loop with `.NET IPGlobalProperties.GetActiveTcpListeners()` (cross-platform, works on Linux/macOS).
- Document that `-WindowStyle Hidden` is silently ignored on Linux/macOS and `-Environment` requires pwsh 7.4+ (already satisfied by `#Requires -Version 7.6.1`).

**Regression test:** `test_stop_matrix_api_process_is_cross_platform` asserts no `& taskkill`, `GetActiveTcpListeners` usage, and `$IsWindows` guard for `Get-NetTCPConnection`.

## Test plan

- [x] `./scripts/check-all.sh` green locally (1274 passed, 5 skipped)
- [x] Both commits signed ed25519
- [x] Staged via explicit paths (no `git add -A`)
- [ ] CI green -> merge

Closes #818
Closes #820

Made with [Cursor](https://cursor.com)