### PR TITLE
docs(man5): document sensitivity_detection connector/fuzzy keys (Closes #455, #456)

### DIFF
--- a/docs/data_boar.5
+++ b/docs/data_boar.5
@@ -340,6 +340,41 @@ See
 .I quasi_identifier_mapping
 (list).
 .TP
+.B sensitivity_detection.connector_format_id_hint
+(optional, bool, default false) When true, connectors pass declared SQL type
+and length metadata (for example VARCHAR(N) on ID-like column names), which
+may elevate a borderline LOW score to MEDIUM (tag:
+.BR FORMAT_LENGTH_HINT_ID ).
+Reduces false negatives on structured ID columns.
+See
+.IR docs/SENSITIVITY_DETECTION.md .
+.TP
+.B sensitivity_detection.fuzzy_column_match
+(optional, bool, default false) When true, applies fuzzy string matching to
+column names to catch variations of known sensitive field names (for example
+cpf_num, email_address). Requires the optional
+.I rapidfuzz
+dependency (extra
+.IR detection-fuzzy );
+ignored when it is not installed.
+.TP
+.B sensitivity_detection.fuzzy_column_match_min_confidence
+(optional, integer 0-100, default 25) Lower bound of the combined-confidence
+band in which a fuzzy column-name match may elevate a finding to MEDIUM.
+.TP
+.B sensitivity_detection.fuzzy_column_match_max_confidence
+(optional, integer 0-100, default 45) Upper bound of that band; it is capped
+at
+.I medium_confidence_threshold
+minus one so normal MEDIUM and ML paths stay unchanged.
+.TP
+.B sensitivity_detection.fuzzy_column_match_min_ratio
+(optional, integer 50-100, default 85) Minimum fuzzy match ratio (string
+similarity) required for a column name to count as a match. Higher values
+reduce false positives.
+See
+.IR docs/SENSITIVITY_DETECTION.md .
+.TP
 .B ml_patterns_file
 Path to ML terms file (used if
 .B sensitivity_detection.ml_terms


### PR DESCRIPTION
## Summary
Extends `docs/data_boar.5` (`.SH MAIN CONFIGURATION FILE`) with `sensitivity_detection` keys that exist in code but were missing from the man page:

- `connector_format_id_hint` (Plan §4, tag `FORMAT_LENGTH_HINT_ID`) — **#455**
- `fuzzy_column_match` + tuning band — **#456**
  - `fuzzy_column_match_min_confidence` ⚠️ **also missing from the issue text**; confirmed in `config/loader.py`, `core/detector.py`, `core/fuzzy_column_match.py` (default 25). Added for completeness (code as source of truth).
  - `fuzzy_column_match_max_confidence`
  - `fuzzy_column_match_min_ratio`

## Notes
- Semantics taken from `core/fuzzy_column_match.py` (confidence band capped at `medium_confidence_threshold - 1`; `min_ratio` clamped 50–100) and `core/detector.py` defaults (25/45/85).
- Documentation only — config keys only, no internals (per issue out-of-scope).

## Test plan
- [x] `git grep` gap closed (5 hits now)
- [x] `groff -man -Tutf8 docs/data_boar.5` renders with no warnings
- [x] `tests/test_operator_help_sync.py` green
- [x] `./scripts/lint-only.sh` green

Closes #455
Closes #456

Made with [Cursor](https://cursor.com)