### PR TITLE
feat(licensing): issuer accepts encrypted signing key passphrase (#910)

### DIFF
--- a/docs/ops/QA_LOCAL_LICENSE.md
+++ b/docs/ops/QA_LOCAL_LICENSE.md
@@ -16,6 +16,26 @@ enforced mode is a real signed license. QA licenses are deliberately:
 Keep the Ed25519 **private** key outside Git (e.g. `~/.keys/data-boar/`).
 See `docs/private.example/licensing/README.md` for key generation.
 
+### Optional: encrypted signing key (passphrase)
+
+The signing key may be stored as an AES-encrypted PKCS#8 PEM. The issuer
+(`scripts/issue_dev_license_jwt.py`) resolves the passphrase in this order:
+
+1. **Env var** `DATA_BOAR_LICENSE_ISSUER_PRIVATE_KEY_PASSWORD` — the
+   non-interactive path for automation. Maestro (`Handle-LicensingMatrix.ps1`)
+   runs head-less, so export it **before** running the handler:
+
+   ```bash
+   export DATA_BOAR_LICENSE_ISSUER_PRIVATE_KEY_PASSWORD='your-passphrase'
+   ```
+
+2. **Interactive prompt** — in a TTY with no env var set, the issuer asks
+   `License signing key passphrase:` and reads it without echo.
+3. **Unencrypted key** — no passphrase needed (backward-compatible).
+
+An encrypted key with neither the env var nor a TTY exits with an actionable
+message (never a raw traceback).
+
 ## 2. Issue a license for THIS machine
 
 ```bash

--- a/docs/ops/QA_LOCAL_LICENSE.pt_BR.md
+++ b/docs/ops/QA_LOCAL_LICENSE.pt_BR.md
@@ -18,6 +18,26 @@ deliberadamente:
 Mantenha a chave **privada** Ed25519 fora do Git (ex.: `~/.keys/data-boar/`).
 Veja `docs/private.example/licensing/README.md` para gerar as chaves.
 
+### Opcional: chave de assinatura cifrada (passphrase)
+
+A chave de assinatura pode ficar como um PEM PKCS#8 cifrado com AES. O emissor
+(`scripts/issue_dev_license_jwt.py`) resolve a passphrase nesta ordem:
+
+1. **Variável de ambiente** `DATA_BOAR_LICENSE_ISSUER_PRIVATE_KEY_PASSWORD` — o
+   caminho não interativo para automação. O Maestro (`Handle-LicensingMatrix.ps1`)
+   roda sem terminal, então exporte-a **antes** de executar o handler:
+
+   ```bash
+   export DATA_BOAR_LICENSE_ISSUER_PRIVATE_KEY_PASSWORD='sua-passphrase'
+   ```
+
+2. **Prompt interativo** — em um TTY sem a variável definida, o emissor pergunta
+   `License signing key passphrase:` e lê sem exibir o que é digitado.
+3. **Chave sem cifra** — não precisa de passphrase (compatível com o fluxo atual).
+
+Uma chave cifrada sem a variável de ambiente e sem TTY encerra com uma mensagem
+acionável (nunca um traceback cru).
+
 ## 2. Emitir licença para ESTA máquina
 
 ```bash

--- a/scripts/issue_dev_license_jwt.py
+++ b/scripts/issue_dev_license_jwt.py
@@ -19,6 +19,7 @@ import argparse
 import os
 import sys
 from datetime import datetime, timedelta, timezone
+from getpass import getpass
 from pathlib import Path
 
 import jwt
@@ -52,6 +53,35 @@ def _load_private_key_pem() -> str:
         file=sys.stderr,
     )
     sys.exit(1)
