### PR TITLE
chore(test): warm pwsh once per session + ParseFile timeout 60s (#860)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ private notes.
 from __future__ import annotations
 
 import os
+import subprocess
 
 import pytest
 
@@ -34,3 +35,26 @@ def include_private_lint(request: pytest.FixtureRequest) -> bool:
     if env in ("1", "true", "yes"):
         return True
     return bool(request.config.getoption("--include-private"))
+
+
+@pytest.fixture(scope="session")
+def warm_pwsh() -> None:
+    """#860: absorb the pwsh cold-start cost ONCE before ParseFile loops.
+
+    The first pwsh invocation after boot can take >30s under load (assembly /
+    JIT cache cold on Linux), which made the per-file 30s ParseFile timeout
+    flake in ``test_maestro_scripts.py``. Warming the shell once per session
+    (generous 120s budget) makes subsequent per-file parses fast (~0.2s).
+    Missing shells are fine — parse tests skip/fall through on their own.
+    """
+    for pw in ("pwsh", "powershell"):
+        try:
+            subprocess.run(
+                [pw, "-NoProfile", "-NonInteractive", "-Command", "exit 0"],
+                capture_output=True,
+                timeout=120,
+                check=False,
+            )
+            return
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            continue

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -20,8 +20,12 @@ def _maestro_ps1_paths(root: Path) -> list[Path]:
     return sorted(base.rglob("*.ps1"))
 
 
-def test_all_maestro_powershell_scripts_parse() -> None:
-    """Every tracked .ps1 under scripts/maestro/ parses under pwsh/PowerShell Parser."""
+def test_all_maestro_powershell_scripts_parse(warm_pwsh) -> None:
+    """Every tracked .ps1 under scripts/maestro/ parses under pwsh/PowerShell Parser.
+
+    ``warm_pwsh`` (#860): session-scoped warm-up absorbs the pwsh cold-start
+    once, so the per-file ParseFile timeout never flakes after a fresh boot.
+    """
     root = _project_root()
     failures: list[str] = []
     for script in _maestro_ps1_paths(root):
@@ -219,7 +223,7 @@ def test_handle_microk8s_fallback_tmux_sends_expanded_payload() -> None:
     )
 
 
-def test_maestro_deep_rc_monitor_collect_wrapper_parse() -> None:
+def test_maestro_deep_rc_monitor_collect_wrapper_parse(warm_pwsh) -> None:
     """Token-aware lab wrapper (Deep + monitor + Collect) parses under pwsh."""
     root = _project_root()
     script = root / "scripts" / "maestro-deep-rc-monitor-collect.ps1"
@@ -610,7 +614,7 @@ def test_smoke_handlers_write_sentinel_file() -> None:
         )
 
 
-def test_wait_handler_sentinel_exists_and_parses() -> None:
+def test_wait_handler_sentinel_exists_and_parses(warm_pwsh) -> None:
     """Anti-regression #831: Wait-HandlerSentinel.ps1 must exist and parse cleanly."""
     root = _project_root()
     sentinel_script = root / "scripts" / "maestro" / "Wait-HandlerSentinel.ps1"

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -56,7 +56,7 @@ def test_prep_audit_sh_has_shebang_and_exit_code():
 # --- PowerShell: commit-or-pr.ps1 syntax (Parser::ParseFile) ---
 
 
-def test_commit_or_pr_ps1_syntax():
+def test_commit_or_pr_ps1_syntax(warm_pwsh):
     """scripts/commit-or-pr.ps1 has valid PowerShell syntax (parse-only, no execution)."""
     root = _project_root()
     script = root / "scripts" / "commit-or-pr.ps1"
@@ -69,9 +69,10 @@ def test_commit_or_pr_ps1_syntax():
         "$null = [System.Management.Automation.Language.Parser]::ParseFile($path, [ref]$null, [ref]$errors); "
         "exit ([int]($errors -and $errors.Count -gt 0))"
     )
-    # CI runners occasionally cold-start pwsh slowly; try both shells and allow
-    # a bit more time than a typical local parse.
-    timeout_s = 30
+    # #860: the FIRST pwsh start after boot can exceed 30s under load (JIT /
+    # assembly cache cold on Linux). The session-scoped ``warm_pwsh`` fixture
+    # absorbs that once; 60s here is belt-and-suspenders for slow CI runners.
+    timeout_s = 60
     errors: list[str] = []
     for pw in ("pwsh", "powershell"):
         try:
@@ -130,7 +131,9 @@ def _parse_powershell_script(script_path: Path, root: Path) -> bool:
                 cwd=str(root),
                 capture_output=True,
                 text=True,
-                timeout=30,
+                # #860: 60s absorbs pwsh cold-start on slow runners; callers in
+                # parse loops should also request the ``warm_pwsh`` fixture.
+                timeout=60,
             )
         except FileNotFoundError:
             continue


### PR DESCRIPTION
Persists the #860 flake fix in code (previously only a runtime warm-up):

- **`tests/conftest.py`:** new session-scoped `warm_pwsh` fixture — runs `pwsh -NoProfile -NonInteractive -Command exit 0` (falls back to `powershell`) with a generous 120s budget, absorbing the post-boot cold-start (assembly/JIT cache) exactly once per session.
- **`tests/test_scripts.py`:** `_parse_powershell_script` and the inline `commit-or-pr` parse loop timeout raised **30s → 60s** with a comment explaining the cold-start rationale; `test_commit_or_pr_ps1_syntax` requests `warm_pwsh`.
- **`tests/test_maestro_scripts.py`:** the per-file parse loop (`test_all_maestro_powershell_scripts_parse` — the test that flaked from cold boot) plus the two standalone parse tests request `warm_pwsh`.

Closes #860.

`./scripts/check-all.sh`: 1433 passed, 7 skipped (green).

Made with [Cursor](https://cursor.com)