### PR TITLE
docs(audience-guide): drop stale #577 hub note + add PMO/CFO/CCO entries

### DIFF
--- a/docs/AUDIENCE_GUIDE.md
+++ b/docs/AUDIENCE_GUIDE.md
@@ -2,7 +2,7 @@
 
 **Português (Brasil):** [AUDIENCE_GUIDE.pt_BR.md](AUDIENCE_GUIDE.pt_BR.md)
 
-Navigation map for **eight** reader types. Full doc index: [README.md](README.md). Executive decks: [pitch/INDEX.md](pitch/INDEX.md).
+Navigation map for **eleven** reader types. Full doc index: [README.md](README.md). Executive decks: [pitch/INDEX.md](pitch/INDEX.md).
 
 ---
 
@@ -32,6 +32,33 @@ Navigation map for **eight** reader types. Full doc index: [README.md](README.md
 | **Trail** | [SECURITY.md](SECURITY.md) → [COMPLIANCE_TECHNICAL_REFERENCE.md](COMPLIANCE_TECHNICAL_REFERENCE.md) → [GRC_EXECUTIVE_REPORT_SCHEMA.md](GRC_EXECUTIVE_REPORT_SCHEMA.md) → [adr/ADR-0039-retention-evidence-posture-bonded-customs-adjacent-contexts.md](adr/ADR-0039-retention-evidence-posture-bonded-customs-adjacent-contexts.md) |
 | **Skip** | Academic primers; stakeholder-only pitch tone |
 | **Overlap** | DPO (legal framing); developer (deploy hardening) |
+
+## PMO / project lead
+
+| | |
+| - | - |
+| **Entry** | `pitch/PITCH_PMO.md` *(pitch planned — #682)* |
+| **Trail** | [GRC_EXECUTIVE_REPORT_SCHEMA.md](GRC_EXECUTIVE_REPORT_SCHEMA.md) → heatmap / sprint tracking → [releases/](releases/) (shipped vs roadmap) |
+| **Skip** | Engineering ADRs, [TECH_GUIDE.md](TECH_GUIDE.md) |
+| **Overlap** | Executive (value brief); CISO (GRC schema) |
+
+## CFO / financial C-level
+
+| | |
+| - | - |
+| **Entry** | `pitch/PITCH_CFO.md` *(pitch planned — #683)* |
+| **Trail** | [DECISION_MAKER_VALUE_BRIEF.md](DECISION_MAKER_VALUE_BRIEF.md) → [LICENSING_OPEN_CORE_AND_COMMERCIAL.md](LICENSING_OPEN_CORE_AND_COMMERCIAL.md) → [releases/](releases/) |
+| **Skip** | [TECH_GUIDE.md](TECH_GUIDE.md), technical compliance frameworks |
+| **Overlap** | Executive (value brief); PMO (delivery vs cost) |
+
+## CCO / General Counsel
+
+| | |
+| - | - |
+| **Entry** | `pitch/PITCH_COMPLIANCE_OFFICER.md` *(pitch planned — #684)* |
+| **Trail** | [COMPLIANCE_AND_LEGAL.md](COMPLIANCE_AND_LEGAL.md) → [COMPLIANCE_FRAMEWORKS.md](COMPLIANCE_FRAMEWORKS.md) |
+| **Skip** | [TECH_GUIDE.md](TECH_GUIDE.md); do not confuse with DPO (operational LGPD) |
+| **Overlap** | DPO (legal summary, distinct role); Executive (compliance posture) |
 
 ## Compliance engineer
 
@@ -83,18 +110,21 @@ Navigation map for **eight** reader types. Full doc index: [README.md](README.md
 
 ## Overlap matrix (shared reads)
 
-| Doc | Executive | DPO | CISO | Compliance | Developer | Academic | Agent | Operator |
-| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| [DECISION_MAKER_VALUE_BRIEF.md](DECISION_MAKER_VALUE_BRIEF.md) | ● | ○ | ○ | ○ | | | | |
-| [COMPLIANCE_FRAMEWORKS.md](COMPLIANCE_FRAMEWORKS.md) | ○ | ● | ○ | ● | ○ | ○ | | |
-| [SECURITY.md](SECURITY.md) | | ○ | ● | ○ | ● | | | ○ |
-| [USAGE.md](USAGE.md) | | ○ | ○ | ○ | ● | | ○ | ● |
-| [pitch/INDEX.md](pitch/INDEX.md) | ● | ● | ● | | | | | |
+| Doc | Executive | DPO | CISO | Compliance | Developer | Academic | Agent | Operator | PMO | CFO | CCO |
+| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [DECISION_MAKER_VALUE_BRIEF.md](DECISION_MAKER_VALUE_BRIEF.md) | ● | ○ | ○ | ○ | | | | | ○ | ● | |
+| [COMPLIANCE_FRAMEWORKS.md](COMPLIANCE_FRAMEWORKS.md) | ○ | ● | ○ | ● | ○ | ○ | | | | | ● |
+| [SECURITY.md](SECURITY.md) | | ○ | ● | ○ | ● | | | ○ | | | |
+| [USAGE.md](USAGE.md) | | ○ | ○ | ○ | ● | | ○ | ● | | | |
+| [pitch/INDEX.md](pitch/INDEX.md) | ● | ● | ● | | | | | | ● | ● | ● |
+| [GRC_EXECUTIVE_REPORT_SCHEMA.md](GRC_EXECUTIVE_REPORT_SCHEMA.md) | | | ○ | | | | | | ● | | |
+| [LICENSING_OPEN_CORE_AND_COMMERCIAL.md](LICENSING_OPEN_CORE_AND_COMMERCIAL.md) | ○ | | | | | | | | | ● | |
+| [COMPLIANCE_AND_LEGAL.md](COMPLIANCE_AND_LEGAL.md) | ○ | ● | | ○ | | | | | | | ● |
 
 ● = primary trail · ○ = optional overlap
 
 ---
 
-## Hubs index (planned)
+## Hubs index
 
-A consolidated **`docs/hubs/INDEX.md`** is tracked on GitHub **#577**. Until it ships, use [README.md](README.md), [pitch/INDEX.md](pitch/INDEX.md), and [use-cases/USE_CASES_HUB.md](use-cases/USE_CASES_HUB.md).
+The consolidated **map of maps** lives at [hubs/INDEX.md](hubs/INDEX.md). Also useful: [README.md](README.md), [pitch/INDEX.md](pitch/INDEX.md), and [use-cases/USE_CASES_HUB.md](use-cases/USE_CASES_HUB.md).

--- a/docs/AUDIENCE_GUIDE.pt_BR.md
+++ b/docs/AUDIENCE_GUIDE.pt_BR.md
@@ -2,7 +2,7 @@
 
 **English:** [AUDIENCE_GUIDE.md](AUDIENCE_GUIDE.md)
 
-Mapa de navegação para **oito** perfis de leitor. Índice completo: [README.md](README.md). Decks executivos: [pitch/INDEX.pt_BR.md](pitch/INDEX.pt_BR.md).
+Mapa de navegação para **onze** perfis de leitor. Índice completo: [README.md](README.md). Decks executivos: [pitch/INDEX.pt_BR.md](pitch/INDEX.pt_BR.md).
 
 ---
 
@@ -32,6 +32,33 @@ Mapa de navegação para **oito** perfis de leitor. Índice completo: [README.md
 | **Trilha** | [SECURITY.pt_BR.md](SECURITY.pt_BR.md) → [COMPLIANCE_TECHNICAL_REFERENCE.pt_BR.md](COMPLIANCE_TECHNICAL_REFERENCE.pt_BR.md) → [GRC_EXECUTIVE_REPORT_SCHEMA.pt_BR.md](GRC_EXECUTIVE_REPORT_SCHEMA.pt_BR.md) → [adr/ADR-0039-retention-evidence-posture-bonded-customs-adjacent-contexts.md](adr/ADR-0039-retention-evidence-posture-bonded-customs-adjacent-contexts.md) |
 | **Evitar** | Primers acadêmicos; tom de pitch para conselho |
 | **Sobreposição** | DPO (enquadramento legal); desenvolvedor (hardening de deploy) |
+
+## PMO / líder de projeto
+
+| | |
+| - | - |
+| **Entrada** | `pitch/PITCH_PMO.md` *(pitch planejado — #682)* |
+| **Trilha** | [GRC_EXECUTIVE_REPORT_SCHEMA.pt_BR.md](GRC_EXECUTIVE_REPORT_SCHEMA.pt_BR.md) → heatmap / acompanhamento de sprint → [releases/](releases/) (entregue vs roadmap) |
+| **Evitar** | ADRs de engenharia, [TECH_GUIDE.pt_BR.md](TECH_GUIDE.pt_BR.md) |
+| **Sobreposição** | Executivo (value brief); CISO (schema GRC) |
+
+## CFO / C-level financeiro
+
+| | |
+| - | - |
+| **Entrada** | `pitch/PITCH_CFO.md` *(pitch planejado — #683)* |
+| **Trilha** | [DECISION_MAKER_VALUE_BRIEF.pt_BR.md](DECISION_MAKER_VALUE_BRIEF.pt_BR.md) → [LICENSING_OPEN_CORE_AND_COMMERCIAL.pt_BR.md](LICENSING_OPEN_CORE_AND_COMMERCIAL.pt_BR.md) → [releases/](releases/) |
+| **Evitar** | [TECH_GUIDE.pt_BR.md](TECH_GUIDE.pt_BR.md), frameworks técnicos de compliance |
+| **Sobreposição** | Executivo (value brief); PMO (entrega vs custo) |
+
+## CCO / jurídico (General Counsel)
+
+| | |
+| - | - |
+| **Entrada** | `pitch/PITCH_COMPLIANCE_OFFICER.md` *(pitch planejado — #684)* |
+| **Trilha** | [COMPLIANCE_AND_LEGAL.pt_BR.md](COMPLIANCE_AND_LEGAL.pt_BR.md) → [COMPLIANCE_FRAMEWORKS.pt_BR.md](COMPLIANCE_FRAMEWORKS.pt_BR.md) |
+| **Evitar** | [TECH_GUIDE.pt_BR.md](TECH_GUIDE.pt_BR.md); não confundir com DPO (LGPD operacional) |
+| **Sobreposição** | DPO (resumo jurídico, papel distinto); Executivo (postura de compliance) |
 
 ## Engenheiro de compliance
 
@@ -83,18 +110,21 @@ Mapa de navegação para **oito** perfis de leitor. Índice completo: [README.md
 
 ## Matriz de sobreposição
 
-| Doc | Executivo | DPO | CISO | Compliance | Dev | Acadêmico | Agente | Operador |
-| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| [DECISION_MAKER_VALUE_BRIEF.pt_BR.md](DECISION_MAKER_VALUE_BRIEF.pt_BR.md) | ● | ○ | ○ | ○ | | | | |
-| [COMPLIANCE_FRAMEWORKS.pt_BR.md](COMPLIANCE_FRAMEWORKS.pt_BR.md) | ○ | ● | ○ | ● | ○ | ○ | | |
-| [SECURITY.pt_BR.md](SECURITY.pt_BR.md) | | ○ | ● | ○ | ● | | | ○ |
-| [USAGE.pt_BR.md](USAGE.pt_BR.md) | | ○ | ○ | ○ | ● | | ○ | ● |
-| [pitch/INDEX.pt_BR.md](pitch/INDEX.pt_BR.md) | ● | ● | ● | | | | | |
+| Doc | Executivo | DPO | CISO | Compliance | Dev | Acadêmico | Agente | Operador | PMO | CFO | CCO |
+| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [DECISION_MAKER_VALUE_BRIEF.pt_BR.md](DECISION_MAKER_VALUE_BRIEF.pt_BR.md) | ● | ○ | ○ | ○ | | | | | ○ | ● | |
+| [COMPLIANCE_FRAMEWORKS.pt_BR.md](COMPLIANCE_FRAMEWORKS.pt_BR.md) | ○ | ● | ○ | ● | ○ | ○ | | | | | ● |
+| [SECURITY.pt_BR.md](SECURITY.pt_BR.md) | | ○ | ● | ○ | ● | | | ○ | | | |
+| [USAGE.pt_BR.md](USAGE.pt_BR.md) | | ○ | ○ | ○ | ● | | ○ | ● | | | |
+| [pitch/INDEX.pt_BR.md](pitch/INDEX.pt_BR.md) | ● | ● | ● | | | | | | ● | ● | ● |
+| [GRC_EXECUTIVE_REPORT_SCHEMA.pt_BR.md](GRC_EXECUTIVE_REPORT_SCHEMA.pt_BR.md) | | | ○ | | | | | | ● | | |
+| [LICENSING_OPEN_CORE_AND_COMMERCIAL.pt_BR.md](LICENSING_OPEN_CORE_AND_COMMERCIAL.pt_BR.md) | ○ | | | | | | | | | ● | |
+| [COMPLIANCE_AND_LEGAL.pt_BR.md](COMPLIANCE_AND_LEGAL.pt_BR.md) | ○ | ● | | ○ | | | | | | | ● |
 
 ● = trilha principal · ○ = sobreposição opcional
 
 ---
 
-## Índice de hubs (planejado)
+## Índice de hubs
 
-**`docs/hubs/INDEX.md`** está no GitHub **#577**. Até lá, use [README.md](README.md), [pitch/INDEX.pt_BR.md](pitch/INDEX.pt_BR.md) e [use-cases/USE_CASES_HUB.pt_BR.md](use-cases/USE_CASES_HUB.pt_BR.md).
+O **mapa de mapas** consolidado fica em [hubs/INDEX.md](hubs/INDEX.md). Também úteis: [README.md](README.md), [pitch/INDEX.pt_BR.md](pitch/INDEX.pt_BR.md) e [use-cases/USE_CASES_HUB.pt_BR.md](use-cases/USE_CASES_HUB.pt_BR.md).


### PR DESCRIPTION
## Summary

Tidies `docs/AUDIENCE_GUIDE.md` (+ pt-BR mirror) per #690:

- **Stale hub note removed** — `#577` (consolidated `docs/hubs/INDEX.md`) is **closed**; the "Hubs index (planned)" block now links straight to [`hubs/INDEX.md`](../blob/main/docs/hubs/INDEX.md) instead of saying "until it ships".
- **Three new reader profiles** added after CISO: **PMO / project lead**, **CFO / financial C-level**, **CCO / General Counsel**.
- **Reader count** updated: eight → eleven.
- **Overlap matrix** gains PMO/CFO/CCO columns + 3 rows for their key docs (GRC schema, licensing open-core, compliance & legal).

## Notes

- The entry pitches `PITCH_PMO` / `PITCH_CFO` / `PITCH_COMPLIANCE_OFFICER` **do not exist yet** (tracked by #682/#683/#684). To avoid dead links they are rendered as code spans with `*(pitch planned — #NNN)*`, not live links — swap to links when those pitches land.
- Stayed out of #642's scope (the 3 obsolete refs) — that issue is still open and owns those.
- pt-BR mirror updated in lockstep; `lint-only.sh` green (markdown + pt-BR locale + external-no-plan-links guards).

Closes #690

Made with [Cursor](https://cursor.com)