### PR TITLE
ci(zizmor): grant security-events: write for SARIF upload on push (#880 follow-up)

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,6 +5,12 @@ name: Zizmor
 
 permissions:
   contents: read
+  # zizmor-action's advanced-security upload (github/codeql-action/upload-sarif)
+  # posts a SARIF to the Security tab even with zero findings. On push to a
+  # branch that needs security-events: write (pull_request runs are allowed
+  # without it). Mirrors codeql.yml so the enforced push run is deterministic.
+  security-events: write
+  actions: read
 
 'on':
   pull_request:


### PR DESCRIPTION
## Resumo

Follow-up do #880. O run **enforced** do Zizmor falhava no **push para `main`** com `Resource not accessible by integration` — e isso **não** era findings nem online-audits.

**Causa real (comprovada nos logs):** o step `advanced-security: true` sobe um SARIF via `github/codeql-action/upload-sarif` **mesmo com zero findings** (para zerar a aba Security), o que exige `security-events: write`. Runs de `pull_request` são permitidos sem essa permissão (por isso o check do PR passava), mas `push` para branch não — então o `main` seguia vermelho **mesmo após o #881** (`online-audits: false`).

## Mudança

Espelha as permissions do `codeql.yml`:

```yaml
permissions:
  contents: read
  security-events: write
  actions: read
```

Escopo mínimo necessário; mantém os achados do Zizmor na aba Security.

## Evidência (ground truth)

No commit `dd97325e` havia 2 check-runs Zizmor: `workflow_dispatch`=success (advisory, Enforce pulado) e `push`=**failure** (enforced). O combined status do commit = PENDING. O run de push enforced é o que vale para o gate (#406).

## Verificação

- [x] `tests/test_github_workflows.py` (19) + `lint-only` verdes.
- [x] Nenhuma mudança em SHAs/comentários de actions.
- [ ] Zizmor verde no PR (CI).
- [ ] Pós-merge: push enforced no `main` verde (o que realmente fechava o #880).

Refs #880

Made with [Cursor](https://cursor.com)