### PR TITLE
test(deps): guards for rpds-py<2026 cap + plotly 6 dashboard path

### DIFF
--- a/tests/test_grc_dashboard_plotly_smoke.py
+++ b/tests/test_grc_dashboard_plotly_smoke.py
@@ -1,0 +1,95 @@
+"""Plotly-side smoke for the GRC dashboard chart (``grc-dashboard`` extra).
+
+``app/dashboard.py`` imports ``plotly.express`` and ``streamlit`` at module top
+and builds a ``px.bar`` figure from ``findings_chart_rows``. The default test run
+(and ``check-all``) does NOT install the optional ``grc-dashboard`` extra, so
+these tests ``importorskip`` plotly/streamlit and only execute where the extra is
+present (e.g. ``uv run --extra grc-dashboard pytest``).
+
+Why this exists: the extra was bumped to ``plotly>=6.8.0`` (a major from the 5.x
+line). Plotly 6 routes dataframe input through ``narwhals`` and targets pandas 3.
+This module reproduces the exact chart-building path the dashboard uses so the
+plotly-6 + pandas-3 contract is guarded instead of silently untested.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[1]
+_EXAMPLE = _REPO / "schemas" / "grc_executive_report.v1.example.json"
+
+
+def _build_dashboard_figure():
+    """Replicate app/dashboard.py's chart build under the installed plotly."""
+    import pandas as pd
+    import plotly.express as px
+
+    from app.grc_dashboard_model import findings_chart_rows, load_grc_json
+
+    rows = findings_chart_rows(load_grc_json(_EXAMPLE))
+    df = pd.DataFrame(rows)
+    color_map = {
+        "CRITICAL": "#c0392b",
+        "HIGH": "#e67e22",
+        "MEDIUM": "#2980b9",
+        "LOW": "#7f8c8d",
+    }
+    fig = px.bar(
+        df,
+        x="asset_id",
+        y="risk_score",
+        color="remediation_priority",
+        title="Risk score by asset (remediation priority)",
+        labels={
+            "asset_id": "Asset",
+            "risk_score": "Risk score (0-100)",
+            "remediation_priority": "Priority",
+        },
+        color_discrete_map=color_map,
+    )
+    fig.update_layout(xaxis_tickangle=-35, height=420)
+    return rows, fig
+
+
+def test_plotly_major_is_6_or_newer() -> None:
+    """The grc-dashboard extra is pinned to plotly>=6.8.0; guard the major line."""
+    plotly = pytest.importorskip("plotly")
+    major = int(plotly.__version__.split(".", 1)[0])
+    assert major >= 6, (
+        f"grc-dashboard extra expects plotly>=6 (got {plotly.__version__}). "
+        "pyproject declares 'plotly>=6.8.0'."
+    )
+
+
+def test_dashboard_chart_builds_and_serializes() -> None:
+    """px.bar + update_layout must build and serialize (Streamlit/plotly.js path)."""
+    pytest.importorskip("plotly")
+    pytest.importorskip("pandas")
+
+    rows, fig = _build_dashboard_figure()
+    assert len(rows) >= 1, "example GRC report should yield at least one finding row"
+    # px.bar with a color dimension yields one trace per priority bucket present.
+    assert len(fig.data) >= 1
+    assert fig.layout.height == 420
+    assert fig.layout.xaxis.tickangle == -35
+    # to_json is what Streamlit hands to plotly.js; it must not raise under plotly 6.
+    payload = fig.to_json()
+    assert isinstance(payload, str) and len(payload) > 0
+
+
+def test_dashboard_module_imports_under_plotly_6() -> None:
+    """Importing app.dashboard exercises the plotly + streamlit import chain.
+
+    set_page_config lives inside main(), so importing the module does not start a
+    Streamlit runtime; it only validates the top-level imports resolve.
+    """
+    pytest.importorskip("plotly")
+    pytest.importorskip("streamlit")
+
+    import importlib
+
+    module = importlib.import_module("app.dashboard")
+    assert hasattr(module, "main")

--- a/tests/test_upstream_capped_dependencies.py
+++ b/tests/test_upstream_capped_dependencies.py
@@ -6,6 +6,10 @@ operator-agreed contract is still present.
 
 - ADR 0053: ``ebcdic`` cap (``extract-msg`` chain).
 - ADR 0054: ``chardet`` cap (``cyclonedx-bom`` / SBOM chain).
+- ``rpds-py`` cap (``referencing`` / ``jsonschema`` chain): upstream pivoted to
+  CalVer at ``2026.5.1``, which is breaking for our suite (Dependabot #871 turned
+  CI red on 3.12/3.13/3.14). We cap ``rpds-py<2026`` via ``[tool.uv]``
+  ``constraint-dependencies`` until the CalVer series is explicitly validated.
 
 When an upstream package relaxes its transitive cap, remove the matching
 assertions in the same PR that drops the pin, the ``ignore`` rule, and updates
