### PR TITLE
fix(maestro): reconcile Handle-web exit code after recovery (#889)

### DIFF
--- a/scripts/maestro/handlers/Handle-web.ps1
+++ b/scripts/maestro/handlers/Handle-web.ps1
@@ -171,8 +171,10 @@ $remoteStartCmd = $remoteStartCmd.Replace("__BENCH_PORT_FILE__", [string]$benchP
 $remoteStartCmd = $remoteStartCmd -replace "`r", ""
 $startOut = ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$targetUser@$targetHost" "$remoteStartCmd"
 if ($LASTEXITCODE -ne 0 -or -not $startOut) {
-    Write-Warning "      [ERROR] Fallback web start falhou em $targetHost."
-    return
+    # Real failure: the recovery start itself did not run. Exit non-zero so Maestro
+    # counts a realFail (#889) instead of treating the swallowed warning as success.
+    Write-Error "      [REAL FAIL] Fallback web start falhou em $targetHost."
+    exit 7
 }
 
 $chosenPort = $webPort
@@ -184,7 +186,10 @@ foreach ($line in $startOut) {
 
 $remoteCurlCmd = "curl -fsS --max-time 5 http://127.0.0.1:$chosenPort$webHealthPath >/dev/null"
 ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$targetUser@$targetHost" "$remoteCurlCmd" > $null 2>&1
-if ($LASTEXITCODE -ne 0) {
+# Ground-truth signal of the recovered process: did the service answer on the chosen
+# port from the host's own loopback? Kept to reconcile against the external HTTP probe.
+$remoteCurlOk = ($LASTEXITCODE -eq 0)
+if (-not $remoteCurlOk) {
     Write-Warning "      [WARNING] Fallback web iniciou, mas curl remoto localhost falhou em ${targetHost}:$chosenPort$webHealthPath."
 }
 
@@ -192,6 +197,14 @@ $webScheme = "http"
 $apiUrl = "http://${targetIp}:${chosenPort}${webHealthPath}"
 for ($attempt = 1; $attempt -le $retries; $attempt++) {
     if (Test-HealthUrl -Url $apiUrl -Scheme $webScheme -SkipTls $false) {
+        # Reconciliation (#889): an external HTTP 200 is not enough. If the recovered
+        # process never answered on the host's own loopback (remoteCurlOk = false), the
+        # 200 is from a stale process / proxy / wrong port -- a realFail masked by 200.
+        # Reconcile the exit code with the ground truth and fail loud (exit 7).
+        if (-not $remoteCurlOk) {
+            Write-Error "      [REAL FAIL] HTTP 200 em $apiUrl, mas o curl remoto localhost falhou no processo recuperado: estado inconsistente pos-recovery em $($Node.hostname). Tratando como falha real."
+            exit 7
+        }
         Write-Host "      [SUCCESS] Persona Web recuperada! $($Node.hostname) responde HTTP 200 em $apiUrl." -ForegroundColor Green
         return
     }
@@ -200,4 +213,7 @@ for ($attempt = 1; $attempt -le $retries; $attempt++) {
     }
 }
 
-Write-Warning "      [ERROR] Health Check Web falhou em $($Node.hostname) após fallback, incluindo start forçado. URL final: $apiUrl."
+# Real failure after the forced recovery: surface a non-zero exit so Maestro records a
+# realFail (#889) rather than letting the script fall off the end with exit 0.
+Write-Error "      [REAL FAIL] Health Check Web falhou em $($Node.hostname) após fallback, incluindo start forçado. URL final: $apiUrl."
+exit 7

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -680,3 +680,38 @@ def test_sync_container_artefact_scp_fallback_is_actionable() -> None:
     assert re.search(r"scp exit \$LASTEXITCODE", text) and "Write-Error" in text, (
         "Sync-ContainerArtefact must report scp failure as an actionable error (#888)."
     )
+
+
+def test_handle_web_reconciles_exit_code_after_recovery() -> None:
+    """#889: Handle-web must reconcile the exit code with the real process health.
+
+    Scenario "HTTP 200 but realFail": after recovery, an external 200 must NOT be
+    reported as success when the recovered process never answered on the host's own
+    loopback. The handler must exit non-zero (exit 7) so Maestro counts a realFail,
+    and the final post-fallback failure path must also exit non-zero (no silent
+    fall-through to exit 0).
+    """
+    root = _project_root()
+    text = (root / "scripts" / "maestro" / "handlers" / "Handle-web.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    # Ground-truth signal is captured (remote loopback curl result).
+    assert "$remoteCurlOk" in text, (
+        "Handle-web must capture the remote loopback curl result to reconcile against "
+        "the external HTTP probe (#889)."
+    )
+    # 200-but-realFail reconciliation: inside the success branch, a failed remote curl
+    # forces exit 7 instead of returning success.
+    assert re.search(r"if \(-not \$remoteCurlOk\)\s*\{[^}]*exit 7", text, re.DOTALL), (
+        "Handle-web must exit 7 when HTTP 200 contradicts the remote loopback check (#889)."
+    )
+    # Real failures (fallback start failed; final health check failed) must exit 7,
+    # not fall through to exit 0.
+    assert text.count("exit 7") >= 3, (
+        "Handle-web must propagate realFail via exit 7 on start failure, the 200-but-"
+        "realFail reconciliation, and the final post-fallback failure (#889)."
+    )
+    # The final failure line must be an error + exit, not a swallowed warning.
+    assert re.search(r"Health Check Web falhou[\s\S]{0,200}exit 7", text), (
+        "Handle-web final failure after fallback must surface a non-zero exit (#889)."
+    )


### PR DESCRIPTION
## Resumo

Após o recovery web, o `Handle-web` reportava sucesso no primeiro HTTP 200 externo e usava `return`/`Write-Warning` em falhas reais → o script caía para `exit 0`. O Maestro conta `realFail` por `$LASTEXITCODE`, então uma persona web realmente quebrada era **mascarada como sucesso** ("HTTP 200 mas realFail").

## Correção (reconciliação)

- Captura o resultado do curl remoto no loopback (`$remoteCurlOk`) em vez de só avisar.
- No loop pós-recovery, um 200 externo que **contradiz** o curl remoto falho (processo stale / proxy / porta errada) vira **falha real → `exit 7`**.
- A falha no start do fallback e a falha final pós-fallback agora fazem `exit 7` em vez de `return`/cair para `exit 0`.
- `tests/test_maestro_scripts.py`: guard estático (`test_handle_web_reconciles_exit_code_after_recovery`) do cenário 200-mas-falhou, do sinal de ground-truth capturado e dos caminhos `exit 7`.

## AC (#889)

- [x] reconciliar exit-code real com o 200 pós-recovery
- [x] propagar a falha (não engolir) — `exit 7` consistente com os outros handlers
- [x] teste do cenário 200-mas-falhou

## Teste

- `check-all.sh` verde: 1463 passed.

Closes #889

Made with [Cursor](https://cursor.com)