+
+
+def _resolve_key_password(pem: str) -> bytes | None:
+    """Resolve the signing-key passphrase for ``load_pem_private_key`` (#910).
+
+    Backward-compatible: an unencrypted PEM still loads with ``password=None``.
+    For an AES-encrypted PKCS#8 PEM the passphrase is resolved in this order:
+
+    1. ``DATA_BOAR_LICENSE_ISSUER_PRIVATE_KEY_PASSWORD`` env var (non-interactive
+       path — Maestro / automation set this before calling the issuer).
+    2. Interactive ``getpass`` prompt when stdin is a TTY (operator issuing a
+       real license at the keyboard).
+    3. Encrypted key with neither env var nor a TTY: exit with an actionable
+       message instead of a raw ``TypeError`` traceback from cryptography.
+    """
+    pw = os.environ.get("DATA_BOAR_LICENSE_ISSUER_PRIVATE_KEY_PASSWORD", "").strip()
+    if pw:
+        return pw.encode("utf-8")
+    if "ENCRYPTED" in pem:
+        if sys.stdin.isatty():
+            entered = getpass("License signing key passphrase: ").strip()
+            if entered:
+                return entered.encode("utf-8")
+        sys.exit(
+            "Signing key is encrypted: set "
+            "DATA_BOAR_LICENSE_ISSUER_PRIVATE_KEY_PASSWORD or run in a TTY to "
+            "enter the passphrase."
+        )
+    return None
 
 
 def _resolve_dbmfp(raw: str) -> str:
@@ -155,7 +185,7 @@ def main() -> None:
     else:
         pem = _load_private_key_pem()
 
