### PR TITLE
feat(licensing): worker cap dbmax_workers + CI matrix Python 3.14 signal-only (#551)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,14 @@
 #     is marked FAILED (not skipped, not passed).
 #   - `pip-audit` security scan: runs after install; a discovered vulnerability
 #     without a matching `--ignore-vuln` entry fails the job.
-#   - `fail-fast: false` on the matrix means Python-3.12 and Python-3.13 jobs
-#     run to completion even if one fails, so both error logs are collected.
+#   - `fail-fast: false` on the matrix means Python-3.12/3.13/3.14 jobs
+#     run to completion even if one fails, so all error logs are collected.
 #     It does NOT mean "pass when there are errors" — just parallel visibility.
+#   - Python 3.14 is SIGNAL-ONLY (#551): it runs the full test suite for the
+#     future no-GIL Enterprise runtime but uses `continue-on-error: true` so an
+#     ecosystem gap (missing wheels, dep incompatibility) does not block merges.
+#     The runtime / Docker base image stays 3.12/3.13 until the licensing
+#     enforcement gate is green (rationale in #551).
 #
 # Third-party Actions use full commit SHAs (major tag noted in comment). Refresh via Dependabot
 # (github-actions) or deliberately after reading upstream release notes. astral-sh/setup-uv `version`
@@ -39,7 +44,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14"]
+    # 3.14 is signal-only (#551) — see header comment. 3.12/3.13 stay blocking.
+    continue-on-error: ${{ matrix.python-version == '3.14' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/core/engine.py
+++ b/core/engine.py
@@ -193,6 +193,33 @@ class AuditEngine:
                 f"Licensing blocks scan: state={c.state} detail={c.detail}",
             )
 
+        # #551: licensing worker cap — effective = min(scan.max_workers, tier cap).
+        # Enforced mode only (open mode returns None = no cap). Fail-soft: a cap
+        # resolution error must never abort a scan the license gate already
+        # allowed — warn and run uncapped instead.
+        import logging
+
+        try:
+            cap = guard.worker_cap()
+        except Exception as e:  # noqa: BLE001
+            logging.getLogger(__name__).warning(
+                "Licensing worker cap resolution failed (fail-soft, no cap): %s", e
+            )
+            cap = None
+        if cap is not None and self._max_workers > cap:
+            from core.licensing.audit import audit_enforcement_event
+
+            c = guard.context
+            audit_enforcement_event(
+                "workers_clamped",
+                mode=c.mode,
+                state=c.state,
+                allowed=False,
+                detail=f"requested={self._max_workers} cap={cap}",
+                level=logging.WARNING,
+            )
+            self._max_workers = cap
+
         session_id = new_session_id()
         self.db_manager.set_current_session_id(session_id)
         scope_hash = _compute_config_scope_hash(self.config)

--- a/core/licensing/guard.py
+++ b/core/licensing/guard.py
@@ -52,6 +52,8 @@ class LicenseContext:
     watermark: str = ""
     # Product tier hint from JWT (`dbtier` claim) when mode is enforced — see LICENSING_SPEC.md
     dbtier: str = ""
+    # Parallel scan worker cap from JWT (`dbmax_workers` claim, #551); 0 = no explicit claim.
+    max_workers: int = 0
 
     def to_public_dict(self) -> dict[str, Any]:
         return {
@@ -69,6 +71,16 @@ class LicenseContext:
             "dbtier": self.dbtier or None,
         }
 
+
+# #551: fallback worker caps when a usable license carries no dbmax_workers
+# claim. Tier resolution in enforced mode already fails closed to COMMUNITY,
+# so an unlicensed/invalid state inherits the Community cap.
+_TIER_DEFAULT_WORKER_CAP: dict[Tier, int | None] = {
+    Tier.OPEN: None,
+    Tier.COMMUNITY: 2,
+    Tier.PRO: 5,
+    Tier.ENTERPRISE: None,  # unlimited — Enterprise perk
+}
 
 _guard_instance: LicenseGuard | None = None
 
@@ -305,6 +317,13 @@ class LicenseGuard:
 
         trial = bool(claims.get("dbtrial", False))
         max_rows = int(claims.get("dbmaxrows", 0) or 0)
+        # #551: dbmax_workers claim — fail-soft on malformed values (treat as absent).
+        try:
+            claim_workers = int(claims.get("dbmax_workers", 0) or 0)
+        except (TypeError, ValueError):
+            claim_workers = 0
+        if claim_workers < 0:
+            claim_workers = 0
 
         if now <= exp:
             state = "VALID"
@@ -336,6 +355,7 @@ class LicenseGuard:
             detail="ok" if state in ("VALID", "GRACE") else state.lower(),
             watermark=wm,
             dbtier=str(claims.get("dbtier") or "").strip(),
+            max_workers=claim_workers,
         )
 
     @property
@@ -381,6 +401,23 @@ class LicenseGuard:
             )
             return c.max_report_rows
         return None
