### PR TITLE
feat(licensing): connector tier map fail-closed — unknown type blocked, explicit open-core entries (#854)

### DIFF
--- a/core/connector_registry.py
+++ b/core/connector_registry.py
@@ -58,17 +58,29 @@ def _resolve_database_connector(
     return None
 
 
-# Connector tier boundary (#843, operator-ratified 2026-06-11):
+# Connector tier boundary (#843, operator-ratified 2026-06-11; #854 fail-closed):
 # - Open-core (Community): filesystem, self-hosted SQL/NoSQL (sqlite/postgres/
-#   mysql/mongo/redis), compressed files, generic REST. Filesystem and
-#   self-hosted DB engines are intentionally ABSENT from this map — never gated.
+#   mysql/mariadb/mongo/redis), compressed files, generic REST/API.
 # - Pro: managed corporate infrastructure (PowerBI, SharePoint, Dataverse,
 #   WebDAV, SMB/CIFS, NFS, MSSQL, Oracle) + cloud connectors.
-# The gate only bites in licensing.mode: enforced; Tier.OPEN stays free.
+# #854 anti-leak: this map is EXHAUSTIVE for registered connector types. A
+# type (or database driver) absent from this map has NO tier decision and is
+# FAIL-CLOSED by require_connector_allowed — blocked outside Tier.OPEN, never
+# silently community. Adding a connector forces an explicit tier choice here.
+# The gate only bites in licensing.mode: enforced (or lab tier simulation);
+# Tier.OPEN stays free.
 _CONNECTOR_TIER_FEATURES: dict[str, str] = {
     # Community baseline (explicit so the gate records an allow decision)
-    "api": "connector_rest",
+    "api": "connector_api",
     "rest": "connector_rest",
+    "filesystem": "connector_filesystem",
+    # Self-hosted SQL/NoSQL engines (open-core; resolved via type or driver)
+    "postgresql": "connector_postgresql",
+    "mysql": "connector_mysql",
+    "mariadb": "connector_mariadb",
+    "sqlite": "connector_sqlite",
+    "mongodb": "connector_mongodb",
+    "redis": "connector_redis",
     # Cloud connectors (Pro)
     "snowflake": "connector_snowflake",
     "s3": "connector_s3_object_storage",
@@ -90,10 +102,12 @@ _CONNECTOR_TIER_FEATURES: dict[str, str] = {
 
 
 def tier_feature_for_target(target: dict[str, Any]) -> str | None:
-    """Return the tier feature name for a target, or None when never gated.
+    """Return the tier feature name for a target, or None when UNKNOWN.
 
-    None means open-core by design (filesystem, self-hosted SQL/NoSQL) —
-    see the boundary comment on ``_CONNECTOR_TIER_FEATURES``.
+    Since #854 the map is exhaustive: every registered connector type has an
+    explicit entry. ``None`` no longer means "never gated" — it means the
+    connector type carries NO tier decision and the gate fails CLOSED on it
+    (outside ``Tier.OPEN``). See ``_CONNECTOR_TIER_FEATURES``.
     """
     t = (target.get("type") or "").strip().lower()
     if t in _CONNECTOR_TIER_FEATURES:
@@ -105,18 +119,54 @@ def tier_feature_for_target(target: dict[str, Any]) -> str | None:
 
 
 def require_connector_allowed(cfg: dict[str, Any], target: dict[str, Any]) -> None:
-    """Tier gate at connector instantiation (#843).
+    """Tier gate at connector instantiation (#843; #854 fail-closed).
 
     Raises :class:`core.licensing.errors.FeatureTierBlockedError` with an
     actionable message when the runtime tier denies this connector in
-    enforced mode. Free in ``Tier.OPEN`` (enforcement off) and for open-core
-    connectors (no map entry).
+    enforced mode. Free in ``Tier.OPEN`` (enforcement off).
+
+    **#854 anti-leak:** a connector type WITHOUT an explicit entry in
+    ``_CONNECTOR_TIER_FEATURES`` is blocked (CRITICAL audit record) instead
+    of silently defaulting to community — adding a connector forces an
+    explicit tier decision.
     """
     feature = tier_feature_for_target(target)
-    if not feature:
-        return
     from core.licensing.errors import FeatureTierBlockedError
     from core.licensing.feature_gate import require_feature
+
+    if not feature:
+        import logging
+
+        from core.licensing.audit import audit_enforcement_event
+        from core.licensing.guard import get_license_guard
+        from core.licensing.tier_features import Tier
+
+        guard = get_license_guard(cfg)
+        if guard.product_tier_for_features() == Tier.OPEN:
+            return  # enforcement off (dev / lab) — never gates
+        ttype = (target.get("type") or "?").strip().lower()
+        pseudo_feature = f"connector_{ttype}"
+        detail = (
+            f"connector '{ttype}' has no explicit FEATURE_TIER_MAP entry — "
+            "fail-closed (#854); add an explicit tier decision in "
+            "core/connector_registry.py before enabling it"
+        )
+        audit_enforcement_event(
+            "connector_unknown_blocked",
+            mode=guard.context.mode,
+            state=guard.context.state,
+            allowed=False,
+            feature=pseudo_feature,
+            tier=guard.product_tier_for_features().value,
+            detail=detail,
+            level=logging.CRITICAL,
+        )
+        raise FeatureTierBlockedError(
+            pseudo_feature,
+            detail,
+            required_tier="unmapped",
+            current_tier=guard.product_tier_for_features().value,
+        )
 
     try:
         require_feature(cfg, feature)

--- a/core/licensing/tier_features.py
+++ b/core/licensing/tier_features.py
@@ -63,6 +63,18 @@ FEATURE_TIER_MAP: dict[str, Tier] = {
     # Generic REST stays open-core (#843) — explicit entry so the registry
     # gate records an allow decision instead of falling through silently.
     "connector_rest": Tier.COMMUNITY,
+    # #854: explicit per-connector entries for EVERY registered connector.
+    # The registry gate now fails CLOSED on a connector type without an
+    # explicit tier decision — absence here means blocked (except Tier.OPEN),
+    # never silently community.
+    "connector_api": Tier.COMMUNITY,  # generic API/REST family (alias of rest)
+    "connector_filesystem": Tier.COMMUNITY,
+    "connector_mongodb": Tier.COMMUNITY,  # self-hosted NoSQL (open-core)
+    "connector_redis": Tier.COMMUNITY,  # self-hosted NoSQL (open-core)
+    "connector_postgresql": Tier.COMMUNITY,  # self-hosted SQL (open-core)
+    "connector_mysql": Tier.COMMUNITY,
+    "connector_mariadb": Tier.COMMUNITY,
+    "connector_sqlite": Tier.COMMUNITY,
     # Pro features (PDF report, advanced connectors, scheduling)
     "ocr_images": Tier.PRO,
     "report_pdf": Tier.PRO,  # see PLAN_PDF_GRC_REPORT.md

--- a/docs/plans/PLAN_CONNECTOR_TIER_GATING.md
+++ b/docs/plans/PLAN_CONNECTOR_TIER_GATING.md
@@ -44,9 +44,15 @@ stays free for dev and lab.
 | C | Per-connector gating tests (`tests/test_connector_tier_gating.py`): map entries, target resolution, community/pro/OPEN behaviour, enforced JWT end-to-end, engine failure row | ✅ Done |
 | D | Pricing/tier docs refresh (#610 `PRICING.md` does not exist yet — boundary documented in `tier_features.py` docstring and this plan until #610 lands) | ⬜ Pending |
 | E | Enterprise connector families (CMDB, findings-sink) gated when implemented | ⬜ Pending |
+| F | **#854 fail-closed:** exhaustive `_CONNECTOR_TIER_FEATURES` (explicit Community entries for api/filesystem/mongodb/redis/postgresql/mysql/mariadb/sqlite); unknown connector type or driver → `FeatureTierBlockedError` + CRITICAL `connector_unknown_blocked` audit (no default-community); free only in `Tier.OPEN` | ✅ Done |
 
 ## Notes
 
 - `powerapps` targets map to `connector_dataverse` (same connector family).
-- MSSQL/Oracle gate via `type: database` + `driver` prefix; postgres, mysql,
-  sqlite drivers are intentionally unmapped (open-core).
+- MSSQL/Oracle gate via `type: database` + `driver` prefix.
+- **#854:** the tier map is now **exhaustive** — every registered connector
+  type (and database driver) carries an explicit entry; absence means
+  **fail-closed** (blocked outside `Tier.OPEN`), so adding a connector forces
+  a tier decision and can never leak as silent community.
+- Open on #854: tier decision for `rich_media` / data-soup formats
+  (community vs Pro) — operator call, tracked on the issue.

--- a/tests/test_connector_tier_gating.py
+++ b/tests/test_connector_tier_gating.py
@@ -77,19 +77,42 @@ def test_feature_tier_map_entries(feature, tier):
         ({"type": "smb"}, "connector_smb"),
         ({"type": "cifs"}, "connector_cifs"),
         ({"type": "nfs"}, "connector_nfs"),
-        ({"type": "api"}, "connector_rest"),
+        ({"type": "api"}, "connector_api"),
         ({"type": "rest"}, "connector_rest"),
         ({"type": "database", "driver": "mssql+pyodbc"}, "connector_mssql"),
         ({"type": "database", "driver": "oracle+oracledb"}, "connector_oracle"),
-        # open-core by design — never gated
-        ({"type": "filesystem"}, None),
-        ({"type": "database", "driver": "postgresql+psycopg2"}, None),
-        ({"type": "database", "driver": "sqlite"}, None),
-        ({"type": "database", "driver": "mysql+pymysql"}, None),
+        # open-core — explicit Community entries since #854 (fail-closed map)
+        ({"type": "filesystem"}, "connector_filesystem"),
+        ({"type": "database", "driver": "postgresql+psycopg2"}, "connector_postgresql"),
+        ({"type": "database", "driver": "sqlite"}, "connector_sqlite"),
+        ({"type": "database", "driver": "mysql+pymysql"}, "connector_mysql"),
+        ({"type": "database", "driver": "mongodb"}, "connector_mongodb"),
+        ({"type": "redis"}, "connector_redis"),
+        # unknown — no tier decision: gate fails closed outside Tier.OPEN
+        ({"type": "carrier_pigeon"}, None),
+        ({"type": "database", "driver": "duckdb"}, None),
     ],
 )
 def test_tier_feature_for_target(target, expected):
     assert tier_feature_for_target(target) == expected
+
+
+@pytest.mark.parametrize(
+    ("feature", "tier"),
+    [
+        ("connector_api", Tier.COMMUNITY),
+        ("connector_filesystem", Tier.COMMUNITY),
+        ("connector_mongodb", Tier.COMMUNITY),
+        ("connector_redis", Tier.COMMUNITY),
+        ("connector_postgresql", Tier.COMMUNITY),
+        ("connector_mysql", Tier.COMMUNITY),
+        ("connector_mariadb", Tier.COMMUNITY),
+        ("connector_sqlite", Tier.COMMUNITY),
+    ],
+)
+def test_feature_tier_map_explicit_open_core_entries(feature, tier):
+    """#854: every registered connector has an explicit map entry."""
+    assert FEATURE_TIER_MAP.get(feature) == tier
 
 
 # --- gate behaviour (lab simulation: mode open + effective_tier) -----------
@@ -116,6 +139,33 @@ def test_community_allowed_on_rest_and_open_core():
     require_connector_allowed(
         _cfg("community"), {"type": "database", "driver": "postgresql+psycopg2"}
     )
+    require_connector_allowed(
+        _cfg("community"), {"type": "database", "driver": "mongodb"}
+    )
+    require_connector_allowed(_cfg("community"), {"type": "redis"})
+
+
+# --- #854: unknown connector type fails CLOSED ------------------------------
+
+
+def test_unknown_connector_blocked_at_community():
+    """#854 anti-leak: no FEATURE_TIER_MAP entry → blocked, not community."""
+    with pytest.raises(FeatureTierBlockedError) as exc_info:
+        require_connector_allowed(_cfg("community"), {"type": "carrier_pigeon"})
+    msg = str(exc_info.value)
+    assert "fail-closed" in msg
+    assert "carrier_pigeon" in msg
+
+
+def test_unknown_database_driver_blocked_at_pro():
+    """#854: unknown driver under type=database also fails closed."""
+    with pytest.raises(FeatureTierBlockedError):
+        require_connector_allowed(_cfg("pro"), {"type": "database", "driver": "duckdb"})
+
+
+def test_unknown_connector_free_in_open_tier():
+    """Tier.OPEN (enforcement off) never gates — including unknown types."""
+    require_connector_allowed(_cfg(None), {"type": "carrier_pigeon"})
 
 
 def test_pro_allowed_on_corporate_connectors():
@@ -171,6 +221,14 @@ def test_enforced_community_license_blocks_pro_connector(tmp_path):
 def test_enforced_pro_license_allows_pro_connector(tmp_path):
     cfg = _signed_license(tmp_path, "pro")
     require_connector_allowed(cfg, {"type": "sharepoint"})
+
+
+def test_enforced_unknown_connector_blocked_even_for_enterprise(tmp_path):
+    """#854: fail-closed has no tier escape — unmapped means blocked."""
+    cfg = _signed_license(tmp_path, "enterprise")
+    with pytest.raises(FeatureTierBlockedError) as exc_info:
+        require_connector_allowed(cfg, {"type": "carrier_pigeon"})
+    assert "fail-closed" in str(exc_info.value)
 
 
 # --- engine integration: blocked connector -> scan_failures row ------------


### PR DESCRIPTION
Anti-leak slice of #854 (`rich_media` / data-soup tier decision stays open on the issue — operator call):

- **`core/connector_registry.py`:** `_CONNECTOR_TIER_FEATURES` is now **exhaustive** — explicit Community entries for `api`, `filesystem`, `mongodb`, `redis`, `postgresql`, `mysql`, `mariadb`, `sqlite` (plus the existing rest/cloud/corporate rows). `require_connector_allowed` **fails CLOSED** on a connector type or database driver without an explicit entry: `FeatureTierBlockedError` (`required_tier=unmapped`) + **CRITICAL `connector_unknown_blocked` audit event** — no more silent default-community. Free only in `Tier.OPEN` (enforcement off, dev/lab).
- **`core/licensing/tier_features.py`:** explicit `connector_*` Community entries for every registered open-core connector — adding a connector now forces a tier decision.
- **`tests/test_connector_tier_gating.py`:** updated target-resolution expectations (open-core now resolves to explicit features); new regressions — unknown type blocked at community/pro simulation, unknown driver blocked, unknown blocked even with a signed **enterprise** license (fail-closed has no tier escape), unknown free in `Tier.OPEN`, mongodb/redis allowed at community.
- **`docs/plans/PLAN_CONNECTOR_TIER_GATING.md`:** Phase F (done) + notes; `plans_hub_sync --check` green.

`./scripts/check-all.sh`: 1449 passed, 7 skipped (green).

Made with [Cursor](https://cursor.com)