-    key = load_pem_private_key(pem.encode("utf-8"), password=None)
+    key = load_pem_private_key(pem.encode("utf-8"), password=_resolve_key_password(pem))
     now = datetime.now(timezone.utc)
     payload = {
         "sub": args.sub,

--- a/scripts/maestro/Handle-LicensingMatrix.ps1
+++ b/scripts/maestro/Handle-LicensingMatrix.ps1
@@ -314,6 +314,13 @@ $tierLicenses = @{
     enterprise = Join-Path $keysDir "dev-enterprise.lic"
 }
 
+# Encrypted signing key (#910): when license-signing-v1-pkcs8.pem is AES-encrypted,
+# the issuer reads its passphrase from DATA_BOAR_LICENSE_ISSUER_PRIVATE_KEY_PASSWORD.
+# Maestro runs head-less (no TTY), so the operator MUST export that env var before
+# running this handler; the child `& uv run` inherits the current process environment.
+# Without it (encrypted key + no TTY) the issuer exits with an actionable message and
+# the per-tier guard below reports the failure. An unencrypted key needs no passphrase.
+
 # QA licenses: 60-day expiry + bound to this machine's fingerprint (#719 —
 # env bypass removed; signed short-lived machine-bound .lic is the only path).
 foreach ($tier in @("community", "pro", "enterprise")) {

--- a/tests/test_issue_dev_license_qa.py
+++ b/tests/test_issue_dev_license_qa.py
@@ -46,6 +46,23 @@ def keypair(tmp_path):
     return priv_path, pub_pem.decode("ascii"), priv.public_key()
 
 
+@pytest.fixture
+def encrypted_keypair(tmp_path):
+    """Ed25519 private key in an AES-encrypted PKCS#8 PEM (#910)."""
+    passphrase = "qa-test-passphrase"  # noqa: S105 - test-only, not a real secret
+    priv = Ed25519PrivateKey.generate()
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.BestAvailableEncryption(
+            passphrase.encode("utf-8")
+        ),
+    )
+    priv_path = tmp_path / "priv-enc.pem"
+    priv_path.write_bytes(priv_pem)
+    return priv_path, priv.public_key(), passphrase
+
+
 @pytest.fixture(autouse=True)
 def _clean_guard():
     reset_license_guard_for_tests()
@@ -54,16 +71,26 @@ def _clean_guard():
     os.environ.pop("DATA_BOAR_LICENSE_PUBLIC_KEY_PEM", None)
 
 
-def _run_issuer(*argv: str) -> str:
-    proc = subprocess.run(
+def _run_issuer(*argv: str, env: dict | None = None) -> str:
+    proc = _run_issuer_proc(*argv, env=env)
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout.strip()
+
+
+def _run_issuer_proc(
+    *argv: str, env: dict | None = None
+) -> subprocess.CompletedProcess[str]:
+    # stdin=DEVNULL makes sys.stdin.isatty() deterministically False in the child,
+    # so the encrypted-key-without-env path exits instead of blocking on getpass.
+    return subprocess.run(
         [sys.executable, str(ISSUER), *argv],
         capture_output=True,
         text=True,
         cwd=str(REPO_ROOT),
         timeout=60,
+        env=env,
+        stdin=subprocess.DEVNULL,
     )
-    assert proc.returncode == 0, proc.stderr
-    return proc.stdout.strip()
 
 
 def test_issuer_defaults_60d_enterprise_machine_bound(keypair):
@@ -125,3 +152,34 @@ def test_maestro_handler_issues_60d_machine_bound():
     )
     assert "--days 60" in src
     assert "--dbmfp auto" in src
+
+
+PASSWORD_ENV = "DATA_BOAR_LICENSE_ISSUER_PRIVATE_KEY_PASSWORD"
+
+
+def test_issuer_encrypted_key_with_password_env(encrypted_keypair):
+    """Encrypted signing key + password env issues OK (Maestro/automation path, #910)."""
+    priv_path, pub_key, passphrase = encrypted_keypair
+    env = {**os.environ, PASSWORD_ENV: passphrase}
+    token = _run_issuer("--private-key-pem-file", str(priv_path), env=env)
+    claims = jwt.decode(token, pub_key, algorithms=["EdDSA"])
+    assert claims["dbtier"] == "enterprise"
+
+
+def test_issuer_clean_key_without_password_env(keypair):
+    """Backward-compat (#910): unencrypted key + no password env still issues."""
+    priv_path, _pub_pem, pub_key = keypair
+    env = {k: v for k, v in os.environ.items() if k != PASSWORD_ENV}
+    token = _run_issuer("--private-key-pem-file", str(priv_path), env=env)
+    claims = jwt.decode(token, pub_key, algorithms=["EdDSA"])
+    assert claims["dbtier"] == "enterprise"
+
+
+def test_issuer_encrypted_key_without_env_or_tty_exits_actionably(encrypted_keypair):
+    """Encrypted key + no env + no TTY exits with an actionable message, not a traceback (#910)."""
+    priv_path, _pub_key, _passphrase = encrypted_keypair
+    env = {k: v for k, v in os.environ.items() if k != PASSWORD_ENV}
+    proc = _run_issuer_proc("--private-key-pem-file", str(priv_path), env=env)
+    assert proc.returncode != 0
+    assert PASSWORD_ENV in proc.stderr
+    assert "Traceback" not in proc.stderr


### PR DESCRIPTION
## Summary

`scripts/issue_dev_license_jwt.py` loaded PEM keys with `password=None`, so the now AES-encrypted PKCS#8 signing key (`license-signing-v1-pkcs8.pem`) could not be read. The issuer now resolves the passphrase from three sources, fully backward-compatible:

1. `DATA_BOAR_LICENSE_ISSUER_PRIVATE_KEY_PASSWORD` env var — non-interactive (Maestro / automation).
2. `getpass` prompt when stdin is a TTY — operator issuing a real license at the keyboard.
3. `None` for unencrypted keys — current behavior preserved.

An encrypted key with neither the env var nor a TTY exits with an **actionable message**, not a raw `cryptography` traceback.

## Changes

- `scripts/issue_dev_license_jwt.py`: `_resolve_key_password()` (env -> TTY -> None) wired into the `load_pem_private_key` call site.
- `scripts/maestro/Handle-LicensingMatrix.ps1`: documents the head-less passphrase requirement (operator exports the env var; child `uv run` inherits it).
- `tests/test_issue_dev_license_qa.py`: encrypted+env signs OK; clean key backward-compat; encrypted without env/TTY exits actionably (no traceback).
- `docs/ops/QA_LOCAL_LICENSE.md` (+ pt-BR): optional passphrase, env var, interactive prompt.

## Test plan

- [x] `uv run pytest tests/test_issue_dev_license_qa.py` (9 passed)
- [x] `./scripts/check-all.sh` green (1472 passed, 3 skipped)
- [ ] CI green across 3.12 / 3.13 / 3.14

Closes #910

Made with [Cursor](https://cursor.com)