+
+    def worker_cap(self) -> int | None:
+        """
+        Max parallel scan workers allowed by licensing (#551). ``None`` = unlimited.
+
+        Only ``enforced`` mode caps — open mode never restricts ``scan.max_workers``.
+        A positive ``dbmax_workers`` claim on a usable (VALID/GRACE) license wins;
+        otherwise the resolved tier default applies (Community 2 / Pro 5 /
+        Enterprise unlimited). Enforced fail-closed states resolve to the
+        Community tier, so they inherit the Community cap.
+        """
+        c = self.context
+        if c.mode != "enforced":
+            return None
+        if c.state in ("VALID", "GRACE") and c.max_workers > 0:
+            return c.max_workers
+        return _TIER_DEFAULT_WORKER_CAP.get(self.product_tier_for_features(), 2)
 
     def product_tier_for_features(self) -> Tier:
         """Resolve product tier for feature gates (YAML lab simulation or JWT dbtier)."""

--- a/docs/LICENSING_SPEC.md
+++ b/docs/LICENSING_SPEC.md
@@ -73,6 +73,7 @@ Custom claims (namespaced to avoid collisions):
 | `dbissuer`  | string | Issuer operator id (e.g. SSH key fingerprint or email)                          |
 | `dbkid`     | string | Signing key id for rotation                                                     |
 | `dbgrace`   | int    | Grace period end (unix); after `exp`, still **GRACE** until this time           |
