### PR TITLE
ci(zizmor): fix ref-version-mismatch repo-wide (#878)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     # 3.14 is signal-only (#551) — see header comment. 3.12/3.13 stay blocking.
     continue-on-error: ${{ matrix.python-version == '3.14' }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Full history required for scripts/pii_history_guard.py --full-history (PII in old commits).
           fetch-depth: 0
@@ -58,7 +58,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libmariadb-dev pkg-config
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -83,7 +83,7 @@ jobs:
     name: Lint (pre-commit)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -92,7 +92,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libmariadb-dev pkg-config
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -110,7 +110,7 @@ jobs:
     name: Bandit (strict)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
@@ -118,7 +118,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libmariadb-dev pkg-config
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -138,7 +138,7 @@ jobs:
     name: Dependency audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
@@ -146,7 +146,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libmariadb-dev pkg-config
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -175,7 +175,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -196,7 +196,7 @@ jobs:
 
       - name: Set up Python
         if: steps.sonar_token.outputs.present == 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -212,7 +212,7 @@ jobs:
 
       - name: SonarQube / SonarCloud Scan
         if: steps.sonar_token.outputs.present == 'true'
-        uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v7
+        uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           # SonarQube Server only: set SONAR_HOST_URL in repo secrets

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -34,7 +34,7 @@ jobs:
       - name: Run Claude Code
         id: claude
         #        uses: anthropics/claude-code-action@v1
-        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102  # v1
+        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102  # v1.0.148
         with:
           #          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/dependabot-sync.yml
+++ b/.github/workflows/dependabot-sync.yml
@@ -27,7 +27,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -33,13 +33,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Gitleaks
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           # GITLEAKS_LICENSE only needed for org features; OSS works without.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -48,7 +48,7 @@ jobs:
       # PyO3 needs a Python interpreter visible at link time; setup-python
       # exports PYO3_PYTHON-compatible env via PATH so cargo builds find it.
       - name: Set up Python (for PyO3 link)
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -43,13 +43,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -19,7 +19,7 @@ jobs:
     container:
       image: semgrep/semgrep:1.117.0@sha256:a256468ff217498bfde2f44bd74dd2ffd0460bd08fabbbec009dbdeb4870f4dc
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## Resumo

Corrige a regra **`ref-version-mismatch`** do Zizmor (vermelha em `main`, `ENFORCE_ZIZMOR=true`). Apenas o **comentário de versão** ao lado de actions pinadas por SHA muda para a tag patch exata que o SHA resolve. **Nenhum SHA alterado.**

| action | de | para |
|---|---|---|
| `actions/checkout` | `# v6` | `# v6.0.2` |
| `actions/setup-python` | `# v6` | `# v6.2.0` |
| `gitleaks/gitleaks-action` | `# v2` | `# v2.3.9` |
| `anthropics/claude-code-action` | `# v1` | `# v1.0.148` |
| `SonarSource/sonarqube-scan-action` | `# v7` | `# v8.1.0` |

Arquivos: `ci.yml`, `gitleaks.yml`, `sbom.yml`, `semgrep.yml`, `dependabot-sync.yml`, `claude.yml`, `rust-ci.yml`.

## Decisões do operador

- **SonarSource** (`7006c449…`): o comentário dizia `# v7` mas o SHA resolve para **v8.1.0** (descasamento de major). Decisão: **v8 é a intenção** → corrigir comentário para `# v8.1.0` (sem mudar runtime; alinha com `astral-sh/setup-uv # v8.1.0` já no repo). Nenhum re-pin.
- **`rust-ci.yml` L51** (`setup-python # v6`): **fora do mapa da #878**, mas o Zizmor escaneia todo `.github/workflows/**`. Incluído (`# v6.2.0`, mesmo SHA) com aprovação do operador para `ref-version-mismatch` chegar a 0.

## Verificação (AC #878)

- [x] Zizmor local: `ref-version-mismatch = 0`.
- [x] Nenhum SHA alterado (só comentários).
- [x] `tests/test_github_workflows.py` (19) + `check-all.sh` (1452 passed) verdes.
- [x] Decisão do SonarSource registrada acima.

Closes #878

Made with [Cursor](https://cursor.com)