### PR TITLE
fix(maestro): actionable Sync-ContainerArtefact fallback + regression guards (#888)

### DIFF
--- a/scripts/maestro/Sync-ContainerArtefact.ps1
+++ b/scripts/maestro/Sync-ContainerArtefact.ps1
@@ -18,10 +18,19 @@ if ($versionMatch -match '^version\s*=\s*"([^"]+)"') { $tag = $matches[1] }
 $tarFile = "data-boar-${tag}.tar"
 $tarPath = "$PSScriptRoot/../../$tarFile"
 
+# Actionable guard: the scp fallback only works if Build-ContainerArtefact produced
+# (or kept) the local tar. Without it, scp would fail with an opaque "No such file"
+# error per node. Fail loud but non-fatally (Write-Error keeps the multi-node loop
+# alive) so the operator knows the engine path and the artefact path both missed.
+if (-not (Test-Path -LiteralPath $tarPath)) {
+    Write-Error "      [ERROR] Artefato local ausente ($tarFile). Build-ContainerArtefact nao gerou o tar (engine indisponivel e sem cache). Sem fallback scp para $($Node.hostname)."
+    return
+}
+
 Write-Host "      [Container Sync] Distribuindo $tarFile para $($Node.hostname)..." -ForegroundColor DarkCyan
 scp -q -o BatchMode=yes -o ConnectTimeout=10 $tarPath "$($Node.user)@$($Node.hostname):$($Node.path)/$tarFile"
 if ($LASTEXITCODE -ne 0) {
-    Write-Warning "      [WARNING] Falha ao enviar $tarFile para $($Node.hostname) (scp exit $LASTEXITCODE)."
+    Write-Error "      [ERROR] Falha ao enviar $tarFile para $($Node.hostname) (scp exit $LASTEXITCODE). Verifique SSH/rede/espaco em disco no alvo."
     return
 }
 

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -630,3 +630,53 @@ def test_wait_handler_sentinel_exists_and_parses(warm_pwsh) -> None:
     assert "_sentinel.txt" in text, (
         "Wait-HandlerSentinel.ps1 must poll for *_sentinel.txt files written by handlers (#831)"
     )
+
+
+def test_build_container_artefact_degrades_without_hub() -> None:
+    """#888: Build-ContainerArtefact must detect podman/docker, build+save a local
+    tar (never assume Docker Hub), and emit an actionable error when no engine and
+    no cached artefact are available.
+    """
+    root = _project_root()
+    text = (root / "scripts" / "maestro" / "Build-ContainerArtefact.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "podman" in text and "docker" in text, (
+        "Build-ContainerArtefact must detect both podman and docker engines (#888)."
+    )
+    assert re.search(r"\$engineCmd\s+save|save\s+\$fullImage", text), (
+        "Build-ContainerArtefact must `save` the image to a local tar (offline/-rc, "
+        "no Docker Hub) (#888)."
+    )
+    # Never pull/push from a registry as the primary path (build is from the working tree).
+    assert "docker pull" not in text and "podman pull" not in text, (
+        "Build-ContainerArtefact must not assume a registry/Hub pull (#888)."
+    )
+    assert "exit 9" in text, (
+        "Build-ContainerArtefact must exit with an actionable code when no engine and "
+        "no local artefact exist (#888)."
+    )
+
+
+def test_sync_container_artefact_scp_fallback_is_actionable() -> None:
+    """#888: Sync-ContainerArtefact must scp the local tar and `load` it remotely,
+    and surface failures (missing artefact / scp failure) as actionable errors
+    instead of silently swallowing them.
+    """
+    root = _project_root()
+    text = (root / "scripts" / "maestro" / "Sync-ContainerArtefact.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "scp " in text, (
+        "Sync-ContainerArtefact must scp the artefact to the node (#888)."
+    )
+    assert re.search(r"(podman|docker)\s+load|load -i", text), (
+        "Sync-ContainerArtefact must `load` the tar on the remote engine (#888)."
+    )
+    assert "Test-Path -LiteralPath $tarPath" in text, (
+        "Sync-ContainerArtefact must guard against a missing local artefact before scp (#888)."
+    )
+    # The scp failure path must be an error (actionable), not a swallowed warning.
+    assert re.search(r"scp exit \$LASTEXITCODE", text) and "Write-Error" in text, (
+        "Sync-ContainerArtefact must report scp failure as an actionable error (#888)."
+    )


### PR DESCRIPTION
## Resumo

O `Build-ContainerArtefact` **já** degrada corretamente (detecta podman/docker via `Test-ContainerEngineReady`, builda do working tree e faz `save` do tar local **sem** depender do Docker Hub, e sai com `exit 9` quando não há engine nem cache). O `Sync-ContainerArtefact` **já** faz o fallback **scp + `load`** remoto. O issue foi aberto no smoke S1 contra uma versão anterior; o refactor já entrou depois.

Esta PR **endurece e trava** esse caminho de degradação:

- `Sync-ContainerArtefact.ps1`: precheck do tar local antes do scp (o fallback só funciona se o artefato existe) e reporta falha de scp via `Write-Error` em vez de `Write-Warning` engolido. Ambos seguem **não-fatais** (`Write-Error` + `return`) para o loop multi-host continuar, mas as falhas ficam **acionáveis** e visíveis no error stream.
- `tests/test_maestro_scripts.py`: guards offline do contrato #888 — detecção podman+docker, `save` local (sem pull de registry), erro acionável `exit 9`, fallback scp + load, e os novos caminhos de erro (artefato ausente / falha de scp).

## AC (#888)

- [x] detectar podman vs docker — `Test-ContainerEngineReady`
- [x] build + `save` tar local quando Hub indisponível/-rc — build do working tree, nunca Hub
- [x] fallback scp do artefato — `Sync-ContainerArtefact` (scp + `load`)
- [x] erro acionável se nenhum caminho serve — `exit 9` (build) + `Write-Error` no sync (artefato ausente / scp falhou)

## Teste

- `check-all.sh` verde: 1462 passed.

Closes #888

Made with [Cursor](https://cursor.com)