### PR TITLE
ci(zizmor): disable online-audits for deterministic runs (#880)

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -46,6 +46,13 @@ jobs:
         id: zizmor
         continue-on-error: true
         uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          # Deterministic runs: skip network-dependent audits (e.g.
+          # ref-version-mismatch, known-vulnerable-actions) that flap on
+          # GITHUB_TOKEN rate-limits. Offline audits (template-injection,
+          # excessive-permissions, artipacked, unpinned-uses, ...) still run.
+          # SHA pins + exact version comments (#878) keep the offline posture.
+          online-audits: false
 
       - name: Warn in advisory mode
         if: ${{ steps.zizmor.outcome == 'failure' && env.ENFORCE_ZIZMOR != 'true' }}


### PR DESCRIPTION
## Resumo

O Zizmor flapeia vermelho no `main` de forma não-determinística por causa dos **online-audits** (default do `zizmor-action@v0.5.6`), que resolvem tags via API do GitHub com o `GITHUB_TOKEN` default e falham sob rate-limit (`ref-version-mismatch` espúrio), mesmo com tudo pinado por SHA + comentários exatos (#878).

**Fix:** `online-audits: false` no step *Run zizmor*. Nenhum SHA/comentário alterado.

## Confirmação do input

Nome exato verificado no `action.yml` do `zizmorcore/zizmor-action` no SHA pinado `5f14fd08…`: input é `online-audits` (default `"true"`). ✔

## Trade-off (honesto)

Caem só os audits de rede:
- `ref-version-mismatch` — perda baixa (SHA pin + comentário exato via #878).
- `known-vulnerable-actions`/freshness — mitigado pelo Dependabot ativo.

**Audits offline seguem rodando** (template-injection, excessive-permissions, artipacked, unpinned-uses, dangerous-triggers, cache-poisoning, ...). Postura de segurança forte; só sai o flaky de rede.

## Verificação (AC #880)

- [x] `online-audits: false` no step Run zizmor.
- [x] `zizmor --no-online-audits` local: audits offline ativos, zero findings.
- [x] `tests/test_github_workflows.py` (19) + `lint-only` verdes.
- [x] Nenhuma mudança em SHAs/comentários de actions.
- [ ] Zizmor verde no PR (CI) → confirmar.
- [ ] Pós-merge: rodar Zizmor no `main` 2× para confirmar que não flapeia.

Closes #880

Made with [Cursor](https://cursor.com)