### PR TITLE
feat(licensing): runtime fingerprint binding + deployment pack (#718, #846)

### DIFF
--- a/core/licensing/guard.py
+++ b/core/licensing/guard.py
@@ -54,6 +54,11 @@ class LicenseContext:
     dbtier: str = ""
     # Parallel scan worker cap from JWT (`dbmax_workers` claim, #551); 0 = no explicit claim.
     max_workers: int = 0
+    # Deployment pack (#846): commercial add-on id + licensed site count. The GLOBAL
+    # deploy count is issuance-enforced (the issuer emits the pack); runtime only
+    # validates its OWN fingerprint ∈ dbmfp (single hex or pack array) — see #718.
+    deployment_pack_id: str = ""
+    max_deployments: int = 0
 
     def to_public_dict(self) -> dict[str, Any]:
         return {
@@ -69,7 +74,42 @@ class LicenseContext:
             "trial": self.trial,
             "watermark": self.watermark or None,
             "dbtier": self.dbtier or None,
+            "deployment_pack_id": self.deployment_pack_id or None,
+            "max_deployments": self.max_deployments or None,
         }
+
+
+# #846: deployment-count defaults are ISSUANCE-enforced — the issuer emits the
+# fingerprint pack; runtime only validates its OWN fingerprint ∈ dbmfp (#718).
+# Pro default pending operator ratification (described as on-prem + 1 cloud/branch).
+DEFAULT_PRO_DEPLOYMENTS = 2  # operator-ratify: 1 vs 2
+DEFAULT_ENTERPRISE_DEPLOYMENTS = 0  # 0 = unlimited (contract-driven)
+
+
+def _parse_dbmfp_claim(raw: Any) -> list[str] | None:
+    """
+    Parse the ``dbmfp`` claim (#718 + #846).
+
+    Accepted shapes: absent/empty → ``[]`` (no binding); a single hex string →
+    one-entry list; a list/tuple of hex strings (deployment pack) → normalized
+    list. Any other type is a malformed claim → ``None`` (caller fails closed,
+    #719 posture — a bad binding claim must never mean "unbound").
+    """
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        v = raw.strip().lower()
+        return [v] if v else []
+    if isinstance(raw, (list, tuple)):
+        out: list[str] = []
+        for item in raw:
+            if not isinstance(item, str):
+                return None
+            v = item.strip().lower()
+            if v:
+                out.append(v)
+        return out
+    return None
 
 
 # #551: fallback worker caps when a usable license carries no dbmax_workers
@@ -279,9 +319,29 @@ class LicenseGuard:
         exp_iso = _ts_iso(exp)
         grace_iso = _ts_iso(grace_ts) if grace_ts else ""
 
-        token_mfp = str(claims.get("dbmfp", "") or "").strip().lower()
-        # Non-empty dbmfp binds the license to one fingerprint (deployment/host).
-        if token_mfp and mfp.lower() != token_mfp:
+        # #718 + #846: dbmfp binds the license to one fingerprint (single hex
+        # string) or to a deployment pack (list of hex strings). Runtime
+        # validates only its OWN fingerprint ∈ pack; the GLOBAL deploy count
+        # (dbmax_deployments) is issuance-enforced by the issuer.
+        allowed_fps = _parse_dbmfp_claim(claims.get("dbmfp"))
+        pack_id = str(claims.get("dbdeployment_pack_id", "") or "").strip()
+        try:
+            max_deployments = int(claims.get("dbmax_deployments", 0) or 0)
+        except (TypeError, ValueError):
+            max_deployments = 0
+        if allowed_fps is None:
+            # Malformed binding claim fails CLOSED (#719 posture) — it must
+            # never degrade to "unbound".
+            self._context = LicenseContext(
+                state="INVALID",
+                mode="enforced",
+                license_id=lic_id,
+                machine_fingerprint=mfp,
+                detail="malformed_dbmfp_claim",
+                watermark="INVALID_TOKEN",
+            )
+            return
+        if allowed_fps and mfp.lower() not in allowed_fps:
             self._context = LicenseContext(
                 state="MACHINE_MISMATCH",
                 mode="enforced",
@@ -298,6 +358,8 @@ class LicenseGuard:
                 machine_fingerprint=mfp,
                 detail="machine_fingerprint_mismatch",
                 watermark="WRONG_HOST",
+                deployment_pack_id=pack_id,
+                max_deployments=max_deployments,
             )
             return
 
@@ -305,7 +367,7 @@ class LicenseGuard:
             os.environ.get("DATA_BOAR_LICENSE_MACHINE_STRICT", "").strip().lower()
             in ("1", "true", "yes")
         )