+| `dbmax_workers` | int | Max parallel scan workers (#551). **Enforced mode only:** the engine clamps `scan.max_workers` to `min(scan.max_workers, dbmax_workers)`. Absent/zero on a usable license → tier defaults apply (Community **2** / Pro **5** / Enterprise **unlimited**). Open mode never caps. Clamp is fail-soft and audited (`workers_clamped`, WARNING). |
 | `dbmax_deployments` | int | **Planned** — max distinct **licensed production sites** (machine seeds / fingerprints) for this token; **1** = Pro-style single server or single consultant laptop; **0** may mean **unlimited** when contract allows (Enterprise). Not enforced until product reads it. |
 | `dbdeployment_pack_id` | string | **Optional** — id of a **commercial add-on** (e.g. “+5 sites”) for audit/refill trail; pairs with re-issued JWT or companion allowlist file. |
 

--- a/tests/test_worker_cap.py
+++ b/tests/test_worker_cap.py
@@ -1,0 +1,255 @@
+"""
+#551 — licensing worker cap (``dbmax_workers``).
+
+Contract under test:
+
+1. Open mode (no ``licensing:`` block or ``mode: open``) NEVER caps
+   ``scan.max_workers`` — ``worker_cap()`` returns ``None``.
+2. Enforced mode with a usable (VALID/GRACE) license: a positive
+   ``dbmax_workers`` claim wins.
+3. Enforced mode without the claim: tier fallback defaults apply —
+   Community 2 / Pro 5 / Enterprise unlimited (``None``).
+4. Enforced fail-closed states (no license, invalid) resolve the tier to
+   Community → inherit the Community cap. Dev env vars do not lift it (#719).
+5. Engine integration: ``start_audit`` clamps ``_max_workers`` to the cap
+   (fail-soft, scan still runs) and records a ``workers_clamped`` WARNING on
+   the audit logger.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from core.licensing.guard import LicenseGuard, reset_license_guard_for_tests
+
+AUDIT_LOGGER = "data_boar.licensing.audit"
+
+
+def _pem_public(priv: Ed25519PrivateKey) -> str:
+    return (
+        priv.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("ascii")
+        .strip()
+    )
+
+
+def _make_token(priv: Ed25519PrivateKey, *, extra: dict | None = None) -> str:
+    now = datetime.now(timezone.utc)
+    payload = {
+        "sub": "lic-worker-cap",
+        "iat": int(now.timestamp()),
+        "exp": int((now + timedelta(days=7)).timestamp()),
+        "dbcid": "cust-1",
+        "dbcname": "Test Customer",
+        "dbenv": "qa",
+        "dbissuer": "test-issuer",
+        "dbkid": "k1",
+    }
+    if extra:
+        payload.update(extra)
+    return jwt.encode(payload, priv, algorithm="EdDSA")
+
+
+@pytest.fixture
+def ed25519_priv() -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.generate()
+
+
+@pytest.fixture(autouse=True)
+def _clean_env():
+    reset_license_guard_for_tests()
+    keys = (
+        "DATA_BOAR_ENV",
+        "DEBUG",
+        "DATA_BOAR_TIER_OVERRIDE",
+        "DATA_BOAR_LICENSE_MODE",
+        "DATA_BOAR_LICENSE_PATH",
+        "DATA_BOAR_LICENSE_PUBLIC_KEY_PEM",
+        "DATA_BOAR_LICENSE_PUBLIC_KEY_PATH",
+        "DATA_BOAR_LICENSE_REVOCATION_PATH",
+    )
+    saved = {k: os.environ.get(k) for k in keys}
+    for k in keys:
+        os.environ.pop(k, None)
+    yield
+    reset_license_guard_for_tests()
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+def _enforced_guard(
+    priv: Ed25519PrivateKey, tmp_path, *, extra: dict | None = None
+) -> LicenseGuard:
+    lic = tmp_path / "t.lic"
+    lic.write_text(_make_token(priv, extra=extra), encoding="utf-8")
+    os.environ["DATA_BOAR_LICENSE_PUBLIC_KEY_PEM"] = _pem_public(priv)
+    return LicenseGuard({"licensing": {"mode": "enforced", "license_path": str(lic)}})
+
+
+# --- 1. open mode: never capped --------------------------------------------
+
+
+def test_open_mode_no_cap():
+    g = LicenseGuard({})
+    assert g.worker_cap() is None
+
+
+def test_open_mode_explicit_no_cap():
+    g = LicenseGuard({"licensing": {"mode": "open", "effective_tier": "community"}})
+    assert g.worker_cap() is None
+
+
+# --- 2. enforced: dbmax_workers claim wins ----------------------------------
+
+
+def test_enforced_claim_wins(ed25519_priv, tmp_path):
+    g = _enforced_guard(
+        ed25519_priv, tmp_path, extra={"dbtier": "enterprise", "dbmax_workers": 3}
+    )
+    assert g.context.state == "VALID"
+    assert g.worker_cap() == 3
+
+
+def test_enforced_malformed_claim_falls_back_to_tier(ed25519_priv, tmp_path):
+    g = _enforced_guard(
+        ed25519_priv,
+        tmp_path,
+        extra={"dbtier": "pro", "dbmax_workers": "not-a-number"},
+    )
+    assert g.context.state == "VALID"
+    assert g.context.max_workers == 0  # fail-soft: malformed claim treated as absent
+    assert g.worker_cap() == 5
+
+
+def test_enforced_negative_claim_treated_as_absent(ed25519_priv, tmp_path):
+    g = _enforced_guard(
+        ed25519_priv, tmp_path, extra={"dbtier": "pro", "dbmax_workers": -4}
+    )
+    assert g.worker_cap() == 5
+
+
+# --- 3. enforced: tier fallback defaults ------------------------------------
+
+
+def test_enforced_community_default_cap(ed25519_priv, tmp_path):
+    g = _enforced_guard(ed25519_priv, tmp_path, extra={"dbtier": "community"})
+    assert g.worker_cap() == 2
+
+
+def test_enforced_pro_default_cap(ed25519_priv, tmp_path):
+    g = _enforced_guard(ed25519_priv, tmp_path, extra={"dbtier": "pro"})
+    assert g.worker_cap() == 5
+
+
+def test_enforced_enterprise_unlimited(ed25519_priv, tmp_path):
+    g = _enforced_guard(ed25519_priv, tmp_path, extra={"dbtier": "enterprise"})
+    assert g.worker_cap() is None
+
+
+# --- 4. enforced fail-closed inherits Community cap; no env lift ------------
+
+
+def test_enforced_unlicensed_inherits_community_cap():
+    g = LicenseGuard({"licensing": {"mode": "enforced"}})
+    assert g.context.state == "UNLICENSED"
+    assert g.worker_cap() == 2
+
+
+def test_dev_env_does_not_lift_cap(monkeypatch):
+    """#719 regression applied to #551: dev env vars never lift the worker cap."""
+    monkeypatch.setenv("DATA_BOAR_ENV", "development")
+    monkeypatch.setenv("DEBUG", "1")
+    monkeypatch.setenv("DATA_BOAR_TIER_OVERRIDE", "enterprise")
+    g = LicenseGuard({"licensing": {"mode": "enforced"}})
+    assert g.worker_cap() == 2
+
+
+# --- 5. engine integration: start_audit clamps + audits ---------------------
+
+
+def _engine(tmp_path, max_workers: int, licensing: dict | None = None):
+    from core.engine import AuditEngine
+
+    cfg: dict = {
+        "targets": [],
+        "scan": {"max_workers": max_workers},
+        "sqlite_path": str(tmp_path / "audit.db"),
+    }
+    if licensing:
+        cfg["licensing"] = licensing
+    return AuditEngine(cfg, db_path=str(tmp_path / "audit.db"))
+
+
+def test_engine_clamps_workers_in_enforced(ed25519_priv, tmp_path, caplog):
+    from core.licensing.guard import get_license_guard
+
+    lic = tmp_path / "t.lic"
+    lic.write_text(
+        _make_token(ed25519_priv, extra={"dbtier": "enterprise", "dbmax_workers": 2}),
+        encoding="utf-8",
+    )
+    os.environ["DATA_BOAR_LICENSE_PUBLIC_KEY_PEM"] = _pem_public(ed25519_priv)
+    licensing = {"mode": "enforced", "license_path": str(lic)}
+    engine = _engine(tmp_path, max_workers=8, licensing=licensing)
+    # Prime the singleton with the same config the engine will use.
+    get_license_guard(engine.config)
+    with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+        engine.start_audit()
+    assert engine._max_workers == 2
+    clamps = [
+        r
+        for r in caplog.records
+        if r.name == AUDIT_LOGGER and "workers_clamped" in r.message
+    ]
+    assert clamps and clamps[0].levelno == logging.WARNING
+    assert "requested=8" in clamps[0].message
+    assert "cap=2" in clamps[0].message
+
+
+def test_engine_open_mode_never_clamps(tmp_path, caplog):
+    engine = _engine(tmp_path, max_workers=16)
+    with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+        engine.start_audit()
+    assert engine._max_workers == 16
+    assert not any(
+        "workers_clamped" in r.message for r in caplog.records if r.name == AUDIT_LOGGER
+    )
+
+
+def test_engine_cap_failure_is_fail_soft(ed25519_priv, tmp_path, monkeypatch, caplog):
+    """A cap-resolution error must not abort a scan the gate already allowed."""
+    from core.licensing.guard import LicenseGuard as _LG
+    from core.licensing.guard import get_license_guard
+
+    lic = tmp_path / "t.lic"
+    lic.write_text(
+        _make_token(ed25519_priv, extra={"dbtier": "enterprise"}), encoding="utf-8"
+    )
+    os.environ["DATA_BOAR_LICENSE_PUBLIC_KEY_PEM"] = _pem_public(ed25519_priv)
+    licensing = {"mode": "enforced", "license_path": str(lic)}
+    engine = _engine(tmp_path, max_workers=4, licensing=licensing)
+    get_license_guard(engine.config)
+
+    def _boom(self):
+        raise RuntimeError("cap backend exploded")
+
+    monkeypatch.setattr(_LG, "worker_cap", _boom)
+    with caplog.at_level(logging.WARNING):
+        session_id = engine.start_audit()
+    assert session_id  # scan completed despite the cap failure
+    assert engine._max_workers == 4  # uncapped fail-soft
+    assert any("fail-soft" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

ENFORCEMENT WAVE — PR 4 (after #847 kill-bypass, #848 QA license, #849 connector gating).

**Worker cap (`dbmax_workers`):**
- `LicenseGuard.worker_cap()` — **enforced mode only**: a positive `dbmax_workers` JWT claim on a usable (VALID/GRACE) license wins; otherwise tier fallback defaults: **Community 2 / Pro 5 / Enterprise unlimited**. **Open mode never caps.** Enforced fail-closed states resolve the tier to Community (#719 posture) and inherit the Community cap — dev env vars cannot lift it.
- `engine.start_audit`: `effective = min(scan.max_workers, cap)` after the scan gate. Clamp is recorded as a `workers_clamped` **WARNING** on the `data_boar.licensing.audit` logger. **Fail-soft**: malformed claims are treated as absent; a cap-resolution error warns and runs uncapped — it never aborts a scan the license gate already allowed.
- `docs/LICENSING_SPEC.md`: new `dbmax_workers` claim row.
- `tests/test_worker_cap.py` (13 tests): open never caps · claim wins · malformed/negative claim fallback · tier defaults · fail-closed Community cap · dev-env no-lift regression · engine clamp + audit record + fail-soft path.

**CI matrix (signal-only):**
- Python **3.14** added to the Test matrix with `continue-on-error: true` — runs the full suite for the future no-GIL Enterprise runtime without blocking merges on ecosystem gaps. ⚠️ Runtime / Docker base image **not** bumped (gate-first rationale in #551).

Closes #551

## Test plan

- [x] `tests/test_worker_cap.py` — 13 passed
- [x] `tests/test_github_workflows.py` — 19 passed (workflow shape guard)
- [x] `./scripts/check-all.sh` green (full pre-commit bundle + pytest)
- [ ] CI green (3.12/3.13 blocking; 3.14 signal-only)

Made with [Cursor](https://cursor.com)