### PR TITLE
security(detector): ReDoS guard on third-party regex overrides (#829)

### DIFF
--- a/config/plugin_validator.py
+++ b/config/plugin_validator.py
@@ -43,6 +43,98 @@ _TYPE_CHECK: dict[str, type | tuple[type, ...]] = {
 _UNIFIED_SECTION_KEYS = frozenset(("regex_patterns", "ml_patterns", "dl_patterns"))
 
 
+def _is_unbounded_brace(body: str) -> bool:
+    """Return True for a ``{m,}`` repetition body (no upper bound), e.g. ``2,``."""
+    return body.endswith(",") and body[:-1].isdigit()
+
+
+def _has_nested_quantifier(pattern: str) -> bool:
+    """ReDoS guard (#829): return True when *pattern* nests an unbounded
+    quantifier inside a group that is itself unbounded-quantified.
+
+    This is the classic catastrophic-backtracking shape ("star height > 1",
+    same criterion as the ``safe-regex`` linter): ``(a+)+``, ``(\\w*)*``,
+    ``([a-z]+)*``, ``(x{2,})+``.
+
+    The scanner walks the pattern character by character so that:
+
+    - escaped metacharacters (``\\+``, ``\\(``, ``\\)``) are treated as
+      literals — Brazilian phone patterns like ``(\\+55\\s?)?`` stay valid;
+    - quantifier characters inside character classes (``[+*]``) are literals;
+    - the bounded ``?`` quantifier never triggers the guard (0-or-1 repetition
+      cannot blow up on its own);
+    - unbounded content propagates to enclosing groups, so ``((a+)b)+`` is
+      flagged like ``safe-regex`` would flag it (conservative by design).
+    """
+    i = 0
+    n = len(pattern)
+    in_class = False
+    # One flag per currently-open group: "contains an unbounded quantifier".
+    group_stack: list[bool] = []
+
+    while i < n:
+        ch = pattern[i]
+
+        if ch == "\\":
+            i += 2  # skip escaped char (literal, never a quantifier/group)
+            continue
+
+        if in_class:
+            if ch == "]":
+                in_class = False
+            i += 1
+            continue
+
+        if ch == "[":
+            in_class = True
+            # "[]" and "[^]" treat the first ] as a literal member.
+            if i + 1 < n and pattern[i + 1] == "]":
+                i += 1
+            elif i + 2 < n and pattern[i + 1] == "^" and pattern[i + 2] == "]":
+                i += 2
+            i += 1
+            continue
+
+        if ch == "(":
+            group_stack.append(False)
+            i += 1
+            continue
+
+        if ch == ")":
+            had_unbounded = group_stack.pop() if group_stack else False
+            j = i + 1
+            if had_unbounded and j < n:
+                nxt = pattern[j]
+                if nxt in "*+":
+                    return True
+                if nxt == "{":
+                    close = pattern.find("}", j)
+                    if close != -1 and _is_unbounded_brace(pattern[j + 1 : close]):
+                        return True
+            if had_unbounded and group_stack:
+                group_stack[-1] = True  # propagate to enclosing group
+            i += 1
+            continue
+
+        if ch in "*+":
+            if group_stack:
+                group_stack = [True] * len(group_stack)
+            i += 1
+            continue
+
+        if ch == "{":
+            close = pattern.find("}", i)
+            if close != -1:
+                if _is_unbounded_brace(pattern[i + 1 : close]) and group_stack:
+                    group_stack = [True] * len(group_stack)
+                i = close + 1
+                continue
+
+        i += 1
+
+    return False
+
+
 class PluginValidationWarning(UserWarning):
     """Raised (via warnings.warn) when a plugin file contains items that do not
     conform to the canonical schema in config/plugin_schema.yaml.
@@ -261,6 +353,17 @@ def _validate_item(
             issues.append(
                 f"{location}, field '{field_name}': value {value!r} not in "
                 f"allowed values {allowed}."
+            )
+
+        # ReDoS guard (#829): reject regex patterns with nested quantifiers.
+        if (
+            field_name == "pattern"
+            and isinstance(value, str)
+            and _has_nested_quantifier(value)
+        ):
+            issues.append(
+                f"{location}, field 'pattern': potential ReDoS — nested quantifiers "
+                f"detected in {value!r}. Simplify or use atomic grouping."
             )
 
     return issues

--- a/core/detector.py
+++ b/core/detector.py
@@ -751,13 +751,38 @@ def _load_regex_overrides(
     items = (
         data if isinstance(data, list) else data.get("patterns", data.get("regex", []))
     )
+    from config.plugin_validator import _has_nested_quantifier
+
     for item in items:
         if isinstance(item, dict):
             name = item.get("name", "")
             pattern = item.get("pattern", "")
             norm = item.get("norm_tag", "Custom")
-            if name and pattern:
-                out[name] = (pattern, norm)
+            if not (name and pattern):
+                continue
+            # ReDoS guard (#829) — enforcement at the trust boundary: third-party
+            # override patterns only. Built-in DEFAULT_PATTERNS are curated and
+            # exempt (calibration test: tests/test_redos_guard.py).
+            if _has_nested_quantifier(pattern):
+                warnings.warn(
+                    f"Plugin file '{path}': pattern '{name}' skipped — nested "
+                    f"quantifiers detected (potential ReDoS). Simplify the "
+                    f"pattern. (#829)",
+                    PluginValidationWarning,
+                    stacklevel=2,
+                )
+                continue
+            try:
+                re.compile(pattern)
+            except re.error as exc:
+                warnings.warn(
+                    f"Plugin file '{path}': pattern '{name}' skipped — invalid "
+                    f"regex: {exc}. (#829)",
+                    PluginValidationWarning,
+                    stacklevel=2,
+                )
+                continue
+            out[name] = (pattern, norm)
     return out
 
 
@@ -1124,6 +1149,9 @@ class SensitivityDetector:
         for k, v in over.items():
             patterns[k] = v
         self.patterns = patterns
+        # Built-in DEFAULT_PATTERNS are curated (trusted); third-party overrides
+        # were already filtered by _load_regex_overrides (ReDoS + re.error guard,
+        # #829), so every pattern reaching this point compiles safely.
         self._compiled = {
             name: re.compile(pat) for name, (pat, _) in self.patterns.items()
         }

--- a/tests/test_redos_guard.py
+++ b/tests/test_redos_guard.py
@@ -1,0 +1,193 @@
+"""
+Anti-regression tests for the ReDoS guard on third-party regex overrides (#829).
+
+Threat model (operator decision on #829): ReDoS is an EXTERNAL-input vector.
+Enforcement happens at the trust boundary — `_load_regex_overrides` (plugin /
+override path) — while curated built-in DEFAULT_PATTERNS are exempt. The
+calibration tests below keep the heuristic honest: every built-in must pass
+the guard, so the heuristic never drifts into rejecting curated patterns
+(the PHONE_BR false-positive regression).
+
+Validates that:
+- _has_nested_quantifier (star height > 1 scanner, escape/class-aware)
+  identifies dangerous shapes and allows curated ones.
+- _validate_item emits an issue for patterns with nested quantifiers.
+- SensitivityDetector skips override patterns with nested quantifiers or
+  invalid regex, with a warning — never crashing the scan.
+- All built-in DEFAULT_PATTERNS pass the guard and compile (calibration).
+"""
+
+import re
+import warnings
+from pathlib import Path
+
+
+def test_has_nested_quantifier_detects_dangerous_patterns() -> None:
+    """ReDoS guard: nested quantifier detector catches known-dangerous patterns."""
+    from config.plugin_validator import _has_nested_quantifier
+
+    dangerous = [
+        r"(a+)+",
+        r"(\w*)*",
+        r"([a-z]+)*",
+        r"(x{2,})+",
+        r"((a+)b)+",  # unbounded content propagates to enclosing group
+    ]
+    for pat in dangerous:
+        assert _has_nested_quantifier(pat), (
+            f"Expected _has_nested_quantifier to flag {pat!r} as dangerous (#829)"
+        )
+
+
+def test_has_nested_quantifier_allows_safe_patterns() -> None:
+    """ReDoS guard: safe patterns are not rejected."""
+    from config.plugin_validator import _has_nested_quantifier
+
+    safe = [
+        r"\d{3}\.?\d{3}\.?\d{3}-?\d{2}",  # CPF
+        r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}",  # e-mail
+        r"(a+)b*",  # quantifier after group, not nested
+        r"(\d+)\s+\w+",
+        r"(\+55\s?)?(\(?\d{2}\)?\s?)?\d{4,5}-?\d{4}",  # PHONE_BR: escaped \+ \( \) are literals
+        r"(a?)+",  # bounded ? inside — CPython empty-match protection, no blowup
+        r"([+*]\d)+",  # quantifier chars inside a character class are literals
+        r"(a{2,5})+",  # bounded brace repetition inside
+    ]
+    for pat in safe:
+        assert not _has_nested_quantifier(pat), (
+            f"Expected _has_nested_quantifier to allow safe pattern {pat!r} (#829)"
+        )
+
+
+def test_validate_item_rejects_nested_quantifier_pattern() -> None:
+    """plugin_validator._validate_item must issue an error for nested-quantifier patterns."""
+    from config.plugin_validator import _validate_item
+
+    item = {"name": "BAD_REDOS", "pattern": r"(a+)+", "norm_tag": "Custom"}
+    # Minimal field definitions matching the regex_patterns schema.
+    item_fields = {
+        "name": {"required": True, "type": "string"},
+        "pattern": {"required": True, "type": "string"},
+        "norm_tag": {"required": False, "type": "string"},
+    }
+    issues = _validate_item(item, 0, item_fields)
+    redos_issues = [i for i in issues if "ReDoS" in i or "nested quantif" in i]
+    assert redos_issues, (
+        "Expected _validate_item to produce a ReDoS issue for (a+)+ pattern (#829)"
+    )
+
+
+def test_validate_item_accepts_safe_pattern() -> None:
+    """plugin_validator._validate_item must not flag safe patterns as ReDoS risks."""
+    from config.plugin_validator import _validate_item
+
+    item = {"name": "SAFE", "pattern": r"\d{11}", "norm_tag": "CPF"}
+    item_fields = {
+        "name": {"required": True, "type": "string"},
+        "pattern": {"required": True, "type": "string"},
+        "norm_tag": {"required": False, "type": "string"},
+    }
+    issues = _validate_item(item, 0, item_fields)
+    redos_issues = [i for i in issues if "ReDoS" in i or "nested quantif" in i]
+    assert not redos_issues, (
+        "Expected no ReDoS issue for a safe pattern, got: %r" % redos_issues
+    )
+
+
+def test_detector_warns_and_skips_nested_quantifier_override(tmp_path: Path) -> None:
+    """SensitivityDetector must warn and skip OVERRIDE patterns with nested quantifiers.
+
+    Enforcement at the trust boundary (#829): the dangerous pattern never reaches
+    `_compiled`, the scan continues, and the good pattern in the same file loads.
+    """
+    import yaml
+
+    from core.detector import SensitivityDetector
+
+    bad_plugin = tmp_path / "bad_patterns.yaml"
+    bad_plugin.write_text(
+        yaml.dump(
+            [
+                {"name": "BAD_REDOS", "pattern": r"(a+)+", "norm_tag": "Custom"},
+                {"name": "GOOD_CUSTOM", "pattern": r"\d{5}", "norm_tag": "Custom"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        det = SensitivityDetector(regex_overrides_path=str(bad_plugin))
+    warning_messages = [str(w.message) for w in caught]
+    redos_warnings = [
+        m for m in warning_messages if "ReDoS" in m or "nested quantif" in m
+    ]
+    assert redos_warnings, (
+        "Expected SensitivityDetector to warn about nested quantifier in plugin (#829). "
+        f"Got warnings: {warning_messages}"
+    )
+    assert "BAD_REDOS" not in det._compiled, (
+        "SensitivityDetector must not include the dangerous pattern in _compiled (#829)"
+    )
+    assert "GOOD_CUSTOM" in det._compiled, (
+        "A safe pattern in the same plugin file must still load — skip is per-item, "
+        "not per-file (#829)"
+    )
+
+
+def test_detector_warns_and_skips_invalid_regex_override(tmp_path: Path) -> None:
+    """SensitivityDetector must warn and skip override patterns that fail re.compile."""
+    import yaml
+
+    from core.detector import SensitivityDetector
+
+    bad_plugin = tmp_path / "invalid_patterns.yaml"
+    bad_plugin.write_text(
+        yaml.dump(
+            [{"name": "BAD_SYNTAX", "pattern": r"(unclosed", "norm_tag": "Custom"}]
+        ),
+        encoding="utf-8",
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        det = SensitivityDetector(regex_overrides_path=str(bad_plugin))
+    warning_messages = [str(w.message) for w in caught]
+    invalid_warnings = [m for m in warning_messages if "invalid regex" in m]
+    assert invalid_warnings, (
+        "Expected SensitivityDetector to warn about invalid regex in plugin (#829). "
+        f"Got warnings: {warning_messages}"
+    )
+    assert "BAD_SYNTAX" not in det._compiled, (
+        "SensitivityDetector must not include the invalid pattern in _compiled (#829)"
+    )
+
+
+def test_default_patterns_pass_redos_guard() -> None:
+    """Calibration (#829): built-ins are EXEMPT from runtime enforcement, but every
+    DEFAULT_PATTERN must still pass the heuristic — if a curated pattern fails it,
+    the heuristic regressed (the PHONE_BR false-positive class), not the pattern.
+    """
+    from config.plugin_validator import _has_nested_quantifier
+    from core.detector import DEFAULT_PATTERNS
+
+    dangerous = [
+        name
+        for name, (pat, _) in DEFAULT_PATTERNS.items()
+        if _has_nested_quantifier(pat)
+    ]
+    assert not dangerous, (
+        f"ReDoS heuristic flagged curated built-in patterns — recalibrate the "
+        f"heuristic, do not weaken the patterns (#829): {dangerous}"
+    )
+
+
+def test_default_patterns_all_compile() -> None:
+    """All built-in DEFAULT_PATTERNS must compile without re.error."""
+    from core.detector import DEFAULT_PATTERNS
+
+    bad = []
+    for name, (pat, _) in DEFAULT_PATTERNS.items():
+        try:
+            re.compile(pat)
+        except re.error as exc:
+            bad.append((name, str(exc)))
+    assert not bad, f"DEFAULT_PATTERNS with re.error: {bad}"


### PR DESCRIPTION
## ReDoS guard (#829)

**Threat model (per operator decision on #829):** ReDoS is an external-input vector. Enforcement happens **at the trust boundary** — `_load_regex_overrides` (third-party plugin/override path) — while curated built-in `DEFAULT_PATTERNS` are **exempt**. Calibration tests keep the heuristic honest: every built-in must pass the guard, so it never drifts into rejecting curated patterns again (the PHONE_BR false-positive class).

### Design
- **`config/plugin_validator.py` — `_has_nested_quantifier`:** char-by-char scanner, "star height > 1" criterion (same as `safe-regex`/eslint). Replaces a regex-over-regex approach that false-positived on PHONE_BR's escaped literals (`\+55`, `\(`, `\)`). Handles:
  - escaped metacharacters → literals
  - quantifier chars inside character classes (`[+*]`) → literals
  - bounded `?` and `{2,5}` never trigger; unbounded `*`, `+`, `{2,}` do
  - unbounded content propagates to enclosing groups (`((a+)b)+` flagged, conservative by design)
- **`core/detector.py` — `_load_regex_overrides`:** per-item skip with `PluginValidationWarning` for nested-quantifier patterns **and** `re.error` invalid regex. Skip is per-item — a good pattern in the same plugin file still loads; the scan never crashes.
- **`__init__` compile loop unchanged** — built-ins trusted, overrides pre-filtered.

### Tests (8, all passing)
- Dangerous shapes flagged: `(a+)+`, `(\w*)*`, `([a-z]+)*`, `(x{2,})+`, `((a+)b)+`
- Safe shapes allowed: CPF, e-mail, PHONE_BR (escaped `\+`/`\(`), `(a?)+`, `([+*]\d)+`, `(a{2,5})+`
- Validator issue emission + detector skip (ReDoS and invalid-regex paths)
- **Calibration:** all `DEFAULT_PATTERNS` pass the heuristic and compile

### Local gate
`./scripts/check-all.sh`: **1294 passed, 5 skipped** ✅

Closes #829

Made with [Cursor](https://cursor.com)