### PR TITLE
security(licensing): kill env tier bypass — fail-closed enforcement + audit trail (#719)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,13 @@
 # Copy to .env for local deployment (never commit real secrets).
 # Licensing env vars: docs/LICENSING_SPEC.md, docs/RELEASE_INTEGRITY.md
 
+# ANTI-PATTERN (#719): DATA_BOAR_ENV=development / DEBUG=1 in production.
+# These vars no longer affect licensing (the tier override was removed), but
+# leaving debug flags on in production weakens logging hygiene. Enforcement is
+# governed ONLY by licensing.mode + a valid signed license; without one the
+# runtime fails CLOSED (scans denied, tier capped to Community).
+# DATA_BOAR_LICENSE_MODE=open cannot downgrade YAML "mode: enforced".
+
 # Optional hex SHA-256 — must match core/licensing/_build_digest.txt in the running image.
 # Generate locally: uv run python scripts/generate_build_digest.py
 # Release builds: see build-digest.txt on the GitHub Release (SBOM workflow).

--- a/core/licensing/audit.py
+++ b/core/licensing/audit.py
@@ -1,0 +1,63 @@
+"""
+License enforcement Audit Trail (#719).
+
+Every enforcement decision (allow / deny / clamp / expire) emits a structured
+record on the dedicated ``data_boar.licensing.audit`` logger with the stable
+prefix ``LICENSE_AUDIT`` so SIEM pipelines and operators can filter it.
+
+Level policy:
+
+- **CRITICAL** — denial while ``mode=enforced`` (scan blocked, fail-closed
+  tier clamp, env downgrade attempt). These must never be silent (#719).
+- **WARNING** — clamps and denials outside enforced mode (lab tier
+  simulation, trial row cap).
+- **INFO** — allow decisions (scan permitted, license evaluated VALID/GRACE).
+- **DEBUG** — high-frequency allow decisions (per-feature checks).
+"""
+
+from __future__ import annotations
+
+import logging
+
+audit_logger = logging.getLogger("data_boar.licensing.audit")
+
+AUDIT_PREFIX = "LICENSE_AUDIT"
+
+
+def audit_enforcement_event(
+    action: str,
+    *,
+    mode: str,
+    state: str = "",
+    allowed: bool,
+    feature: str = "",
+    tier: str = "",
+    detail: str = "",
+    level: int | None = None,
+) -> None:
+    """Record one enforcement decision on the audit logger.
+
+    *level* overrides the default policy (e.g. DEBUG for per-feature allows).
+    """
+    if level is None:
+        if allowed:
+            level = logging.INFO
+        elif mode == "enforced":
+            level = logging.CRITICAL
+        else:
+            level = logging.WARNING
+    parts = [
+        AUDIT_PREFIX,
+        f"action={action}",
+        f"mode={mode}",
+        f"allowed={str(allowed).lower()}",
+    ]
+    if state:
+        parts.append(f"state={state}")
+    if tier:
+        parts.append(f"tier={tier}")
+    if feature:
+        parts.append(f"feature={feature}")
+    if detail:
+        parts.append(f"detail={detail}")
+    audit_logger.log(level, " ".join(parts))

--- a/core/licensing/guard.py
+++ b/core/licensing/guard.py
@@ -4,6 +4,7 @@ Runtime license guard: open mode (default) vs enforced commercial token verifica
 
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -12,6 +13,7 @@ from typing import Any
 
 import jwt
 
+from core.licensing.audit import audit_enforcement_event
 from core.licensing.feature_gate import FeatureCheckResult, check_feature
 from core.licensing.fingerprint import compute_machine_fingerprint
 from core.licensing.runtime_feature_tier import map_dbtier_string_to_tier
@@ -92,18 +94,41 @@ class LicenseGuard:
 
     def __init__(self, config: dict[str, Any]) -> None:
         lc = (config.get("licensing") or {}) if isinstance(config, dict) else {}
+        yaml_mode = str(lc.get("mode", "open")).strip().lower()
+        if yaml_mode not in ("open", "enforced"):
+            yaml_mode = "open"
         env_mode = (os.environ.get("DATA_BOAR_LICENSE_MODE") or "").strip().lower()
-        if env_mode in ("open", "enforced"):
-            mode = env_mode
+        # #719: environment can only ESCALATE open -> enforced; it can never
+        # downgrade enforced -> open. Enforcement state is determined solely by
+        # licensing.mode + a valid signed license — no env kill-switch.
+        if yaml_mode == "enforced":
+            mode = "enforced"
+            if env_mode == "open":
+                audit_enforcement_event(
+                    "env_mode_downgrade_ignored",
+                    mode="enforced",
+                    allowed=False,
+                    detail="DATA_BOAR_LICENSE_MODE=open ignored — licensing.mode is enforced",
+                )
+        elif env_mode == "enforced":
+            mode = "enforced"
         else:
-            mode = str(lc.get("mode", "open")).strip().lower()
-        if mode not in ("open", "enforced"):
-            mode = "open"
+            mode = yaml_mode
         self.mode = mode
         self._config = config
         self._lc = lc
         self._context: LicenseContext | None = None
         self._evaluate()
+        # Audit Trail (#719): every license evaluation outcome is recorded —
+        # allow (OPEN/VALID/GRACE) at INFO, deny/expire at CRITICAL in enforced.
+        c = self.context
+        audit_enforcement_event(
+            "license_evaluated",
+            mode=c.mode,
+            state=c.state,
+            allowed=c.state in ("OPEN", "VALID", "GRACE"),
+            detail=c.detail,
+        )
 
     def _evaluate(self) -> None:
         mfp = compute_machine_fingerprint()
@@ -320,7 +345,15 @@ class LicenseGuard:
 
     def allows_scan(self) -> bool:
         c = self.context
-        return c.state in ("OPEN", "VALID", "GRACE")
+        allowed = c.state in ("OPEN", "VALID", "GRACE")
+        audit_enforcement_event(
+            "scan_gate",
+            mode=c.mode,
+            state=c.state,
+            allowed=allowed,
+            detail=c.detail if not allowed else "",
+        )
+        return allowed
 
     def allows_full_report(self) -> bool:
         c = self.context
@@ -338,18 +371,50 @@ class LicenseGuard:
         """If trial with positive cap, return max rows; else None (no cap)."""
         c = self.context
         if c.state in ("OPEN", "VALID", "GRACE") and c.trial and c.max_report_rows > 0:
+            audit_enforcement_event(
+                "report_rows_clamped",
+                mode=c.mode,
+                state=c.state,
+                allowed=False,
+                detail=f"trial_cap={c.max_report_rows}",
+                level=logging.WARNING,
+            )
             return c.max_report_rows
         return None
 
     def product_tier_for_features(self) -> Tier:
-        """Resolve product tier for feature gates (YAML, JWT, dev override)."""
+        """Resolve product tier for feature gates (YAML lab simulation or JWT dbtier)."""
         from core.licensing.runtime_feature_tier import get_runtime_tier_for_features
 
         return get_runtime_tier_for_features(self._config)
 
     def check_feature(self, feature: str) -> FeatureCheckResult:
-        """Structured tier gate — does not raise on denial."""
-        return check_feature(feature, self.product_tier_for_features())
+        """Structured tier gate — does not raise on denial. Denials are audited."""
+        result = check_feature(feature, self.product_tier_for_features())
+        c = self.context
+        if result.allowed:
+            # Per-feature allows are high-frequency: DEBUG keeps the audit
+            # record available without flooding default INFO logs.
+            audit_enforcement_event(
+                "feature_gate",
+                mode=c.mode,
+                state=c.state,
+                allowed=True,
+                feature=result.feature,
+                tier=result.current_tier,
+                level=logging.DEBUG,
+            )
+        else:
+            audit_enforcement_event(
+                "feature_denied",
+                mode=c.mode,
+                state=c.state,
+                allowed=False,
+                feature=result.feature,
+                tier=result.current_tier,
+                detail=f"required={result.required_tier}",
+            )
+        return result
 
     def is_allowed(self, feature: str) -> bool:
         return self.check_feature(feature).allowed

--- a/core/licensing/runtime_feature_tier.py
+++ b/core/licensing/runtime_feature_tier.py
@@ -2,34 +2,30 @@
 Resolve effective product tier for feature gating (YAML ``licensing.effective_tier``, JWT ``dbtier``).
 
 Shared by API routes, RBAC, and maturity POC so tier logic stays in one place.
+
+Enforcement contract (#719 — no env bypass):
+
+- Environment variables (``DATA_BOAR_ENV``, ``DEBUG``, ``DATA_BOAR_TIER_OVERRIDE``)
+  can **never** alter the effective tier or disable enforcement. The former
+  dev/CI override path was removed — it let a misconfigured production
+  container (``DEBUG=1``) grant Enterprise without a JWT and without audit.
+- In ``mode: enforced`` the tier comes **only** from a validated signed
+  license (``dbtier`` claim, state VALID/GRACE). Any other state fails
+  **closed** to Community, with a CRITICAL audit record. ``licensing.
+  effective_tier`` from YAML is ignored in enforced mode.
+- In ``mode: open`` (default) lab simulation via ``licensing.effective_tier``
+  stays available; default is OPEN (all features on).
 """
 
 from __future__ import annotations
 
 import logging
-import os
 from typing import Any
 
+from core.licensing.audit import audit_enforcement_event
 from core.licensing.tier_features import Tier
 
 logger = logging.getLogger("data_boar.licensing")
-
-
-def is_dev_tier_override_env() -> bool:
-    """True when CI/dev may honor DATA_BOAR_TIER_OVERRIDE (never production builds)."""
-    env = os.environ.get("DATA_BOAR_ENV", "").strip().lower()
-    if env in ("development", "dev", "ci"):
-        return True
-    debug = os.environ.get("DEBUG", "").strip().lower()
-    return debug in ("1", "true", "yes")
-
-
-def tier_override_from_env() -> Tier | None:
-    """Optional lab/CI tier simulation via DATA_BOAR_TIER_OVERRIDE."""
-    raw = os.environ.get("DATA_BOAR_TIER_OVERRIDE", "").strip().lower()
-    if not raw or not is_dev_tier_override_env():
-        return None
-    return map_dbtier_string_to_tier(raw)
 
 
 def map_dbtier_string_to_tier(raw: str) -> Tier:
@@ -48,37 +44,83 @@ def map_dbtier_string_to_tier(raw: str) -> Tier:
 
 def get_runtime_tier_for_features(cfg: dict[str, Any]) -> Tier:
     """
-    Resolve tier for ``is_feature_available``: JWT ``dbtier`` when enforced and VALID/GRACE wins over
-    ``licensing.effective_tier``; otherwise lab YAML; default OPEN (all features on).
-    """
-    env_override = tier_override_from_env()
-    if env_override is not None:
-        return env_override
+    Resolve tier for ``is_feature_available``.
 
-    dbtier_claim = ""
+    - **enforced:** JWT ``dbtier`` (state VALID/GRACE) is the only source;
+      everything else fails closed to Community with a CRITICAL audit record.
+    - **open:** lab YAML ``licensing.effective_tier``; default OPEN.
+    """
     lc = cfg.get("licensing") if isinstance(cfg.get("licensing"), dict) else {}
+    yaml_tier = str(lc.get("effective_tier") or "").strip().lower()
+
+    guard = None
     try:
         from core.licensing.guard import get_license_guard
 
-        g = get_license_guard(cfg)
-        c = g.context
+        guard = get_license_guard(cfg)
+    except Exception:  # noqa: BLE001
+        # License guard may be unavailable during early bootstrap. If the
+        # YAML asks for enforcement, fail closed rather than open (#719).
+        yaml_mode = str(lc.get("mode") or "open").strip().lower()
+        if yaml_mode == "enforced":
+            audit_enforcement_event(
+                "tier_fail_closed",
+                mode="enforced",
+                state="GUARD_UNAVAILABLE",
+                allowed=False,
+                tier=Tier.COMMUNITY.value,
+                detail="license_guard_unavailable_during_bootstrap",
+            )
+            return Tier.COMMUNITY
+        return map_dbtier_string_to_tier(yaml_tier) if yaml_tier else Tier.OPEN
+
+    if guard.mode == "enforced":
+        c = guard.context
         if c.state in ("VALID", "GRACE"):
             dbtier_claim = str(getattr(c, "dbtier", "") or "").strip().lower()
-        elif c.state == "TAMPERED":
-            mode = str(lc.get("mode") or "open").strip().lower()
-            if mode == "enforced":
-                logger.critical(
-                    "LicenseGuard state=TAMPERED in enforced mode — capping effective tier to Community"
-                )
-                return Tier.COMMUNITY
-            logger.critical(
-                "LicenseGuard state=TAMPERED in open mode — unauthorized build detected"
+            if dbtier_claim:
+                return map_dbtier_string_to_tier(dbtier_claim)
+            # Valid license without a dbtier claim: fail closed to the base
+            # sellable tier — never OPEN in enforced mode (#719).
+            audit_enforcement_event(
+                "tier_fail_closed",
+                mode="enforced",
+                state=c.state,
+                allowed=False,
+                tier=Tier.COMMUNITY.value,
+                detail="valid_license_missing_dbtier_claim",
+                level=logging.WARNING,
             )
-    except Exception:  # noqa: BLE001
-        pass  # license guard may be unavailable during early bootstrap
-    yaml_tier = str(lc.get("effective_tier") or "").strip().lower()
-    if dbtier_claim:
-        return map_dbtier_string_to_tier(dbtier_claim)
+            return Tier.COMMUNITY
+        if c.state == "TAMPERED":
+            logger.critical(
+                "LicenseGuard state=TAMPERED in enforced mode — capping effective tier to Community"
+            )
+        audit_enforcement_event(
+            "tier_fail_closed",
+            mode="enforced",
+            state=c.state,
+            allowed=False,
+            tier=Tier.COMMUNITY.value,
+            detail=c.detail or c.state.lower(),
+        )
+        if yaml_tier:
+            audit_enforcement_event(
+                "yaml_tier_ignored_enforced",
+                mode="enforced",
+                state=c.state,
+                allowed=False,
+                tier=yaml_tier,
+                detail="licensing.effective_tier has no effect in enforced mode",
+                level=logging.WARNING,
+            )
+        return Tier.COMMUNITY
+
+    # open mode (lab / default): YAML simulation allowed; flag tampering.
+    if guard.context.state == "TAMPERED":
+        logger.critical(
+            "LicenseGuard state=TAMPERED in open mode — unauthorized build detected"
+        )
     if yaml_tier:
         return map_dbtier_string_to_tier(yaml_tier)
     return Tier.OPEN

--- a/docs/LICENSING_SPEC.md
+++ b/docs/LICENSING_SPEC.md
@@ -6,12 +6,31 @@ Technical specification for **optional** commercial enforcement. Default is **op
 
 | Mode       | Config / env                                                    | Behaviour                                                                                          |
 | ----       | ------------                                                    | ----------                                                                                         |
-| `open`     | `licensing.mode: open` or unset; `DATA_BOAR_LICENSE_MODE=open`  | Full functionality; license token optional; status shows **OPEN**                                  |
-| `enforced` | `licensing.mode: enforced` or `DATA_BOAR_LICENSE_MODE=enforced` | Valid signed token required for ingest/digest; invalid/expired/revoked/tampered states block scans |
+| `open`     | `licensing.mode: open` or unset; `DATA_BOAR_LICENSE_MODE=enforced` can escalate | Full functionality; license token optional; status shows **OPEN**                                  |
+| `enforced` | `licensing.mode: enforced`                                      | Valid signed token required for ingest/digest; invalid/expired/revoked/tampered states block scans |
+
+### No environment bypass (#719)
+
+Enforcement state is determined **only** by `licensing.mode: enforced` plus a
+valid signed license. Environment variables can never disable it:
+
+- `DATA_BOAR_LICENSE_MODE=open` is **ignored** when YAML sets `mode: enforced`
+  (the attempt is recorded as a CRITICAL audit event). The env var can only
+  **escalate** `open` → `enforced`.
+- `DATA_BOAR_ENV=development`, `DEBUG=1`, and the former
+  `DATA_BOAR_TIER_OVERRIDE` have **zero** licensing effect. The dev/CI tier
+  override was removed — use a locally issued signed QA license instead
+  (`scripts/issue_dev_license_jwt.py`).
+- Without a valid license in enforced mode the runtime **fails closed**:
+  scans are denied (Safe-Hold / HTTP 403) and the feature tier is capped to
+  Community — never "open".
+
+Every enforcement decision (allow / deny / clamp / expire) is recorded on the
+`data_boar.licensing.audit` logger with the `LICENSE_AUDIT` prefix.
 
 Environment variables override YAML when set:
 
-- `DATA_BOAR_LICENSE_MODE` — `open` | `enforced`
+- `DATA_BOAR_LICENSE_MODE` — `enforced` (escalation only; `open` cannot downgrade YAML `enforced`)
 - `DATA_BOAR_LICENSE_PATH` — path to JWT file (`.lic`)
 - `DATA_BOAR_LICENSE_PUBLIC_KEY_PATH` — PEM file with **Ed25519 public** key (verify only)
 - `DATA_BOAR_LICENSE_PUBLIC_KEY_PEM` — inline PEM (alternative to path; dev/CI only)

--- a/tests/test_licensing_enforcement_no_bypass.py
+++ b/tests/test_licensing_enforcement_no_bypass.py
@@ -1,0 +1,251 @@
+"""
+#719 regression — env vars can NEVER bypass licensing enforcement.
+
+Contract under test:
+
+1. ``DATA_BOAR_ENV=development`` / ``DEBUG=1`` / ``DATA_BOAR_TIER_OVERRIDE``
+   have zero effect when ``licensing.mode: enforced`` — the gate still bites.
+2. ``DATA_BOAR_LICENSE_MODE=open`` cannot downgrade YAML ``mode: enforced``.
+3. Enforced without a valid signed license fails CLOSED (scan denied,
+   tier capped to Community) — never "open".
+4. Every enforcement decision lands on the ``data_boar.licensing.audit``
+   logger (allow / deny / clamp / expire).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from core.licensing.guard import LicenseGuard, reset_license_guard_for_tests
+from core.licensing.runtime_feature_tier import get_runtime_tier_for_features
+from core.licensing.tier_features import Tier
+
+AUDIT_LOGGER = "data_boar.licensing.audit"
+
+
+def _pem_public(priv: Ed25519PrivateKey) -> str:
+    return (
+        priv.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("ascii")
+        .strip()
+    )
+
+
+def _make_token(
+    priv: Ed25519PrivateKey,
+    *,
+    exp_delta_days: int = 7,
+    extra: dict | None = None,
+) -> str:
+    now = datetime.now(timezone.utc)
+    payload = {
+        "sub": "lic-no-bypass",
+        "iat": int(now.timestamp()),
+        "exp": int((now + timedelta(days=exp_delta_days)).timestamp()),
+        "dbcid": "cust-1",
+        "dbcname": "Test Customer",
+        "dbenv": "qa",
+        "dbissuer": "test-issuer",
+        "dbkid": "k1",
+    }
+    if extra:
+        payload.update(extra)
+    return jwt.encode(payload, priv, algorithm="EdDSA")
+
+
+@pytest.fixture
+def ed25519_priv() -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.generate()
+
+
+@pytest.fixture(autouse=True)
+def _clean_env():
+    reset_license_guard_for_tests()
+    keys = (
+        "DATA_BOAR_ENV",
+        "DEBUG",
+        "DATA_BOAR_TIER_OVERRIDE",
+        "DATA_BOAR_LICENSE_MODE",
+        "DATA_BOAR_LICENSE_PATH",
+        "DATA_BOAR_LICENSE_PUBLIC_KEY_PEM",
+        "DATA_BOAR_LICENSE_PUBLIC_KEY_PATH",
+        "DATA_BOAR_LICENSE_REVOCATION_PATH",
+    )
+    saved = {k: os.environ.get(k) for k in keys}
+    for k in keys:
+        os.environ.pop(k, None)
+    yield
+    reset_license_guard_for_tests()
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+def _audit_records(caplog):
+    return [r for r in caplog.records if r.name == AUDIT_LOGGER]
+
+
+# --- 1. dev env vars do not bypass enforced mode -------------------------
+
+
+def test_dev_env_and_tier_override_do_not_bypass_enforced(monkeypatch, caplog):
+    """THE #719 regression: DATA_BOAR_ENV=development + enforced still bites."""
+    monkeypatch.setenv("DATA_BOAR_ENV", "development")
+    monkeypatch.setenv("DEBUG", "1")
+    monkeypatch.setenv("DATA_BOAR_TIER_OVERRIDE", "enterprise")
+    cfg = {"licensing": {"mode": "enforced"}}
+    with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+        g = LicenseGuard(cfg)
+        assert g.allows_scan() is False  # fail-closed: no key, no license
+        assert get_runtime_tier_for_features(cfg) == Tier.COMMUNITY
+    crit = [r for r in _audit_records(caplog) if r.levelno == logging.CRITICAL]
+    assert crit, "deny decisions in enforced mode must be CRITICAL audit records"
+    assert any("scan_gate" in r.message for r in crit)
+    assert any("tier_fail_closed" in r.message for r in crit)
+
+
+def test_debug_env_alone_does_not_grant_tier(monkeypatch):
+    monkeypatch.setenv("DEBUG", "true")
+    monkeypatch.setenv("DATA_BOAR_TIER_OVERRIDE", "enterprise")
+    cfg = {"licensing": {"mode": "open", "effective_tier": "community"}}
+    assert get_runtime_tier_for_features(cfg) == Tier.COMMUNITY
+
+
+# --- 2. env cannot downgrade enforced -> open -----------------------------
+
+
+def test_env_license_mode_cannot_downgrade_enforced(monkeypatch, caplog):
+    monkeypatch.setenv("DATA_BOAR_LICENSE_MODE", "open")
+    cfg = {"licensing": {"mode": "enforced"}}
+    with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+        g = LicenseGuard(cfg)
+    assert g.mode == "enforced"
+    assert g.allows_scan() is False
+    assert any(
+        "env_mode_downgrade_ignored" in r.message for r in _audit_records(caplog)
+    )
+
+
+def test_env_license_mode_can_escalate_open_to_enforced(monkeypatch):
+    monkeypatch.setenv("DATA_BOAR_LICENSE_MODE", "enforced")
+    cfg = {"licensing": {"mode": "open"}}
+    g = LicenseGuard(cfg)
+    assert g.mode == "enforced"
+    assert g.allows_scan() is False
+
+
+# --- 3. fail-closed tier resolution in enforced mode ----------------------
+
+
+def test_yaml_effective_tier_ignored_in_enforced(monkeypatch):
+    """YAML effective_tier cannot grant tier without a valid license."""
+    cfg = {"licensing": {"mode": "enforced", "effective_tier": "enterprise"}}
+    assert get_runtime_tier_for_features(cfg) == Tier.COMMUNITY
+
+
+def test_enforced_valid_license_dbtier_governs(ed25519_priv, tmp_path):
+    lic = tmp_path / "t.lic"
+    lic.write_text(_make_token(ed25519_priv, extra={"dbtier": "pro"}), encoding="utf-8")
+    os.environ["DATA_BOAR_LICENSE_PUBLIC_KEY_PEM"] = _pem_public(ed25519_priv)
+    cfg = {
+        "licensing": {
+            "mode": "enforced",
+            "license_path": str(lic),
+            # YAML tier must lose to the JWT claim in enforced mode:
+            "effective_tier": "enterprise",
+        }
+    }
+    g = LicenseGuard(cfg)
+    assert g.context.state == "VALID"
+    assert g.allows_scan() is True
+    assert get_runtime_tier_for_features(cfg) == Tier.PRO
+
+
+def test_enforced_valid_license_without_dbtier_falls_to_community(
+    ed25519_priv, tmp_path
+):
+    lic = tmp_path / "t.lic"
+    lic.write_text(_make_token(ed25519_priv), encoding="utf-8")
+    os.environ["DATA_BOAR_LICENSE_PUBLIC_KEY_PEM"] = _pem_public(ed25519_priv)
+    cfg = {"licensing": {"mode": "enforced", "license_path": str(lic)}}
+    assert get_runtime_tier_for_features(cfg) == Tier.COMMUNITY
+
+
+def test_enforced_expired_license_fails_closed(ed25519_priv, tmp_path, caplog):
+    lic = tmp_path / "t.lic"
+    lic.write_text(
+        _make_token(ed25519_priv, exp_delta_days=-2, extra={"dbtier": "enterprise"}),
+        encoding="utf-8",
+    )
+    os.environ["DATA_BOAR_LICENSE_PUBLIC_KEY_PEM"] = _pem_public(ed25519_priv)
+    cfg = {"licensing": {"mode": "enforced", "license_path": str(lic)}}
+    with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+        g = LicenseGuard(cfg)
+        # PyJWT rejects expired tokens at decode time (INVALID); the guard's
+        # own EXPIRED state covers grace-window logic. Both fail closed.
+        assert g.context.state in ("EXPIRED", "INVALID")
+        assert g.allows_scan() is False
+        assert get_runtime_tier_for_features(cfg) == Tier.COMMUNITY
+    assert any(
+        "license_evaluated" in r.message and r.levelno == logging.CRITICAL
+        for r in _audit_records(caplog)
+    )
+
+
+# --- 4. audit log coverage (allow / deny / clamp) --------------------------
+
+
+def test_audit_allow_decisions_recorded(ed25519_priv, tmp_path, caplog):
+    lic = tmp_path / "t.lic"
+    lic.write_text(
+        _make_token(ed25519_priv, extra={"dbtier": "enterprise"}), encoding="utf-8"
+    )
+    os.environ["DATA_BOAR_LICENSE_PUBLIC_KEY_PEM"] = _pem_public(ed25519_priv)
+    cfg = {"licensing": {"mode": "enforced", "license_path": str(lic)}}
+    with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+        g = LicenseGuard(cfg)
+        assert g.allows_scan() is True
+    records = _audit_records(caplog)
+    assert any(
+        "license_evaluated" in r.message and "allowed=true" in r.message
+        for r in records
+    )
+    assert any(
+        "scan_gate" in r.message and "allowed=true" in r.message for r in records
+    )
+
+
+def test_audit_feature_denial_recorded(caplog):
+    cfg = {"licensing": {"mode": "open", "effective_tier": "community"}}
+    with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+        g = LicenseGuard(cfg)
+        result = g.check_feature("governance_lens_pro")
+    assert not result.allowed
+    assert any("feature_denied" in r.message for r in _audit_records(caplog))
+
+
+def test_audit_trial_clamp_recorded(ed25519_priv, tmp_path, caplog):
+    lic = tmp_path / "t.lic"
+    lic.write_text(
+        _make_token(ed25519_priv, extra={"dbtrial": True, "dbmaxrows": 100}),
+        encoding="utf-8",
+    )
+    os.environ["DATA_BOAR_LICENSE_PUBLIC_KEY_PEM"] = _pem_public(ed25519_priv)
+    cfg = {"licensing": {"mode": "enforced", "license_path": str(lic)}}
+    with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+        g = LicenseGuard(cfg)
+        assert g.trial_cap_rows() == 100
+    assert any("report_rows_clamped" in r.message for r in _audit_records(caplog))

--- a/tests/test_licensing_tier_gates.py
+++ b/tests/test_licensing_tier_gates.py
@@ -7,10 +7,7 @@ import os
 import pytest
 
 from core.licensing.guard import LicenseGuard, reset_license_guard_for_tests
-from core.licensing.runtime_feature_tier import (
-    get_runtime_tier_for_features,
-    tier_override_from_env,
-)
+from core.licensing.runtime_feature_tier import get_runtime_tier_for_features
 from core.licensing.tier_features import Tier
 
 
@@ -97,18 +94,12 @@ def test_scan_max_workers_enterprise_denied_pro(pro_guard):
     assert not result.allowed
 
 
-def test_tier_override_env_requires_dev_env(monkeypatch):
-    monkeypatch.setenv("DATA_BOAR_TIER_OVERRIDE", "pro")
-    monkeypatch.delenv("DATA_BOAR_ENV", raising=False)
-    monkeypatch.delenv("DEBUG", raising=False)
-    assert tier_override_from_env() is None
-
-
-def test_tier_override_env_honored_in_dev(monkeypatch):
+def test_tier_override_env_removed_no_bypass(monkeypatch):
+    """#719: DATA_BOAR_TIER_OVERRIDE no longer exists — env never changes tier."""
     monkeypatch.setenv("DATA_BOAR_TIER_OVERRIDE", "community")
     monkeypatch.setenv("DATA_BOAR_ENV", "development")
     reset_license_guard_for_tests()
     cfg = {"licensing": {"mode": "open", "effective_tier": "pro"}}
-    assert get_runtime_tier_for_features(cfg) == Tier.COMMUNITY
+    assert get_runtime_tier_for_features(cfg) == Tier.PRO
     g = LicenseGuard(cfg)
-    assert not g.is_allowed("governance_lens_pro")
+    assert g.is_allowed("governance_lens_pro")

--- a/tests/test_runtime_feature_tier.py
+++ b/tests/test_runtime_feature_tier.py
@@ -18,24 +18,26 @@ def _reset_guard():
     reset_license_guard_for_tests()
 
 
-def _tampered_guard() -> MagicMock:
+def _tampered_guard(mode: str) -> MagicMock:
     ctx = MagicMock()
     ctx.state = "TAMPERED"
+    ctx.detail = "tampered_build"
     guard = MagicMock()
+    guard.mode = mode
     guard.context = ctx
     return guard
 
 
 @patch("core.licensing.guard.get_license_guard")
 def test_tampered_enforced_returns_community(mock_get_guard):
-    mock_get_guard.return_value = _tampered_guard()
+    mock_get_guard.return_value = _tampered_guard("enforced")
     cfg = {"licensing": {"mode": "enforced", "effective_tier": "enterprise"}}
     assert get_runtime_tier_for_features(cfg) == Tier.COMMUNITY
 
 
 @patch("core.licensing.guard.get_license_guard")
 def test_tampered_open_returns_open_and_logs_critical(mock_get_guard, caplog):
-    mock_get_guard.return_value = _tampered_guard()
+    mock_get_guard.return_value = _tampered_guard("open")
     cfg = {"licensing": {"mode": "open"}}
     with caplog.at_level("CRITICAL", logger="data_boar.licensing"):
         assert get_runtime_tier_for_features(cfg) == Tier.OPEN

--- a/tests/test_tier_features_open_core_subscription.py
+++ b/tests/test_tier_features_open_core_subscription.py
@@ -96,7 +96,8 @@ def test_runtime_tier_from_yaml_effective_tier():
     assert get_runtime_tier_for_features(cfg) == Tier.PRO
 
 
-def test_runtime_tier_env_override_wins_in_dev(monkeypatch):
+def test_runtime_tier_env_override_removed(monkeypatch):
+    """#719: env override removed — YAML effective_tier wins even with dev env vars."""
     monkeypatch.setenv("DATA_BOAR_TIER_OVERRIDE", "enterprise")
     monkeypatch.setenv("DATA_BOAR_ENV", "ci")
     reset_license_guard_for_tests()
@@ -104,4 +105,4 @@ def test_runtime_tier_env_override_wins_in_dev(monkeypatch):
         "licensing": {"mode": "open", "effective_tier": "community"},
         "api": {},
     }
-    assert get_runtime_tier_for_features(cfg) == Tier.ENTERPRISE
+    assert get_runtime_tier_for_features(cfg) == Tier.COMMUNITY


### PR DESCRIPTION
Closes #719

## Summary

Foundation PR of the **enforcement wave** — without this, every later gate is bypassable.

- **Env bypass removed:** `DATA_BOAR_TIER_OVERRIDE` / `DATA_BOAR_ENV=development` / `DEBUG=1` no longer have ANY licensing effect (the dev/CI override path in `runtime_feature_tier.py` is gone). Enforcement state is determined **only** by `licensing.mode: enforced` + a valid signed license.
- **No env downgrade:** `DATA_BOAR_LICENSE_MODE` can only escalate `open` → `enforced`; `=open` against YAML `mode: enforced` is ignored and audited (CRITICAL).
- **Fail-closed:** in enforced mode without VALID/GRACE license → scans denied (Safe-Hold / 403, pre-existing paths now audited) and tier capped to **Community**, never OPEN. YAML `effective_tier` is ignored in enforced mode; valid license without `dbtier` claim caps to Community.
- **Audit trail (#719 core bug = "sem audit"):** new `core/licensing/audit.py` — dedicated `data_boar.licensing.audit` logger, `LICENSE_AUDIT` prefix. Decisions recorded: `license_evaluated`, `scan_gate` (allow/deny), `feature_denied`, `feature_gate` allow (DEBUG), `report_rows_clamped`, `tier_fail_closed`, `env_mode_downgrade_ignored`. Denials in enforced mode log at CRITICAL.
- **Regression:** `tests/test_licensing_enforcement_no_bypass.py` (11 tests) — proves `DATA_BOAR_ENV=development` + `DEBUG=1` + `TIER_OVERRIDE=enterprise` with `licensing.mode=enforced` still bites: scan denied, Community cap, CRITICAL audit records.
- **Docs:** `LICENSING_SPEC.md` "No environment bypass" section; `.env.example` anti-pattern warning (`DEBUG=1` in production).

## Test plan

- [x] `./scripts/check-all.sh` green (1338 passed, 7 skipped, 248 subtests)
- [x] New regression suite passes (11 tests)
- [x] Existing licensing suites updated (override tests now assert NO bypass)

Made with [Cursor](https://cursor.com)