### PR TITLE
deps(uv): bump redis 7.4.0 -> 8.0.0 (Lote C Dependabot)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ data-boar = "main:main"
 data-boar-report = "cli.reporter:main"
 
 [project.optional-dependencies]
-nosql = ["pymongo>=4.0", "redis>=5.0"]
+nosql = ["pymongo>=4.0", "redis>=8.0.0"]
 bigdata = ["snowflake-connector-python>=4.6.0"]
 shares = ["smbprotocol>=1.2.0", "webdavclient3>=0.14.0", "requests_ntlm>=1.2.0"]
 # Scan inside .7z archives (ZIP/tar/tar.gz etc. use stdlib). See docs/plans/PLAN_COMPRESSED_FILES.md.

--- a/uv.lock
+++ b/uv.lock
@@ -960,7 +960,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.31" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "rapidfuzz", marker = "extra == 'detection-fuzzy'", specifier = ">=3.9.0" },
-    { name = "redis", marker = "extra == 'nosql'", specifier = ">=5.0" },
+    { name = "redis", marker = "extra == 'nosql'", specifier = ">=8.0.0" },
     { name = "regex", specifier = ">=2026.5.9" },
     { name = "reportlab", specifier = ">=4.5.1" },
     { name = "requests", specifier = ">=2.34.2" },
@@ -3555,11 +3555,11 @@ sdist = { url = "https://files.pythonhosted.org/packages/48/75/bfa342a2ebfc9623b
 
 [[package]]
 name = "redis"
-version = "7.4.0"
+version = "8.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/ae/ed461cca5780b5fc8b9fe8ca0ed98d89508645fb9d880c24cc42c087678f/redis-8.0.0.tar.gz", hash = "sha256:a00c5355432051ac14e593b8b197fc76c887ee12d55a0984f69328a1115fdc49", size = 5101591, upload-time = "2026-05-28T12:45:13.5Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e3/b519734372d305bd547534a9f32e4ce9f98552af753dce72cf3483a0ff0b/redis-8.0.0-py3-none-any.whl", hash = "sha256:c938c18338585009f0bc310f4c7e4e4b4d37639356c4ac072cedf3af570c8dc7", size = 499870, upload-time = "2026-05-28T12:45:11.697Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Lote C — redis 8.0 (isolado)

Aplica o Dependabot #872 localmente: redis-py **7.4 -> 8.0** (major). Sobe o floor opcional `nosql` de `redis>=5.0` para `redis>=8.0.0` (versao testada).

### Por que e seguro
`connectors/redis_connector.py` usa so APIs de runtime estaveis (`redis.Redis`, `scan_iter`, `info`, `close`) com `decode_responses=True`. Os breaking do redis-py 8.0 sao **so de type hints**; o RESP3-por-padrao mantem os response shapes legados. **Runtime inalterado.** `redis` e extra opcional -> `requirements.txt` (export default) nao muda.

### Validacao
`./scripts/check-all.sh` verde — **1463 passed, 4 skipped**, incluindo os guards de tier/timeout/inventory do connector.

Closes #872