-        if bind_strict and not token_mfp:
+        if bind_strict and not allowed_fps:
             self._context = LicenseContext(
                 state="UNLICENSED",
                 mode="enforced",
@@ -356,6 +418,8 @@ class LicenseGuard:
             watermark=wm,
             dbtier=str(claims.get("dbtier") or "").strip(),
             max_workers=claim_workers,
+            deployment_pack_id=pack_id,
+            max_deployments=max_deployments,
         )
 
     @property

--- a/docs/LICENSING_SPEC.md
+++ b/docs/LICENSING_SPEC.md
@@ -67,17 +67,17 @@ Custom claims (namespaced to avoid collisions):
 | `dbcid`     | string | Customer ID                                                                     |
 | `dbcname`   | string | Customer display name                                                           |
 | `dbenv`     | string | Target environment: `production`, `qa`, `uat`, `homologation`, `debug`, `trial` |
-| `dbmfp`     | string | Expected machine fingerprint (hex SHA-256); empty = any host                    |
+| `dbmfp`     | string \| array | Expected machine fingerprint(s). Single hex string = one host; **array of hex strings = deployment pack** (#718 + #846): runtime accepts when its own fingerprint ∈ pack. Empty/absent = any host. **Malformed claim (wrong type) fails closed** (`INVALID`) — never degrades to "unbound". |
 | `dbtrial`   | bool   | Trial / POC: cap report rows and watermark                                      |
 | `dbmaxrows` | int    | Max data rows in report when trial (e.g. 15)                                    |
 | `dbissuer`  | string | Issuer operator id (e.g. SSH key fingerprint or email)                          |
 | `dbkid`     | string | Signing key id for rotation                                                     |
 | `dbgrace`   | int    | Grace period end (unix); after `exp`, still **GRACE** until this time           |
 | `dbmax_workers` | int | Max parallel scan workers (#551). **Enforced mode only:** the engine clamps `scan.max_workers` to `min(scan.max_workers, dbmax_workers)`. Absent/zero on a usable license → tier defaults apply (Community **2** / Pro **5** / Enterprise **unlimited**). Open mode never caps. Clamp is fail-soft and audited (`workers_clamped`, WARNING). |
-| `dbmax_deployments` | int | **Planned** — max distinct **licensed production sites** (machine seeds / fingerprints) for this token; **1** = Pro-style single server or single consultant laptop; **0** may mean **unlimited** when contract allows (Enterprise). Not enforced until product reads it. |
-| `dbdeployment_pack_id` | string | **Optional** — id of a **commercial add-on** (e.g. “+5 sites”) for audit/refill trail; pairs with re-issued JWT or companion allowlist file. |
+| `dbmax_deployments` | int | Max distinct **licensed production sites** (fingerprints) for this token (#846). **Issuance-enforced:** the issuer emits the `dbmfp` pack with at most this many entries; runtime reads the claim into `LicenseContext.max_deployments` (audit/report surface) and validates only its **own** fingerprint ∈ pack. **0** may mean **unlimited** when contract allows (Enterprise). Pro default pending operator ratification — see `DEFAULT_PRO_DEPLOYMENTS` in `core/licensing/guard.py`. |
+| `dbdeployment_pack_id` | string | Id of a **commercial add-on** (e.g. “+5 sites”) for audit/refill trail (#846); surfaced in `LicenseContext.deployment_pack_id`. Issuer: `scripts/issue_dev_license_jwt.py --dbmfp-pack <hex,hex,...> [--pack-id ...]`. |
 
-**Multi-site verification (not implemented):** Today only **`dbmfp`** (single) is meaningful. For Enterprise **N** sites, options to evaluate: (1) **array** of allowed fingerprints in an extended token or **signed sidecar JSON** next to the `.lic` file; (2) **online** registration (privacy + ops cost); (3) **multiple JWTs** same `dbcid`, one fingerprint each — simplest cryptographically, heavier for the customer. See [LICENSING_OPEN_CORE_AND_COMMERCIAL.md](LICENSING_OPEN_CORE_AND_COMMERCIAL.md) §Deployments, copies, and sites.
+**Multi-site verification (honest boundary, #718 + #846):** Implemented via option (1) — **array** of allowed fingerprints in the `dbmfp` claim (deployment pack). Runtime validates only that **its own** `compute_machine_fingerprint()` (hostname + optional `DATA_BOAR_MACHINE_SEED`) is in the pack — the **global** deploy count is enforced at **issuance** (the issuer signs a pack of at most `dbmax_deployments` fingerprints); the runtime cannot count other sites. Alternatives kept for reference: (2) **online** registration (privacy + ops cost); (3) **multiple JWTs** same `dbcid`, one fingerprint each. See [LICENSING_OPEN_CORE_AND_COMMERCIAL.md](LICENSING_OPEN_CORE_AND_COMMERCIAL.md) §Deployments, copies, and sites.
 
 ## Lifecycle states
 

--- a/scripts/issue_dev_license_jwt.py
+++ b/scripts/issue_dev_license_jwt.py
@@ -64,6 +64,25 @@ def _resolve_dbmfp(raw: str) -> str:
     return value
 
 
+def _resolve_dbmfp_pack(raw: str) -> list[str]:
+    """
+    Resolve --dbmfp-pack: comma-separated fingerprints (deployment pack, #846).
+
+    Each entry is a hex fingerprint from --show-machine-fingerprint on the
+    target machine; the literal 'auto' binds THIS machine as one pack member.
+    """
+    pack: list[str] = []
+    for part in raw.split(","):
+        value = part.strip().lower()
+        if not value:
+            continue
+        if value == "auto":
+            value = _machine_fingerprint()
+        if value not in pack:
+            pack.append(value)
+    return pack
+
+
 def main() -> None:
     p = argparse.ArgumentParser(
         description=(
@@ -98,6 +117,28 @@ def main() -> None:
         ),
     )
     p.add_argument(
+        "--dbmfp-pack",
+        help=(
+            "Deployment pack (#846): comma-separated fingerprint hexes to bind "
+            "the license to N machines (use 'auto' for THIS machine, e.g. "
+            "'auto,<tester-hex>'). Overrides --dbmfp. Runtime validates only "
+            "its own fingerprint; the pack size is issuance-enforced."
+        ),
+    )
+    p.add_argument(
+        "--pack-id",
+        help="dbdeployment_pack_id claim (audit trail; default: '<sub>-pack' when --dbmfp-pack is used)",
+    )
+    p.add_argument(
+        "--dbmax-deployments",
+        type=int,
+        help=(
+            "dbmax_deployments claim — licensed site count. Default: pack size "
+            "when --dbmfp-pack is used, else omitted. Enterprise contracts may "
+            "use 0 = unlimited."
+        ),
+    )
+    p.add_argument(
         "--show-machine-fingerprint",
         action="store_true",
         help="Print this machine's fingerprint (send to the issuer) and exit",
@@ -127,9 +168,24 @@ def main() -> None:
         "dbkid": "dev",
         "dbtier": args.dbtier.strip(),
     }
-    dbmfp = _resolve_dbmfp(args.dbmfp)
-    if dbmfp:
-        payload["dbmfp"] = dbmfp
+    if args.dbmfp_pack:
+        pack = _resolve_dbmfp_pack(args.dbmfp_pack)
+        if not pack:
+            print("--dbmfp-pack resolved to an empty pack", file=sys.stderr)
+            sys.exit(1)
+        payload["dbmfp"] = pack
+        payload["dbdeployment_pack_id"] = args.pack_id or f"{args.sub}-pack"
+        payload["dbmax_deployments"] = (
+            args.dbmax_deployments if args.dbmax_deployments is not None else len(pack)
+        )
+    else:
+        dbmfp = _resolve_dbmfp(args.dbmfp)
+        if dbmfp:
+            payload["dbmfp"] = dbmfp
+        if args.dbmax_deployments is not None:
+            payload["dbmax_deployments"] = args.dbmax_deployments
+        if args.pack_id:
+            payload["dbdeployment_pack_id"] = args.pack_id
     token = jwt.encode(payload, key, algorithm="EdDSA")
     if args.out:
         Path(args.out).write_text(token + "\n", encoding="utf-8")

--- a/tests/test_fingerprint_binding_deployments.py
+++ b/tests/test_fingerprint_binding_deployments.py
@@ -1,0 +1,336 @@
+"""
+#718 + #846 — runtime fingerprint binding (dbmfp single + deployment pack).
+
+Contract under test:
+
+1. Enforced + license bound to the LOCAL fingerprint (single ``dbmfp`` string
+   or pack array containing it) → VALID, scan allowed.
+2. Enforced + license bound to ANOTHER fingerprint (or a pack without the
+   local one) → MACHINE_MISMATCH, fail-closed (scan denied, tier capped to
+   Community) + audit CRITICAL — same posture as #719/#847.
+3. Enforced + no ``dbmfp`` claim → no binding (current behavior preserved).
+4. Open mode → binding never checked.
+5. Malformed ``dbmfp`` claim (wrong type) → INVALID, fail-closed — never
+   degrades to "unbound".
+6. ``dbmax_deployments`` + ``dbdeployment_pack_id`` claims are plumbed into
+   ``LicenseContext`` (issuance-enforced count; runtime validates own fp only).
+7. Issuer ``--dbmfp-pack`` emits a pack license usable on a pack member.
+8. ``DATA_BOAR_MACHINE_SEED`` changes the computed fingerprint (documented
+   deployment-stability knob).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from core.licensing.fingerprint import compute_machine_fingerprint
+from core.licensing.guard import (
+    LicenseGuard,
+    _parse_dbmfp_claim,
+    reset_license_guard_for_tests,
+)
+from core.licensing.runtime_feature_tier import get_runtime_tier_for_features
+from core.licensing.tier_features import Tier
+
+AUDIT_LOGGER = "data_boar.licensing.audit"
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ISSUER = REPO_ROOT / "scripts" / "issue_dev_license_jwt.py"
+
+OTHER_FP = "f" * 64  # a fingerprint that is never the local machine's
+
+
+def _pem_public(priv: Ed25519PrivateKey) -> str:
+    return (
+        priv.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("ascii")
+        .strip()
+    )
+
+
+def _pem_private(priv: Ed25519PrivateKey) -> str:
+    return priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("ascii")
+
+
+def _make_token(priv: Ed25519PrivateKey, *, extra: dict | None = None) -> str:
+    now = datetime.now(timezone.utc)
+    payload = {
+        "sub": "lic-fp-binding",
+        "iat": int(now.timestamp()),
+        "exp": int((now + timedelta(days=7)).timestamp()),
+        "dbcid": "cust-1",
+        "dbcname": "Test Customer",
+        "dbenv": "qa",
+        "dbissuer": "test-issuer",
+        "dbkid": "k1",
+        "dbtier": "enterprise",
+    }
+    if extra:
+        payload.update(extra)
+    return jwt.encode(payload, priv, algorithm="EdDSA")
+
+
+@pytest.fixture
+def ed25519_priv() -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.generate()
+
+
+@pytest.fixture(autouse=True)
+def _clean_env():
+    reset_license_guard_for_tests()
+    keys = (
+        "DATA_BOAR_ENV",
+        "DEBUG",
+        "DATA_BOAR_LICENSE_MODE",
+        "DATA_BOAR_LICENSE_PATH",
+        "DATA_BOAR_LICENSE_PUBLIC_KEY_PEM",
+        "DATA_BOAR_LICENSE_PUBLIC_KEY_PATH",
+        "DATA_BOAR_LICENSE_REVOCATION_PATH",
+        "DATA_BOAR_LICENSE_MACHINE_STRICT",
+        "DATA_BOAR_MACHINE_SEED",
+    )
+    saved = {k: os.environ.get(k) for k in keys}
+    for k in keys:
+        os.environ.pop(k, None)
+    yield
+    reset_license_guard_for_tests()
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+def _enforced_guard(
+    priv: Ed25519PrivateKey, tmp_path, *, extra: dict | None = None
+) -> LicenseGuard:
+    lic = tmp_path / "t.lic"
+    lic.write_text(_make_token(priv, extra=extra), encoding="utf-8")
+    os.environ["DATA_BOAR_LICENSE_PUBLIC_KEY_PEM"] = _pem_public(priv)
+    return LicenseGuard({"licensing": {"mode": "enforced", "license_path": str(lic)}})
+
+
+def _audit_records(caplog):
+    return [r for r in caplog.records if r.name == AUDIT_LOGGER]
+
+
+# --- claim parsing -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, []),
+        ("", []),
+        ("  ", []),
+        ("ABCD12", ["abcd12"]),
+        (["ABCD12", "ef34"], ["abcd12", "ef34"]),
+        ([], []),
+        (["", "ab"], ["ab"]),
+    ],
+)
+def test_parse_dbmfp_claim_valid_shapes(raw, expected):
+    assert _parse_dbmfp_claim(raw) == expected
+
+
+@pytest.mark.parametrize("raw", [{"a": 1}, 42, [1, 2], ["ok", 3]])
+def test_parse_dbmfp_claim_malformed_returns_none(raw):
+    assert _parse_dbmfp_claim(raw) is None
+
+
+# --- 1. bound to local fingerprint → accepted --------------------------------
+
+
+def test_single_dbmfp_local_accepted(ed25519_priv, tmp_path):
+    g = _enforced_guard(
+        ed25519_priv, tmp_path, extra={"dbmfp": compute_machine_fingerprint()}
+    )
+    assert g.context.state == "VALID"
+    assert g.allows_scan() is True
+
+
+def test_pack_containing_local_accepted(ed25519_priv, tmp_path):
+    pack = [OTHER_FP, compute_machine_fingerprint()]
+    g = _enforced_guard(
+        ed25519_priv,
+        tmp_path,
+        extra={
+            "dbmfp": pack,
+            "dbdeployment_pack_id": "qa-pack-1",
+            "dbmax_deployments": 2,
+        },
+    )
+    assert g.context.state == "VALID"
+    assert g.allows_scan() is True
+    assert g.context.deployment_pack_id == "qa-pack-1"
+    assert g.context.max_deployments == 2
+
+
+# --- 2. bound to another fingerprint → fail-closed + audit CRITICAL ----------
+
+
+def test_single_dbmfp_other_host_fails_closed(ed25519_priv, tmp_path, caplog):
+    with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+        g = _enforced_guard(ed25519_priv, tmp_path, extra={"dbmfp": OTHER_FP})
+        assert g.context.state == "MACHINE_MISMATCH"
+        assert g.allows_scan() is False
+        cfg = {"licensing": {"mode": "enforced"}}
+        assert get_runtime_tier_for_features(cfg) == Tier.COMMUNITY
+    crit = [r for r in _audit_records(caplog) if r.levelno == logging.CRITICAL]
+    assert any("license_evaluated" in r.message for r in crit)
+    assert any("scan_gate" in r.message for r in crit)
+
+
+def test_pack_without_local_fails_closed(ed25519_priv, tmp_path, caplog):
+    with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+        g = _enforced_guard(
+            ed25519_priv,
+            tmp_path,
+            extra={"dbmfp": [OTHER_FP, "e" * 64], "dbmax_deployments": 2},
+        )
+        assert g.context.state == "MACHINE_MISMATCH"
+        assert g.allows_scan() is False
+    assert any(r.levelno == logging.CRITICAL for r in _audit_records(caplog))
+
+
+def test_dev_env_does_not_bypass_machine_mismatch(ed25519_priv, tmp_path, monkeypatch):
+    """#719 posture: dev env vars never bypass the fingerprint binding."""
+    monkeypatch.setenv("DATA_BOAR_ENV", "development")
+    monkeypatch.setenv("DEBUG", "1")
+    g = _enforced_guard(ed25519_priv, tmp_path, extra={"dbmfp": OTHER_FP})
+    assert g.context.state == "MACHINE_MISMATCH"
+    assert g.allows_scan() is False
+
+
+# --- 3./4. no claim = unbound; open mode never checks -------------------------
+
+
+def test_enforced_without_dbmfp_runs_normally(ed25519_priv, tmp_path):
+    g = _enforced_guard(ed25519_priv, tmp_path)
+    assert g.context.state == "VALID"
+    assert g.allows_scan() is True
+
+
+def test_open_mode_never_checks_binding():
+    g = LicenseGuard({})
+    assert g.context.state == "OPEN"
+    assert g.allows_scan() is True
+
+
+# --- 5. malformed dbmfp fails closed ------------------------------------------
+
+
+def test_malformed_dbmfp_claim_fails_closed(ed25519_priv, tmp_path, caplog):
+    with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+        g = _enforced_guard(ed25519_priv, tmp_path, extra={"dbmfp": [123, 456]})
+        assert g.context.state == "INVALID"
+        assert g.context.detail == "malformed_dbmfp_claim"
+        assert g.allows_scan() is False
+    assert any(r.levelno == logging.CRITICAL for r in _audit_records(caplog))
+
+
+# --- 6. deployment claims plumbing --------------------------------------------
+
+
+def test_deployment_claims_default_zero_when_absent(ed25519_priv, tmp_path):
+    g = _enforced_guard(ed25519_priv, tmp_path)
+    assert g.context.deployment_pack_id == ""
+    assert g.context.max_deployments == 0
+
+
+def test_malformed_dbmax_deployments_fail_soft(ed25519_priv, tmp_path):
+    g = _enforced_guard(
+        ed25519_priv,
+        tmp_path,
+        extra={"dbmax_deployments": "not-a-number"},
+    )
+    assert g.context.state == "VALID"
+    assert g.context.max_deployments == 0
+
+
+# --- 7. issuer --dbmfp-pack ----------------------------------------------------
+
+
+def _run_issuer(args: list[str], env_extra: dict[str, str]) -> str:
+    env = dict(os.environ)
+    env.update(env_extra)
+    proc = subprocess.run(
+        [sys.executable, str(ISSUER), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+        cwd=str(REPO_ROOT),
+    )
+    return proc.stdout.strip()
+
+
+def test_issuer_dbmfp_pack_binds_n_machines(ed25519_priv, tmp_path):
+    token = _run_issuer(
+        ["--dbmfp-pack", f"auto,{OTHER_FP}", "--sub", "qa-pack-lic"],
+        {"DATA_BOAR_LICENSE_ISSUER_PRIVATE_KEY_PEM": _pem_private(ed25519_priv)},
+    )
+    claims = jwt.decode(
+        token,
+        _pem_public(ed25519_priv),
+        algorithms=["EdDSA"],
+    )
+    assert isinstance(claims["dbmfp"], list)
+    assert compute_machine_fingerprint() in claims["dbmfp"]
+    assert OTHER_FP in claims["dbmfp"]
+    assert claims["dbmax_deployments"] == 2
+    assert claims["dbdeployment_pack_id"] == "qa-pack-lic-pack"
+
+    # End-to-end: the pack license is VALID on this (pack member) machine.
+    lic = tmp_path / "pack.lic"
+    lic.write_text(token, encoding="utf-8")
+    os.environ["DATA_BOAR_LICENSE_PUBLIC_KEY_PEM"] = _pem_public(ed25519_priv)
+    g = LicenseGuard({"licensing": {"mode": "enforced", "license_path": str(lic)}})
+    assert g.context.state == "VALID"
+    assert g.context.max_deployments == 2
+
+
+def test_issuer_explicit_dbmax_deployments_and_pack_id(ed25519_priv):
+    token = _run_issuer(
+        [
+            "--dbmfp-pack",
+            f"auto,{OTHER_FP}",
+            "--pack-id",
+            "plus-5-sites",
+            "--dbmax-deployments",
+            "5",
+        ],
+        {"DATA_BOAR_LICENSE_ISSUER_PRIVATE_KEY_PEM": _pem_private(ed25519_priv)},
+    )
+    claims = jwt.decode(token, _pem_public(ed25519_priv), algorithms=["EdDSA"])
+    assert claims["dbdeployment_pack_id"] == "plus-5-sites"
+    assert claims["dbmax_deployments"] == 5
+
+
+# --- 8. DATA_BOAR_MACHINE_SEED stability knob ----------------------------------
+
+
+def test_machine_seed_changes_fingerprint(monkeypatch):
+    base = compute_machine_fingerprint()
+    monkeypatch.setenv("DATA_BOAR_MACHINE_SEED", "deployment-secret-1")
+    seeded = compute_machine_fingerprint()
+    assert seeded != base
+    # Deterministic per host/seed pair:
+    assert compute_machine_fingerprint() == seeded


### PR DESCRIPTION
## Summary

**#718 — runtime fingerprint binding (enforced mode):**
- `dbmfp` claim now accepts a single hex string **or an array** (deployment pack). When present, `compute_machine_fingerprint()` must be in the allowed set.
- Mismatch → **fail-closed** (`MACHINE_MISMATCH`: scan denied, tier capped to Community) + **CRITICAL audit** — same posture as #719/#847. Dev env vars do not bypass.
- Absent `dbmfp` = unbound (current behavior preserved). Open mode never checks.
- **Malformed `dbmfp` claim (wrong type) fails closed** (`INVALID`) — never degrades to "unbound".
- `DATA_BOAR_MACHINE_SEED` documented (deployment-stability knob; LICENSING_SPEC §fingerprint).

**#846 — dbmax_deployments claim plumbing + issuer (partial):**
- `dbmax_deployments` + `dbdeployment_pack_id` read into `LicenseContext` / status payload.
- Issuer: `--dbmfp-pack <hex,hex,...>` ('auto' = this machine) emits an N-fingerprint pack license; `--pack-id`, `--dbmax-deployments` (default = pack size).
- **Honest boundary documented:** global deploy count is **issuance-enforced** (issuer signs the pack); runtime validates only its **own** fingerprint ∈ pack.
- `DEFAULT_PRO_DEPLOYMENTS = 2` constant marked `# operator-ratify: 1 vs 2` — **not** final. Enterprise = 0/unlimited.

PLANS_TODO update intentionally **out** of this PR (rides in #851).

Closes #718. Refs #846 (partial — runtime binding done; Pro pricing-number pending).

## Test plan

- [x] 24 new regression tests (`tests/test_fingerprint_binding_deployments.py`): local-bound accepted; other-host / pack-without-local fail-closed + CRITICAL audit; dev-env no bypass; enforced-unbound runs; open mode never checks; malformed claim fail-closed; claim plumbing; issuer pack end-to-end; seed determinism
- [x] `./scripts/check-all.sh` green (1418 passed)
- [ ] CI green

Made with [Cursor](https://cursor.com)