@@ -20,10 +24,28 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 DEPENDABOT_YML = REPO_ROOT / ".github" / "dependabot.yml"
+UV_LOCK = REPO_ROOT / "uv.lock"
 
 
 def _pyproject_text() -> str:
     return PYPROJECT.read_text(encoding="utf-8")
+
+
+def _locked_version(package: str) -> str | None:
+    """Return the version string locked for ``package`` in ``uv.lock`` (or None).
+
+    Parses the ``[[package]]`` TOML blocks without a TOML lib: matches the
+    ``name = "<package>"`` line and grabs the ``version = "..."`` in the same
+    block. Avoids depending on resolver behaviour or network access.
+    """
+    text = UV_LOCK.read_text(encoding="utf-8")
+    block_re = re.compile(
+        r'\[\[package\]\]\s*\nname = "' + re.escape(package) + r'"\s*\n'
+        r'version = "([^"]+)"',
+        re.MULTILINE,
+    )
+    m = block_re.search(text)
+    return m.group(1) if m else None
 
 
 def _dependabot_text() -> str:
@@ -81,4 +103,33 @@ def test_chardet_dependabot_ignore_present() -> None:
     assert has_chardet, (
         ".github/dependabot.yml must keep the ignore entry for 'chardet'. "
         "See docs/adr/ADR-0054-chardet-pinned-by-cyclonedx-bom.md."
+    )
+
+
+def test_rpds_py_cap_present_in_pyproject() -> None:
+    """``rpds-py`` must stay ``<2026`` via ``[tool.uv]`` constraint-dependencies.
+
+    rpds-py is transitive (referencing -> jsonschema). Upstream's CalVer pivot
+    (``2026.5.1``) is breaking for our suite. The cap keeps the working 0.x line.
+    """
+    text = _pyproject_text()
+    # Match e.g. constraint-dependencies = ["rpds-py<2026"] (whitespace-tolerant).
+    pattern = re.compile(r'"rpds-py\s*<\s*2026"')
+    assert pattern.search(text) is not None, (
+        "pyproject.toml [tool.uv] must declare a constraint 'rpds-py<2026'. "
+        "rpds-py pivoted to CalVer at 2026.5.1, which is breaking for the suite "
+        "(Dependabot #871). If you intend to adopt the CalVer series, validate "
+        "the full test matrix and update this test in the same PR."
+    )
+
+
+def test_rpds_py_locked_below_2026() -> None:
+    """The resolved ``rpds-py`` in ``uv.lock`` must remain on the pre-CalVer line."""
+    version = _locked_version("rpds-py")
+    assert version is not None, "rpds-py is expected in uv.lock (transitive dep)."
+    major = int(version.split(".", 1)[0])
+    assert major < 2026, (
+        f"uv.lock has rpds-py=={version}; expected the pre-CalVer line (major < 2026). "
+        "The 2026.x CalVer series is breaking for the suite (Dependabot #871). "
+        "Re-run 'uv lock' with the [tool.uv] 'rpds-py<2026' constraint in place."
     )


### PR DESCRIPTION
## Follow-ups do Lote B (#907) — endurecendo os 2 pontos de risco

### 1) Guarda do cap `rpds-py<2026` (`tests/test_upstream_capped_dependencies.py`)
- `test_rpds_py_cap_present_in_pyproject`: asserta `[tool.uv] constraint-dependencies` com `"rpds-py<2026"`.
- `test_rpds_py_locked_below_2026`: parseia o `uv.lock` e asserta `rpds-py` major < 2026 (linha 0.x pre-CalVer).

Impede remocao acidental do cap que reintroduziria o breaking `2026.5.1` (#871) e deixaria o CI vermelho em 3.12/3.13/3.14. Espelha o padrao dos caps `ebcdic` (ADR 0053) e `chardet` (ADR 0054).

### 2) Smoke do `plotly 6` no dashboard (`tests/test_grc_dashboard_plotly_smoke.py`)
- Reproduz o `px.bar` + `update_layout` do `app/dashboard.py` a partir do exemplo GRC, asserta traces/layout e que o `to_json` serializa (caminho Streamlit/plotly.js); importa `app.dashboard`.
- `importorskip`: faz **skip** quando a extra `grc-dashboard` esta ausente (check-all/CI default) e **roda** onde ela esta instalada.

**Prova viva** (com a extra): plotly **6.8.0** + pandas **3.0.3** + narwhals **2.20.0** constroem e serializam o grafico do dashboard sem erro.

### Validacao
`./scripts/check-all.sh` verde — **1469 passed, 3 skipped**; o modulo plotly tambem passa em `uv run --extra grc-dashboard pytest`.