### PR TITLE
docs(ops): today-mode 2026-06-16 — safe Dependabot drain (A->C->B)

### DIFF
--- a/docs/ops/today-mode/OPERATOR_TODAY_MODE_2026-06-16.md
+++ b/docs/ops/today-mode/OPERATOR_TODAY_MODE_2026-06-16.md
@@ -1,0 +1,77 @@
+# Operator today-mode — 2026-06-16 (safe Dependabot queue drain, no regressions)
+
+**pt-BR:** [OPERATOR_TODAY_MODE_2026-06-16.pt_BR.md](OPERATOR_TODAY_MODE_2026-06-16.pt_BR.md)
+
+**Note:** Drafted to drain the **Dependabot PR backlog safely**. The product gate work (#891/#890/#888/#889, deps #896/#899, claims #894, rust dev-dep #892) is merged. Seven Dependabot PRs remain in the queue; three of them (Python) were opened **before** the recent dependency merges, so their base is stale — blind-merging would conflict or downgrade. The safe ritual is **apply locally + validate + close the bot PR as "applied locally"**, per `.cursor/skills/dependabot-recommendations/SKILL.md`.
+
+**`main` anchor:** `f870f156` — **#903** (handle-web exit reconcile) merged. Open Dependabot PRs: **#867 #868 #869** (actions), **#870 #871 #348** (Python minor/patch + build), **#872** (redis major). Remaining alert: one low-severity `torch` (no upstream fix).
+
+---
+
+## Block 0 — Morning reality (10–15 min)
+
+1. **`origin/main`:** `git fetch` · `git status -sb` · confirm `ci.yml` green on `main` before deep work.
+2. **Open PRs:** `gh pr list --state open` — all 7 are Dependabot.
+3. **Private stack:** if `docs/private/` changed overnight, `./scripts/private-git-sync.ps1 -Push` (or the `.sh` path on Linux).
+
+**Continuous queue:** [CARRYOVER.md](CARRYOVER.md)
+
+---
+
+## Safe drain ritual (no-regression contract)
+
+For every batch:
+
+1. **Apply locally** (do not merge the bot branch) — edit YAML / `pyproject.toml`, then `uv lock` (or `uv lock --upgrade-package <name>`), then refresh `requirements.txt` with `uv export --frozen --no-emit-project -o requirements.txt` (the `--no-emit-project` form locked in by #891).
+2. **Validate:** `./scripts/check-all.sh` (Ruff + format + markdown + full pytest). For deps specifically, also reproduce the CI audit: `uv sync --extra shares && uv pip install pip-audit && uv run pip-audit` (matches the `Dependency audit` gate).
+3. **Regression guard** only when it protects a contract (security floor, behavior). Skip for trivial patches.
+4. **One PR per batch**, signed commit, no rebase/force. After merge, **close the matching bot PR** with a "applied locally in #<PR>" comment; let the branch be deleted.
+
+---
+
+## Risk classification (the 7 PRs)
+
+| PR | Change | Type | Risk | Batch |
+| -- | ------ | ---- | ---- | ----- |
+| **#867** | `actions/checkout` 6.0.2→6.0.3 (10 workflows) | action patch | Low | **A** |
+| **#869** | `astral-sh/setup-uv` 8.1.0→8.2.0 (3 workflows) | action minor | Low | **A** |
+| **#868** | `gitleaks/gitleaks-action` 2.3.9→**3.0.0** | action major (Node 20→24, *no input/output/behavior change*) | Low, **time-boxed** | **A** |
+| **#348** | `hatchling` >=1.24.0→>=1.29.0 | build backend | Low | **B** |
+| **#870** | `uv-minor-patch` group (20 pkgs) | Python minor/patch | Medium (**stale base**) | **B** |
+| **#871** | `rpds-py` 0.30.0→2026.5.1 (CalVer) | transitive (via referencing/jsonschema) | **High — breaking** | **B (pin `<2026`)** |
+| **#872** | `redis` 7.4.0→**8.0.0** | direct-optional major (`nosql` extra; breaking only in type hints, RESP3 default) | Medium | **C** |
+
+**Stale-base note:** `main` already has `pypdf 6.13.2`, `starlette 1.3.1`, `python-multipart 0.0.32` (from #896/#899). The #870 group still targets older versions of those — apply via `uv lock --upgrade` so the resolver keeps the higher floors; do **not** downgrade.
+
+**#868 urgency:** GitHub flips runners to Node 24 on **2026-06-02** (already past) and removes Node 20 on **2026-09-16**. v3 is a pure runtime bump — safe and needed.
+
+**#871 rpds-py is breaking (verified):** `2026.5.1` is a **legitimate** release (real CalVer pivot on PyPI, not a typosquat), **but it breaks `check-all`** — the bot PR's own CI is red on Lint + Test 3.12/3.13/3.14 (4 reds). `rpds-py` is purely transitive (via `referencing`/`jsonschema`); nothing here needs the pivot. **Fix:** add a constraint `rpds-py<2026` in Batch B so the resolver keeps the working `0.x`. Do not let `uv lock --upgrade` pull `2026.5.1`.
+
+**#872 redis:** used by `connectors/redis_connector.py` (lazy import, `redis>=5.0` already permits 8.0). The 8.0 breaking changes are type-hint-only; runtime unchanged. Still isolate it and run the connector tier/timeout tests.
+
+---
+
+## Suggested order
+
+| Step | Batch | PRs | Validation |
+| ---- | ----- | --- | ---------- |
+| 1 | **A — Actions** | #867, #869, #868 | `quick-test.sh --path tests/test_github_workflows.py` + `workflow-security-lint` (zizmor). #868 has a Sep/2026 deadline — do not sit on it. |
+| 2 | **C — redis major** | #872 | `check-all.sh` + connector tier/timeout tests; isolated |
+| 3 | **B — Python minor/patch + build** | #870, #348 | `check-all.sh` + reproduce `pip-audit` gate. **Pin `rpds-py<2026`** (close #871 as "won't take pivot — breaking") |
+
+Order A → C → B is deliberate: A is low-risk and time-boxed; C is isolated and testable; B last because it needs the `rpds-py<2026` constraint to stay green. Each step = one signed PR; close matching bot PR(s) after merge.
+
+---
+
+## End of day (2026-06-16)
+
+- `eod-sync` + `private-stack-sync` if the private stack or social hub changed.
+- Tomorrow's checklist path: `OPERATOR_TODAY_MODE_2026-06-17.md` (create at next `eod-sync` if missing).
+
+---
+
+## Quick references
+
+- Dependabot ritual: `.cursor/skills/dependabot-recommendations/SKILL.md`
+- Session keywords: `.cursor/rules/session-mode-keywords.mdc` (`today-mode`, `eod-sync`, `deps`)
+- Workflow SHA-pin guard: `tests/test_github_workflows.py`; zizmor: `scripts/workflow-security-lint.sh`

--- a/docs/ops/today-mode/OPERATOR_TODAY_MODE_2026-06-16.pt_BR.md
+++ b/docs/ops/today-mode/OPERATOR_TODAY_MODE_2026-06-16.pt_BR.md
@@ -1,0 +1,77 @@
+# Modo de hoje do operador — 2026-06-16 (drenar fila do Dependabot com segurança, sem regressões)
+
+**English:** [OPERATOR_TODAY_MODE_2026-06-16.md](OPERATOR_TODAY_MODE_2026-06-16.md)
+
+**Nota:** Rascunhado para **drenar a fila de PRs do Dependabot com segurança**. O trabalho do gate de produto (#891/#890/#888/#889, deps #896/#899, claims #894, dev-dep rust #892) está mergeado. Sobram sete PRs do Dependabot na fila; três deles (Python) foram abertos **antes** dos merges recentes de dependências, então a base está desatualizada — fazer merge cego causaria conflito ou downgrade. O ritual seguro é **aplicar localmente + validar + fechar o PR do bot como "applied locally"**, conforme `.cursor/skills/dependabot-recommendations/SKILL.md`.
+
+**Âncora da `main`:** `f870f156` — **#903** (handle-web exit reconcile) mergeado. PRs abertos do Dependabot: **#867 #868 #869** (actions), **#870 #871 #348** (Python minor/patch + build), **#872** (redis major). Alerta restante: um `torch` de baixa severidade (sem correção upstream).
+
+---
+
+## Bloco 0 — Realidade da manhã (10–15 min)
+
+1. **`origin/main`:** `git fetch` · `git status -sb` · confirme `ci.yml` verde na `main` antes de trabalho profundo.
+2. **PRs abertos:** `gh pr list --state open` — os 7 são do Dependabot.
+3. **Stack privado:** se `docs/private/` mudou durante a noite, `./scripts/private-git-sync.ps1 -Push` (ou o caminho `.sh` no Linux).
+
+**Fila contínua:** [CARRYOVER.pt_BR.md](CARRYOVER.pt_BR.md)
+
+---
+
+## Ritual de drenagem segura (contrato sem regressão)
+
+Para cada lote:
+
+1. **Aplicar localmente** (não mergear a branch do bot) — editar YAML / `pyproject.toml`, depois `uv lock` (ou `uv lock --upgrade-package <nome>`), depois atualizar `requirements.txt` com `uv export --frozen --no-emit-project -o requirements.txt` (forma `--no-emit-project` fixada no #891).
+2. **Validar:** `./scripts/check-all.sh` (Ruff + format + markdown + pytest completo). Para deps, reproduza também o audit do CI: `uv sync --extra shares && uv pip install pip-audit && uv run pip-audit` (espelha o gate `Dependency audit`).
+3. **Guard de regressão** só quando protege um contrato (piso de segurança, comportamento). Pular para patch trivial.
+4. **Um PR por lote**, commit assinado, sem rebase/force. Depois do merge, **feche o PR do bot** com comentário "applied locally in #<PR>"; deixe a branch ser apagada.
+
+---
+
+## Classificação de risco (os 7 PRs)
+
+| PR | Mudança | Tipo | Risco | Lote |
+| -- | ------- | ---- | ----- | ---- |
+| **#867** | `actions/checkout` 6.0.2→6.0.3 (10 workflows) | patch de action | Baixo | **A** |
+| **#869** | `astral-sh/setup-uv` 8.1.0→8.2.0 (3 workflows) | minor de action | Baixo | **A** |
+| **#868** | `gitleaks/gitleaks-action` 2.3.9→**3.0.0** | major de action (Node 20→24, *sem mudança de input/output/comportamento*) | Baixo, **com prazo** | **A** |
+| **#348** | `hatchling` >=1.24.0→>=1.29.0 | build backend | Baixo | **B** |
+| **#870** | grupo `uv-minor-patch` (20 pacotes) | minor/patch Python | Médio (**base velha**) | **B** |
+| **#871** | `rpds-py` 0.30.0→2026.5.1 (CalVer) | transitivo (via referencing/jsonschema) | **Alto — breaking** | **B (pinar `<2026`)** |
+| **#872** | `redis` 7.4.0→**8.0.0** | major direto-opcional (extra `nosql`; breaking só em type hints, RESP3 default) | Médio | **C** |
+
+**Nota da base velha:** a `main` já tem `pypdf 6.13.2`, `starlette 1.3.1`, `python-multipart 0.0.32` (dos #896/#899). O grupo #870 ainda mira versões mais antigas desses — aplique via `uv lock --upgrade` para o resolver manter os pisos mais altos; **não** faça downgrade.
+
+**Urgência do #868:** o GitHub vira os runners para Node 24 em **2026-06-02** (já passou) e remove o Node 20 em **2026-09-16**. O v3 é puro bump de runtime — seguro e necessário.
+
+**#871 rpds-py é breaking (verificado):** o `2026.5.1` é um release **legítimo** (pivô CalVer real no PyPI, não typosquat), **mas quebra o `check-all`** — o próprio CI do PR do bot está vermelho em Lint + Test 3.12/3.13/3.14 (4 reds). `rpds-py` é puramente transitivo (via `referencing`/`jsonschema`); nada aqui precisa do pivô. **Fix:** adicionar a restrição `rpds-py<2026` no Lote B para o resolver manter o `0.x` que funciona. Não deixe o `uv lock --upgrade` puxar o `2026.5.1`.
+
+**redis (#872):** usado por `connectors/redis_connector.py` (import lazy, `redis>=5.0` já permite 8.0). Os breaking do 8.0 são só de type hints; runtime inalterado. Mesmo assim, isole e rode os testes de tier/timeout do connector.
+
+---
+
+## Ordem sugerida
+
+| Passo | Lote | PRs | Validação |
+| ----- | ---- | --- | --------- |
+| 1 | **A — Actions** | #867, #869, #868 | `quick-test.sh --path tests/test_github_workflows.py` + `workflow-security-lint` (zizmor). #868 tem prazo Set/2026 — não sentar nele. |
+| 2 | **C — redis major** | #872 | `check-all.sh` + testes de tier/timeout do connector; isolado |
+| 3 | **B — Python minor/patch + build** | #870, #348 | `check-all.sh` + reproduzir o gate `pip-audit`. **Pinar `rpds-py<2026`** (fechar #871 como "não aceita o pivô — breaking") |
+
+A ordem A → C → B é deliberada: A é baixo risco e tem prazo; C é isolado e testável; B por último porque precisa da restrição `rpds-py<2026` para ficar verde. Cada passo = um PR assinado; feche o(s) PR(s) do bot após o merge.
+
+---
+
+## Fim do dia (2026-06-16)
+
+- `eod-sync` + `private-stack-sync` se o stack privado ou o hub social mudarem.
+- Caminho do checklist de amanhã: `OPERATOR_TODAY_MODE_2026-06-17.md` (criar no próximo `eod-sync` se faltar).
+
+---
+
+## Referências rápidas
+
+- Ritual Dependabot: `.cursor/skills/dependabot-recommendations/SKILL.md`
+- Palavras-chave de sessão: `.cursor/rules/session-mode-keywords.mdc` (`today-mode`, `eod-sync`, `deps`)
+- Guard de SHA-pin de workflow: `tests/test_github_workflows.py`; zizmor: `scripts/workflow-security-lint.sh`


### PR DESCRIPTION
## Today-mode 2026-06-16

Registra o ritual de drenagem segura dos 7 PRs do Dependabot (aplicar local → validar → fechar PR do bot), com classificação de risco e ordem **A → C → B**.

- **A (actions)** — já mergeado em #904 (#867/#868/#869 fechados).
- **C (redis 8.0)** — isolado, próximo.
- **B (Python minor/patch + build)** — por último; **pina `rpds-py<2026`** porque o `2026.5.1` é CalVer legítimo porém breaking (CI do #871 vermelho em 4 jobs) e é puramente transitivo.

EN canônico + espelho pt-BR.

Made with [Cursor](https://cursor.com)