### PR TITLE
docs(licensing): LICENSE_FAQ — operator draft points (air-gapped, auditability, declarative plugins, official build)

### DIFF
--- a/docs/LICENSE_FAQ.md
+++ b/docs/LICENSE_FAQ.md
@@ -17,6 +17,12 @@ A **dual structure in one public, auditable repository** (the Bitwarden / Elasti
 
 Everything in the **core**, for any purpose the BSD 3-Clause allows — including **internal use inside a commercial organisation** at no cost (see [Terms of Use §2](../TERMS_OF_USE.md)). Scanning systems you are authorised to scan, building reports for your own compliance program, modifying and extending the code: all free.
 
+Explicitly included in "free":
+
+- **Self-host** — you run it on your own infrastructure; no hosted dependency.
+- **Air-gapped** — Data Boar works fully offline; no phone-home is required to scan.
+- **No mandatory telemetry** — the scanner does not require sending your data, metrics, or findings anywhere. Your data stays where it is.
+
 ## 3. What requires a paid subscription?
 
 - **Delivering scan results to third parties as a paid service** (consulting, audit, MSSP) — Pro or higher (see [Terms of Use §4](../TERMS_OF_USE.md)).
@@ -26,6 +32,8 @@ Everything in the **core**, for any purpose the BSD 3-Clause allows — includin
 ## 4. Will the core ever close?
 
 **No — by definition.** The open-source core (scanner, detectors, plugin interface, baseline surfaces, research material) **never closes**. The commercial model funds the project precisely so the core can stay open and auditable.
+
+The key argument: **a tool that reads ALL of a customer's data MUST be auditable**. Nobody should trust a privacy **black box** with full read access to their most sensitive stores — open code is the only honest answer to "what exactly does this scanner do with my data?". The open core is also the project's **adoption engine**: DPOs, researchers, and engineers can evaluate, audit, and adopt it with zero friction, and that funnel is worth more than any closed-source moat.
 
 ## 5. Can I fork Data Boar?
 
@@ -45,13 +53,15 @@ Yes. The BSD 3-Clause core is forkable under its terms. Two boundaries:
 
 A determined actor can patch any of it locally; the point is that **tampered builds are evident**, unsupported, and commercially unusable at scale.
 
+For buyers, the practical takeaway: **customers handling sensitive data should run the OFFICIAL signed and supported build**. Trust, integrity verification, and support are part of what the subscription delivers — a patched or unofficial build forfeits exactly the assurances a privacy tool exists to provide.
+
 ## 7. What are the tiers?
 
 Community (free) → Pro → Pro+ → Enterprise, plus a custom **Partner** family. **Tier = capability, claim = quantity.** Full ladder, capability table, and worker/deployment claims: [SUBSCRIPTION_TIERS.md](SUBSCRIPTION_TIERS.md).
 
 ## 8. Can I write and distribute plugins?
 
-The **plugin interface is core (BSD-3)** — writing plugins against it is free. The **plugin/partner architecture** for commercial distribution (partner catalogs, white-label packaging) is an **Enterprise/Partner** capability. Independent open-source plugins remain yours under your own license.
+The **plugin interface is core (BSD-3)** — writing plugins against it is free. Third-party plugins are **declarative by default**: they describe patterns and rules, and the validator **rejects unsafe patterns** before they run. Plugins that **execute arbitrary code** are a different risk surface — that path is **Enterprise/Partner**, under agreement. The **plugin/partner architecture** for commercial distribution (partner catalogs, white-label packaging) is likewise an **Enterprise/Partner** capability. Independent open-source plugins remain yours under your own license.
 
 ## 9. Can I use Data Boar in academic work?
 

--- a/docs/LICENSE_FAQ.pt_BR.md
+++ b/docs/LICENSE_FAQ.pt_BR.md
@@ -17,6 +17,12 @@ Uma **estrutura dupla em um único repositório público e auditável** (o padr�
 
 Tudo no **core**, para qualquer propósito que a BSD 3-Clause permita — incluindo **uso interno em organização comercial** sem custo (veja [Termos de Uso §2](../TERMS_OF_USE.pt_BR.md)). Varrer sistemas que você está autorizado a varrer, montar relatórios para o seu próprio programa de conformidade, modificar e estender o código: tudo livre.
 
+Explicitamente incluído no "grátis":
+
+- **Self-host** — você roda na sua própria infraestrutura; sem dependência de serviço hospedado.
+- **Air-gapped** — o Data Boar funciona totalmente offline; nenhum phone-home é necessário para varrer.
+- **Sem telemetria obrigatória** — o scanner não exige enviar seus dados, métricas ou achados para lugar nenhum. Seu dado fica onde está.
+
 ## 3. O que exige assinatura paga?
 
 - **Entregar resultados de varredura a terceiros como serviço pago** (consultoria, auditoria, MSSP) — Pro ou superior (veja [Termos de Uso §4](../TERMS_OF_USE.pt_BR.md)).
@@ -26,6 +32,8 @@ Tudo no **core**, para qualquer propósito que a BSD 3-Clause permita — inclui
 ## 4. O core vai fechar algum dia?
 
 **Não — por definição.** O core open-source (scanner, detectores, interface de plugin, superfícies base, material de pesquisa) **nunca fecha**. O modelo comercial financia o projeto justamente para o core continuar aberto e auditável.
+
+O argumento-chave: **uma ferramenta que lê TODO o dado do cliente TEM que ser auditável**. Ninguém deve confiar numa **caixa-preta** de privacidade com acesso total de leitura aos seus repositórios mais sensíveis — código aberto é a única resposta honesta para "o que exatamente esse scanner faz com o meu dado?". O core aberto também é o **motor de adoção** do projeto: DPOs, pesquisadores e engenheiros conseguem avaliar, auditar e adotar sem fricção, e esse funil vale mais que qualquer fosso de código fechado.
 
 ## 5. Posso forkar o Data Boar?
 
@@ -45,13 +53,15 @@ Sim. O core BSD 3-Clause é forkável nos termos da licença. Duas fronteiras:
 
 Um ator determinado consegue alterar qualquer coisa localmente; o ponto é que **builds adulterados ficam evidentes**, sem suporte e comercialmente inutilizáveis em escala.
 
+Para quem compra, a leitura prática: **clientes que tratam dado sensível devem rodar o build OFICIAL assinado e suportado**. Confiança, verificação de integridade e suporte são parte do que a assinatura entrega — um build alterado ou não oficial abre mão exatamente das garantias que uma ferramenta de privacidade existe para dar.
+
 ## 7. Quais são as camadas?
 
 Community (grátis) → Pro → Pro+ → Enterprise, mais a família **Partner** customizada. **Tier = capacidade, claim = quantidade.** Escada completa, tabela de capacidades e claims de workers/deployments: [SUBSCRIPTION_TIERS.pt_BR.md](SUBSCRIPTION_TIERS.pt_BR.md).
 
 ## 8. Posso escrever e distribuir plugins?
 
-A **interface de plugin é core (BSD-3)** — escrever plugins contra ela é livre. A **arquitetura de plugin/partner** para distribuição comercial (catálogos de parceiros, empacotamento white-label) é capacidade **Enterprise/Partner**. Plugins open-source independentes continuam sendo seus, sob a licença que você escolher.
+A **interface de plugin é core (BSD-3)** — escrever plugins contra ela é livre. Plugins de terceiros são **declarativos por padrão**: eles descrevem padrões e regras, e o validador **rejeita patterns inseguros** antes de rodarem. Plugins que **executam código arbitrário** são outra superfície de risco — esse caminho é **Enterprise/Partner**, sob acordo. A **arquitetura de plugin/partner** para distribuição comercial (catálogos de parceiros, empacotamento white-label) também é capacidade **Enterprise/Partner**. Plugins open-source independentes continuam sendo seus, sob a licença que você escolher.
 
 ## 9. Posso usar o Data Boar em trabalho acadêmico?
 


### PR DESCRIPTION
Follow-up to #859 (merged) — folds in the four operator-draft points that were missing from `docs/LICENSE_FAQ.md` (+pt_BR):

- **§2 free use:** explicit **self-host**, **air-gapped** (fully offline), and **no mandatory telemetry**.
- **§4 core never closes:** key argument — a tool that reads ALL customer data MUST be auditable; a privacy black box cannot be trusted; open core = adoption engine.
- **§8 plugins:** third-party plugins are **declarative by default** (validator rejects unsafe patterns); code-executing plugins = Enterprise/Partner surface under agreement.
- **§6 fork/protection:** customers handling sensitive data should run the **official signed and supported build** — trust/integrity/support is part of what the subscription delivers.

`./scripts/check-all.sh`: 1433 passed, 7 skipped (green).

Made with [Cursor](https://cursor.com)