### PR TITLE
security(connectors): SSRF guard on outbound URLs (#832)

### DIFF
--- a/connectors/powerbi_connector.py
+++ b/connectors/powerbi_connector.py
@@ -16,6 +16,8 @@ from core.suggested_review import (
     augment_low_id_like_for_persist,
 )
 
+from .url_guard import target_allows_private, validate_outbound_url
+
 try:
     import httpx
 
@@ -48,6 +50,15 @@ def _get_access_token(target: dict[str, Any]) -> str | None:
     token_url = auth.get("token_url") or _AZURE_TOKEN_URL_TMPL.format(
         tenant_id=tenant_id
     )
+    # SSRF guard (#832): a custom token_url receives the client_secret via POST —
+    # never let it point at link-local/private hosts without explicit opt-in.
+    err = validate_outbound_url(
+        token_url,
+        allow_private=target_allows_private(target),
+        label="auth.token_url",
+    )
+    if err:
+        raise ValueError(err)
     resp = httpx.post(
         token_url,
         data={

--- a/connectors/rest_connector.py
+++ b/connectors/rest_connector.py
@@ -16,6 +16,8 @@ from core.suggested_review import (
     augment_low_id_like_for_persist,
 )
 
+from .url_guard import target_allows_private, validate_outbound_url
+
 try:
     import httpx
 
@@ -197,6 +199,19 @@ class RESTConnector:
         base_url = (self.config.get("base_url") or self.config.get("url", "")).rstrip(
             "/"
         )
+        # SSRF guard (#832): reject link-local/private/loopback hosts unless the
+        # target config opts in with allow_private_networks: true.
+        allow_private = target_allows_private(self.config)
+        for candidate, label in (
+            (base_url, "base_url"),
+            (self.config.get("discover_url", ""), "discover_url"),
+            ((self.config.get("auth") or {}).get("token_url", ""), "auth.token_url"),
+        ):
+            err = validate_outbound_url(
+                candidate, allow_private=allow_private, label=label
+            )
+            if err:
+                raise ValueError(err)
         connect_s = float(self.config.get("connect_timeout_seconds", 25))
         read_s = float(self.config.get("read_timeout_seconds", 90))
         # Default (first arg) used for write/pool; connect and read set explicitly (httpx requires default or all four).
@@ -232,7 +247,14 @@ class RESTConnector:
                 "httpx not installed. Install with: pip install httpx",
             )
             return
-        self.connect()
+        try:
+            self.connect()
+        except ValueError as e:
+            # SSRF guard rejection (#832) — record and stop, never request.
+            self.db_manager.save_failure(
+                self.config.get("name", "api"), "error", str(e)
+            )
+            return
         try:
             paths = self.config.get("paths") or self.config.get("endpoints") or []
             discover_url = self.config.get("discover_url")

--- a/connectors/sharepoint_connector.py
+++ b/connectors/sharepoint_connector.py
@@ -127,6 +127,18 @@ class SharePointConnector:
                 "Missing site_url (e.g. https://host/sites/sitename)",
             )
             return
+        # SSRF guard (#832): reject link-local/private/loopback hosts unless the
+        # target config opts in with allow_private_networks: true.
+        from .url_guard import target_allows_private, validate_outbound_url
+
+        err = validate_outbound_url(
+            site_url,
+            allow_private=target_allows_private(self.config),
+            label="site_url",
+        )
+        if err:
+            self.db_manager.save_failure(target_name, "error", err)
+            return
         user = self.config.get("user", self.config.get("username", ""))
         password = self.config.get("pass", self.config.get("password", ""))
         path_in_site = (

--- a/connectors/url_guard.py
+++ b/connectors/url_guard.py
@@ -1,0 +1,126 @@
+"""SSRF guard for outbound connector URLs (#832).
+
+Threat model: operator-supplied (or partner-supplied) target configs steer
+HTTP(S) requests from the scanning host. A malicious or mistyped
+``base_url`` / ``discover_url`` / ``token_url`` can point the engine at:
+
+- cloud metadata endpoints (``169.254.169.254``, link-local),
+- loopback / internal admin services,
+- private RFC1918 / ULA ranges the scan host can reach but the config
+  author should not target implicitly.
+
+Default posture: **reject non-global addresses** (link-local, loopback,
+private, reserved). Scanning internal infrastructure is a legitimate
+Data Boar use case, so each target config may opt in explicitly::
+
+    targets:
+      - name: internal-api
+        type: rest
+        base_url: http://10.0.0.5:8080
+        allow_private_networks: true   # explicit opt-in (#832)
+
+Shared by: rest_connector, powerbi_connector (token_url),
+sharepoint_connector (site_url), webdav_connector (base_url).
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from typing import Any
+from urllib.parse import urlparse
+
+_ALLOWED_SCHEMES = frozenset(("http", "https"))
+
+# Config key for the per-target opt-in.
+OPT_IN_KEY = "allow_private_networks"
+
+
+def _classify(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> str | None:
+    """Return a human-readable rejection category for *ip*, or None if global."""
+    if ip.is_link_local:
+        return "link-local (e.g. cloud metadata 169.254.0.0/16, fe80::/10)"
+    if ip.is_loopback:
+        return "loopback"
+    if ip.is_private:
+        return "private (RFC1918 / ULA)"
+    if ip.is_unspecified:
+        return "unspecified (0.0.0.0 / ::)"
+    if ip.is_reserved or ip.is_multicast:
+        return "reserved/multicast"
+    if not ip.is_global:
+        return "non-global"
+    return None
+
+
+def _resolve_host_ips(
+    host: str,
+) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    """Best-effort resolution of *host* to IP addresses.
+
+    Literal IPs are returned directly. DNS failures return an empty list —
+    the connection will fail naturally at request time, so the guard does
+    not block on resolver outages (no availability regression).
+    """
+    try:
+        return [ipaddress.ip_address(host)]
+    except ValueError:
+        pass
+    try:
+        infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+    except OSError:
+        return []
+    ips: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    for info in infos:
+        try:
+            ips.append(ipaddress.ip_address(info[4][0]))
+        except ValueError:
+            continue
+    return ips
+
+
+def validate_outbound_url(
+    url: str,
+    *,
+    allow_private: bool = False,
+    label: str = "url",
+) -> str | None:
+    """Validate *url* against the SSRF allowlist (#832).
+
+    Returns ``None`` when the URL is acceptable, or a human-readable error
+    string describing the rejection (scheme not http/https, missing host,
+    or host resolving to a non-global address without opt-in).
+    """
+    if not url:
+        return None
+    if "://" in url:
+        parsed = urlparse(url)
+        scheme = (parsed.scheme or "").lower()
+        if scheme not in _ALLOWED_SCHEMES:
+            return (
+                f"{label} rejected: scheme '{scheme}' not allowed "
+                f"(only http/https). (#832)"
+            )
+    else:
+        # Bare "host[:port]/path" form (WebDAV configs allow it) — no scheme
+        # to enforce, but the host still gets the address checks below.
+        parsed = urlparse(f"//{url}")
+    host = parsed.hostname
+    if not host:
+        return f"{label} rejected: no host found in {url!r}. (#832)"
+    if allow_private:
+        return None
+    for ip in _resolve_host_ips(host):
+        category = _classify(ip)
+        if category:
+            return (
+                f"{label} rejected: host '{host}' resolves to {ip} "
+                f"[{category}]. Scanning internal/private networks requires "
+                f"explicit opt-in — add '{OPT_IN_KEY}: true' to this target. (#832)"
+            )
+    return None
+
+
+def target_allows_private(target_config: dict[str, Any]) -> bool:
+    """Read the per-target opt-in flag (#832)."""
+    return bool(target_config.get(OPT_IN_KEY, False))

--- a/connectors/webdav_connector.py
+++ b/connectors/webdav_connector.py
@@ -157,6 +157,18 @@ class WebDAVConnector:
                 target_name, "error", "Missing base_url or url (e.g. https://host/path)"
             )
             return
+        # SSRF guard (#832): reject link-local/private/loopback hosts unless the
+        # target config opts in with allow_private_networks: true.
+        from .url_guard import target_allows_private, validate_outbound_url
+
+        err = validate_outbound_url(
+            base_url,
+            allow_private=target_allows_private(self.config),
+            label="base_url",
+        )
+        if err:
+            self.db_manager.save_failure(target_name, "error", err)
+            return
         user = self.config.get("user", self.config.get("username", ""))
         password = self.config.get("pass", self.config.get("password", ""))
         path_in_share = (self.config.get("path", "") or "").strip("/")

--- a/docs/TECH_GUIDE.md
+++ b/docs/TECH_GUIDE.md
@@ -345,6 +345,8 @@ You can scan remote HTTP(S) APIs for personal or sensitive data by adding target
 
 **Required:** `name`, `base_url` (or `url`). **Optional:** `paths` or `endpoints` (list of path strings, e.g. `["/users", "/orders"]`), `discover_url` (GET returns a list of paths to scan), `timeout`, `headers`, and an `auth` block.
 
+**SSRF guard (#832):** `base_url`, `discover_url`, and `auth.token_url` resolving to link-local (cloud metadata `169.254.0.0/16`), loopback, or private (RFC1918/ULA) hosts are **rejected by default** — the target records a failure and no request is sent. Scanning internal infrastructure is a normal Data Boar use case, so opt in per target with `allow_private_networks: true`. Non-`http(s)` schemes are always rejected. The same guard applies to SharePoint (`site_url`), WebDAV (`base_url`), and Power BI (custom `auth.token_url`).
+
 **Default outbound User-Agent:** discovery HTTP(S) clients send **`DataBoar-Prospector/<version>`** (same resolved version as the installed `data-boar` package — `core.about.get_http_user_agent()`). Use this string in remote WAF or API-gateway logs to identify this product. If a vendor requires a different token, set **`User-Agent`** (case-insensitive key) under `headers` on the target; that value **overrides** the default for REST/API. SharePoint, Power BI, and Dataverse connectors apply the same default. See [ADR 0034](adr/ADR-0034-outbound-http-user-agent-data-boar-prospector.md).
 
 ### Auth types

--- a/docs/TECH_GUIDE.pt_BR.md
+++ b/docs/TECH_GUIDE.pt_BR.md
@@ -345,6 +345,8 @@ Você pode varrer APIs HTTP(S) remotas em busca de dados pessoais ou sensíveis 
 
 **Obrigatório:** `name`, `base_url` (ou `url`). **Opcional:** `paths` ou `endpoints` (lista de paths, ex.: `["/users", "/orders"]`), `discover_url` (GET retorna lista de paths a varrer), `timeout`, `headers` e um bloco `auth`.
 
+**Guarda SSRF (#832):** `base_url`, `discover_url` e `auth.token_url` que resolvem para hosts link-local (metadados de nuvem `169.254.0.0/16`), loopback ou privados (RFC1918/ULA) são **rejeitados por padrão** — o alvo registra a falha e nenhuma requisição é enviada. Varrer infraestrutura interna é um caso de uso normal do Data Boar, então faça o opt-in por alvo com `allow_private_networks: true`. Esquemas que não sejam `http(s)` são sempre rejeitados. A mesma guarda vale para SharePoint (`site_url`), WebDAV (`base_url`) e Power BI (`auth.token_url` customizado).
+
 **User-Agent HTTP(S) padrão de saída:** clientes de descoberta enviam **`DataBoar-Prospector/<versão>`** (mesma versão resolvida do pacote `data-boar` instalado — `core.about.get_http_user_agent()`). Use essa string em logs de WAF ou API gateway no destino para identificar o produto. Se o fornecedor exigir outro valor, defina **`User-Agent`** (chave case-insensitive) em `headers` no alvo; isso **substitui** o padrão em REST/API. Conectores SharePoint, Power BI e Dataverse aplicam o mesmo padrão. Veja [ADR 0034](adr/ADR-0034-outbound-http-user-agent-data-boar-prospector.md) (texto canônico em inglês).
 
 ### Tipos de auth

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -678,6 +678,18 @@ No credentials. Uses `file_scan` settings (extensions, recursive, scan_sqlite_as
 
 Use `type: api` or `type: rest`. Required: `name`, `base_url` (or `url`). Optional: `paths` or `endpoints`, `discover_url`, `timeout`, `headers`, and an `auth` block.
 
+**SSRF guard:** `base_url`, `discover_url`, and `auth.token_url` pointing at link-local (cloud metadata `169.254.0.0/16`), loopback, or private (RFC1918/ULA) hosts are rejected by default. To scan internal infrastructure, add `allow_private_networks: true` to the target. The same guard applies to SharePoint (`site_url`), WebDAV (`base_url`), and Power BI (`auth.token_url`) targets.
+
+```yaml
+
+- name: "Internal API"
+
+    type: api
+    base_url: "http://10.0.0.5:8080"
+    paths: ["/users"]
+    allow_private_networks: true  # explicit opt-in for private/loopback hosts
+```
+
 ## Basic auth
 
 ```yaml

--- a/tests/test_ssrf_guard.py
+++ b/tests/test_ssrf_guard.py
@@ -1,0 +1,240 @@
+"""
+Anti-regression tests for the SSRF guard on outbound connector URLs (#832).
+
+Default posture: reject link-local (cloud metadata), loopback, and private
+hosts in base_url / discover_url / token_url / site_url. Each target config
+may opt in with ``allow_private_networks: true`` — internal scanning is a
+legitimate Data Boar use case, but it must be explicit.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from connectors.url_guard import (
+    OPT_IN_KEY,
+    target_allows_private,
+    validate_outbound_url,
+)
+
+
+class _FailureRecorder:
+    """Minimal db_manager stub capturing save_failure calls."""
+
+    def __init__(self) -> None:
+        self.failures: list[tuple[str, str, str]] = []
+
+    def save_failure(self, name: str, status: str, message: str) -> None:
+        self.failures.append((name, status, message))
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://169.254.169.254/latest/meta-data/",  # cloud metadata
+        "http://169.254.0.1/",  # link-local
+        "http://127.0.0.1:8080/api",  # loopback
+        "http://localhost/api",  # loopback via name
+        "http://10.0.0.5/api",  # RFC1918
+        "http://172.16.1.1/api",  # RFC1918
+        "http://192.168.0.10/api",  # RFC1918
+        "http://[::1]/api",  # IPv6 loopback
+        "http://[fe80::1]/api",  # IPv6 link-local
+        "http://[fd00::1]/api",  # IPv6 ULA
+        "http://0.0.0.0/api",  # unspecified
+    ],
+)
+def test_guard_rejects_non_global_hosts_by_default(url: str) -> None:
+    err = validate_outbound_url(url, allow_private=False, label="base_url")
+    assert err is not None, f"Expected rejection for {url!r} (#832)"
+    assert "#832" in err and OPT_IN_KEY in err, (
+        "Rejection message must reference #832 and the opt-in key for "
+        f"actionability, got: {err!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://169.254.169.254/latest/meta-data/",
+        "http://10.0.0.5/api",
+        "http://localhost:9002/health",
+    ],
+)
+def test_guard_allows_private_hosts_with_opt_in(url: str) -> None:
+    assert validate_outbound_url(url, allow_private=True) is None, (
+        f"Opt-in must allow {url!r} (#832)"
+    )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "ftp://example.com/file",
+        "file:///etc/passwd",
+        "gopher://example.com/",
+    ],
+)
+def test_guard_rejects_non_http_schemes(url: str) -> None:
+    err = validate_outbound_url(url, allow_private=True)
+    assert err is not None and "scheme" in err, (
+        f"Expected scheme rejection for {url!r} even with opt-in (#832)"
+    )
+
+
+def test_guard_allows_empty_and_unresolvable_urls() -> None:
+    # Empty: nothing to guard (connector handles missing-url errors itself).
+    assert validate_outbound_url("") is None
+    # Unresolvable DNS: no availability regression — connection fails later.
+    assert (
+        validate_outbound_url("https://nonexistent.invalid.example-tld-x/api") is None
+    )
+
+
+def test_target_allows_private_reads_config_flag() -> None:
+    assert target_allows_private({OPT_IN_KEY: True}) is True
+    assert target_allows_private({OPT_IN_KEY: False}) is False
+    assert target_allows_private({}) is False
+
+
+def test_rest_connector_rejects_metadata_base_url() -> None:
+    """RESTConnector.run() must save_failure and never request on a guarded URL."""
+    from connectors.rest_connector import _HTTPX_AVAILABLE, RESTConnector
+
+    if not _HTTPX_AVAILABLE:
+        pytest.skip("httpx not installed")
+    db = _FailureRecorder()
+    conn = RESTConnector(
+        {
+            "name": "ssrf-probe",
+            "base_url": "http://169.254.169.254/latest",
+            "paths": ["/meta-data"],
+        },
+        scanner=None,
+        db_manager=db,
+    )
+    conn.run()
+    assert db.failures, "Expected save_failure for guarded base_url (#832)"
+    assert "#832" in db.failures[0][2]
+
+
+def test_rest_connector_allows_private_with_opt_in() -> None:
+    """With opt-in, connect() must pass the guard (no ValueError)."""
+    from connectors.rest_connector import _HTTPX_AVAILABLE, RESTConnector
+
+    if not _HTTPX_AVAILABLE:
+        pytest.skip("httpx not installed")
+    conn = RESTConnector(
+        {
+            "name": "lab-api",
+            "base_url": "http://127.0.0.1:9999",
+            "paths": ["/x"],
+            OPT_IN_KEY: True,
+        },
+        scanner=None,
+        db_manager=_FailureRecorder(),
+    )
+    conn.connect()  # must not raise the guard ValueError
+    conn.close()
+
+
+def test_rest_connector_guards_discover_and_token_url() -> None:
+    """discover_url and auth.token_url go through the same guard (#832)."""
+    from connectors.rest_connector import _HTTPX_AVAILABLE, RESTConnector
+
+    if not _HTTPX_AVAILABLE:
+        pytest.skip("httpx not installed")
+    for cfg in (
+        {
+            "name": "d",
+            "base_url": "https://api.example.com",
+            "discover_url": "http://192.168.0.1/paths",
+        },
+        {
+            "name": "t",
+            "base_url": "https://api.example.com",
+            "auth": {"type": "oauth2_client", "token_url": "http://10.1.1.1/token"},
+        },
+    ):
+        conn = RESTConnector(cfg, scanner=None, db_manager=_FailureRecorder())
+        with pytest.raises(ValueError, match="#832"):
+            conn.connect()
+
+
+def test_webdav_connector_rejects_private_base_url() -> None:
+    from connectors.webdav_connector import _WEBDAV_AVAILABLE, WebDAVConnector
+
+    if not _WEBDAV_AVAILABLE:
+        pytest.skip("webdavclient3 not installed (guard covered by source test)")
+    db = _FailureRecorder()
+    conn = WebDAVConnector(
+        {"name": "dav", "base_url": "http://192.168.1.50/dav"},
+        scanner=None,
+        db_manager=db,
+    )
+    conn.run()
+    assert db.failures and "#832" in db.failures[-1][2], (
+        "WebDAV must save_failure on guarded base_url (#832)"
+    )
+
+
+def test_sharepoint_connector_rejects_private_site_url() -> None:
+    from connectors.sharepoint_connector import (
+        _REQUESTS_NTLM_AVAILABLE,
+        SharePointConnector,
+    )
+
+    if not _REQUESTS_NTLM_AVAILABLE:
+        pytest.skip("requests_ntlm not installed (guard covered by source test)")
+    db = _FailureRecorder()
+    conn = SharePointConnector(
+        {"name": "sp", "site_url": "http://10.2.3.4/sites/x"},
+        scanner=None,
+        db_manager=db,
+    )
+    conn.run()
+    failures = [f for f in db.failures if "#832" in f[2]]
+    assert failures, (
+        f"SharePoint must save_failure on guarded site_url (#832); got: {db.failures}"
+    )
+
+
+@pytest.mark.parametrize(
+    "connector_file",
+    [
+        "connectors/rest_connector.py",
+        "connectors/powerbi_connector.py",
+        "connectors/sharepoint_connector.py",
+        "connectors/webdav_connector.py",
+    ],
+)
+def test_connector_sources_call_url_guard(connector_file: str) -> None:
+    """Dependency-free anti-regression: every outbound HTTP connector must call
+    validate_outbound_url (#832) — even when optional deps are absent in CI."""
+    from pathlib import Path
+
+    source = (Path(__file__).resolve().parents[1] / connector_file).read_text(
+        encoding="utf-8"
+    )
+    assert "validate_outbound_url(" in source, (
+        f"{connector_file} lost its SSRF guard call (#832)"
+    )
+    assert "target_allows_private(" in source, (
+        f"{connector_file} lost its allow_private_networks opt-in wiring (#832)"
+    )
+
+
+def test_powerbi_token_url_guarded() -> None:
+    from connectors.powerbi_connector import _HTTPX_AVAILABLE, _get_access_token
+
+    if not _HTTPX_AVAILABLE:
+        pytest.skip("httpx not installed")
+    with pytest.raises(ValueError, match="#832"):
+        _get_access_token(
+            {
+                "tenant_id": "t",
+                "client_id": "c",
+                "client_secret": "s",
+                "auth": {"token_url": "http://169.254.169.254/token"},
+            }
+        )


### PR DESCRIPTION
## SSRF allowlist (#832)

Shared guard `connectors/url_guard.py` applied to **rest**, **powerbi**, **sharepoint**, **webdav** — the four outbound-HTTP connectors.

### Default posture
- Reject non-`http(s)` schemes (always — opt-in does not lift this).
- Reject hosts resolving to **link-local** (cloud metadata `169.254.0.0/16`, `fe80::/10`), **loopback**, **private** (RFC1918/ULA), unspecified, or reserved addresses. Literal IPs checked directly; hostnames via `getaddrinfo`. DNS failures do **not** block (connection fails naturally later — no availability regression).
- **Per-target opt-in:** `allow_private_networks: true` — internal scanning is a legitimate Data Boar use case, but it must be explicit in the target config.

### Guarded fields per connector
| Connector | Fields |
| --- | --- |
| rest | `base_url`, `discover_url`, `auth.token_url` (oauth2_client) |
| powerbi | custom `auth.token_url` (receives `client_secret` via POST — exfiltration vector) |
| sharepoint | `site_url` |
| webdav | `base_url` |

Note: REST discovered paths are already normalized to relative `/` form before GET — no absolute-URL pivot through httpx `base_url` merging.

### Failure mode
Rejection → `save_failure` on the target (visible in the report) and **no request is sent**.

### Tests (29)
Metadata/link-local/loopback/private/IPv6 rejection matrix, opt-in acceptance, scheme rejection, DNS-failure tolerance, connector-level `save_failure` paths, plus a **dependency-free source-content check** so optional-dep connectors (`webdavclient3`, `requests_ntlm`) keep the guard even when CI lacks the extras.

### Docs
USAGE.md + TECH_GUIDE.md / TECH_GUIDE.pt_BR.md (EN/pt-BR parity). CHANGELOG intentionally untouched to avoid conflict with release PR #840's section restructure.

### Local gate
`./scripts/check-all.sh`: **1313 passed, 7 skipped** ✅

Closes #832

Made with [Cursor](https://cursor.com)