### PR TITLE
fix(rust): build-rust-prefilter.ps1 uv-first + cross-platform (#890)

### DIFF
--- a/rust/boar_fast_filter/README.md
+++ b/rust/boar_fast_filter/README.md
@@ -10,11 +10,10 @@ Current suspects include:
 
 ## Build (dev)
 
-From repository root:
+From repository root (`maturin` ships as a dev dependency, so `uv run` finds it in the `.venv` — no separate `pip install`):
 
-```powershell
-uv run pip install maturin
-maturin develop --manifest-path rust/boar_fast_filter/Cargo.toml --release
+```bash
+uv run maturin develop --manifest-path rust/boar_fast_filter/Cargo.toml --release
 ```
 
 This makes `boar_fast_filter` importable in the active Python environment.

--- a/scripts/build-rust-prefilter.ps1
+++ b/scripts/build-rust-prefilter.ps1
@@ -7,7 +7,9 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
-$manifestPath = Join-Path $repoRoot "rust\boar_fast_filter\Cargo.toml"
+# Nested Join-Path keeps the separator portable across Windows PowerShell 5.1 and
+# PowerShell Core on Linux/musl (the multi-segment Join-Path form needs PS 6+).
+$manifestPath = Join-Path (Join-Path (Join-Path $repoRoot "rust") "boar_fast_filter") "Cargo.toml"
 
 if (-not (Test-Path -LiteralPath $manifestPath)) {
     throw "Rust manifest not found: $manifestPath"
@@ -15,20 +17,18 @@ if (-not (Test-Path -LiteralPath $manifestPath)) {
 
 Push-Location $repoRoot
 try {
-    & uv run pip install maturin
-    if ($LASTEXITCODE -ne 0) {
-        throw "Failed to install maturin"
-    }
-
-    $args = @("develop", "--manifest-path", $manifestPath)
+    # maturin is a dev dependency (pyproject [dependency-groups].dev, #892), so it is
+    # already in the uv-managed .venv. Run it via `uv run maturin` (uv-first) rather
+    # than installing it with pip, which would pollute the env outside the lockfile.
+    $maturinArgs = @("develop", "--manifest-path", $manifestPath)
     if ($Release) {
-        $args += "--release"
+        $maturinArgs += "--release"
     }
     if ($Target) {
-        $args += @("--target", $Target)
+        $maturinArgs += @("--target", $Target)
     }
 
-    & maturin @args
+    & uv run maturin @maturinArgs
     if ($LASTEXITCODE -ne 0) {
         throw "maturin develop failed"
     }

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1146,3 +1146,32 @@ def test_powershell_scripts_ascii_safe():
         "PowerShell scripts contain non-ASCII characters that break PS 5.1:\n"
         + "\n".join(violations)
     )
+
+
+def test_build_rust_prefilter_is_uv_first_and_cross_platform():
+    """#890 guard: build-rust-prefilter.ps1 must be uv-first and path-portable.
+
+    Regressions this catches:
+    - `pip install maturin` (not uv-first; maturin is a dev-dep since #892).
+    - bare `maturin` invocation instead of `uv run maturin`.
+    - a hardcoded backslash separator in the manifest path (breaks PowerShell Core
+      on Linux/musl, where the build must also run).
+    """
+    root = _project_root()
+    script = root / "scripts" / "build-rust-prefilter.ps1"
+    if not script.exists():
+        return
+    text = script.read_text(encoding="utf-8")
+
+    assert "pip install maturin" not in text, (
+        "build-rust-prefilter.ps1 must not pip-install maturin; use `uv run maturin` "
+        "(maturin is a dev dependency)."
+    )
+    assert "uv run maturin" in text, (
+        "build-rust-prefilter.ps1 must invoke maturin via `uv run maturin` (uv-first)."
+    )
+    # No backslash path literal for the Rust manifest (cross-platform Join-Path only).
+    assert "rust\\boar_fast_filter" not in text, (
+        "build-rust-prefilter.ps1 must not hardcode a backslash manifest path; "
+        "use nested Join-Path so PowerShell Core on Linux/musl resolves it too."
+    )


### PR DESCRIPTION
## Resumo

`scripts/build-rust-prefilter.ps1` não era uv-first nem portável (achado do smoke S1):
- `uv run pip install maturin` poluía o ambiente fora do lockfile;
- chamada `maturin` bare dependia de instalação global;
- o path do manifesto usava backslash literal → PowerShell Core no Linux/musl não resolvia.

## Correção

- Remove o passo pip. `maturin` é dev-dep (#892) → `uv run maturin develop ...` (uv-first, resolve do `.venv`).
- Path via `Join-Path` aninhado (portável no PS 5.1 e PS Core no Linux/musl; a forma multi-segmento exige PS 6+).
- Renomeia `$args` → `$maturinArgs` (evita sombrear a variável automática `$args` do PowerShell).
- `rust/boar_fast_filter/README.md`: comando de build uv-first.
- `tests/test_scripts.py`: guard offline (`test_build_rust_prefilter_is_uv_first_and_cross_platform`) que falha se o pip, a chamada bare, ou o path com backslash voltarem.

## AC (#890)

- [x] remover pip; maturin via uv
- [x] path cross-platform
- [ ] build verde no T14 + 1 host musl — **validação de lab do operador** (a mudança deixa o script correto para ambos os alvos)

## Teste

- `check-all.sh` verde: 1460 passed.

Closes #890

Made with [Cursor](https://cursor.com)