### PR TITLE
docs(releases): feature highlights for v1.7.3 (#463)

### DIFF
--- a/docs/releases/1.7.3.md
+++ b/docs/releases/1.7.3.md
@@ -12,6 +12,15 @@
 - **Docker Hub:** **`fabioleitao/data_boar:1.7.3`** and **`latest`** (same digest after publish).
 - **Prior golden** remains documented at [1.7.2-safe.md](1.7.2-safe.md) for historical audit narrative.
 
+### Feature highlights since 1.7.1
+
+This is a **maintenance / sanitization** baseline; the application line carries the features that landed on `main` between **v1.7.1** and **v1.7.3** (confirmed in [CHANGELOG.md](../../CHANGELOG.md) `## 1.7.2+safe` carryover):
+
+- **Dashboard auth — WebAuthn passkeys (Phase 1a + 1b):** optional `api.webauthn` JSON core plus HTML session + CSRF on gated routes. Disabled by default. See [ADR 0033](../adr/ADR-0033-webauthn-open-relying-party-json-endpoints.md).
+- **Dashboard RBAC (Phase 2, [#86](https://github.com/FabioLeitao/data-boar/issues/86)):** optional `api.rbac.enabled` role gating. Enterprise SSO/OIDC (Phase 3) remains future work.
+- **Filesystem "data soup" Tier 1 + steganography hints:** broader `SUPPORTED_EXTENSIONS`, `file_scan.scan_for_stego` / CLI `--scan-stego`.
+- **Security & sanitization baseline (`v1.7.2-safe`):** PII-sensitive history remediation and a single clean Docker Hub digest — clone from `v1.7.2-safe` onward for the clean baseline story.
+
 ---
 
 ## Bump type


### PR DESCRIPTION
## Summary

Closes #463 — the v1.7.3 release notes only said "maintenance baseline", so a PRD/investor evaluator clicking **Latest** saw no shipped features.

Adds a short, factual **Feature highlights since 1.7.1** subsection to `docs/releases/1.7.3.md`, sourced from `CHANGELOG.md` `## 1.7.2+safe` carryover (code/changelog as source of truth):

- WebAuthn passkeys (Phase 1a + 1b) — `api.webauthn`
- Dashboard RBAC (Phase 2, #86) — `api.rbac.enabled`
- Filesystem data-soup Tier 1 + steganography hints — `file_scan.scan_for_stego` / `--scan-stego`
- v1.7.2-safe security & sanitization baseline

Candidate features from the issue body not confirmed in the `1.7.2+safe` carryover (maturity POC, scope CSV) were **omitted** to avoid asserting unverified facts. Docs-only; no runtime/Maestro impact.

## Notes

- The GitHub Release **body** for `v1.7.3` is a separate published surface — left for an operator-approved `gh release edit` follow-up (not auto-mutated here).

## Test plan

- [x] markdown lint + pt-BR locale + external-no-plan-links guards green
- [x] pre-commit (PII seed gate, guards) green on signed commit

Made with [Cursor](https://cursor.com)