### PR TITLE
fix(ci): ignore mariadb PYSEC-2026-217 in pip-audit (no fix yet, #922)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,8 +163,9 @@ jobs:
 
       # CVE-2026-3219 cleared: pip>=26.1 fixes (PyPI 26.1.1 as of 2026-05); no longer suppressed.
       # PYSEC-2024-277 / PYSEC-2026-89 / PYSEC-2025-183: OSV entries without PyPI fix versions (2026-05-20); triage via deps issue.
+      # PYSEC-2026-217: mariadb 1.1.14 connector — OSV entry without a PyPI fix version (2026-06-17); remove when a fixed release ships. Tracked in #922.
       - name: Run pip audit
-        run: uv run pip-audit --ignore-vuln PYSEC-2024-277 --ignore-vuln PYSEC-2026-89 --ignore-vuln PYSEC-2025-183
+        run: uv run pip-audit --ignore-vuln PYSEC-2024-277 --ignore-vuln PYSEC-2026-89 --ignore-vuln PYSEC-2025-183 --ignore-vuln PYSEC-2026-217
 
   sonar:
     name: SonarQube / SonarCloud


### PR DESCRIPTION
## Summary

A newly published OSV advisory **PYSEC-2026-217** affects **`mariadb 1.1.14`** (latest release; **no PyPI fix version** as of 2026-06-17). Because the CI **Dependency audit** gate is repo-wide, this reds **every** PR (e.g. docs-only #921), even though no PR introduced it.

This adds `--ignore-vuln PYSEC-2026-217` to the `pip-audit` step, matching the existing precedent for fix-less OSV entries (PYSEC-2024-277 / PYSEC-2026-89 / PYSEC-2025-183), and unblocks all PR merges.

## Scope

- One line in `.github/workflows/ci.yml` (dep-audit step) + a dated, issue-linked comment.
- **No** change to dependency versions, test corpus, or Maestro benchmark profile.

## Removal condition (tracked)

Remove the ignore when a fixed `mariadb` release ships, then re-run `pip-audit`. Tracked in #922 (kept open intentionally).

## Refs

- #922 — deps/security tracker
- OSV: PYSEC-2026-217

Made with [Cursor](https://cursor.com)