### PR TITLE
docs(readme): add forensic-grade positioning tagline (en_US + pt_BR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 ![Data Boar mascot](api/static/mascot/data_boar_mascote_color.svg)
 
+**Forensic-grade open-source PII scanner for LGPD · GDPR · evidence-ready compliance.**
+
 **LGPD — real-world witness report (ISP field visit, Brazil):** [English](docs/LGPD_WITNESS_REPORT_NIO_FIELD_VISIT_2026.md) · [Português (Brasil)](docs/LGPD_WITNESS_REPORT_NIO_FIELD_VISIT_2026.pt_BR.md)
 
 **Português (Brasil):** [README.pt_BR.md](README.pt_BR.md) · [docs/USAGE.pt_BR.md](docs/USAGE.pt_BR.md) · → [Audience guide](docs/AUDIENCE_GUIDE.md) — who should read which docs · **5 min (pt-BR):** [QUICKSTART.md](QUICKSTART.md)

--- a/README.pt_BR.md
+++ b/README.pt_BR.md
@@ -4,6 +4,8 @@
 
 ![Data Boar mascot](api/static/mascot/data_boar_mascote_color.svg)
 
+**Scanner de PII de código aberto com postura forense para LGPD · GDPR · conformidade auditável.**
+
 **LGPD — relato-testemunho (visita de campo, Brasil):** [Português (Brasil)](docs/LGPD_WITNESS_REPORT_NIO_FIELD_VISIT_2026.pt_BR.md) · [English](docs/LGPD_WITNESS_REPORT_NIO_FIELD_VISIT_2026.md)
 
 **English:** [README.md](README.md) · [docs/USAGE.md](docs/USAGE.md) · **5 min (pt-BR):** [QUICKSTART.md](QUICKSTART.md)


### PR DESCRIPTION
## Summary

Adds the **forensic-grade** positioning label to the top of `README.md` + `README.pt_BR.md` per #693 — one tagline line under the mascot, nothing more.

- **EN:** `Forensic-grade open-source PII scanner for LGPD · GDPR · evidence-ready compliance.`
- **pt-BR:** `Scanner de PII de código aberto com postura forense para LGPD · GDPR · conformidade auditável.`

## Decisions (operator-approved)

- **Wording:** the short, grounded variant. **Dropped the issue's "chain-of-custody documentation" phrasing** — that capability is not in the product (the term only appears in ops/review docs). The real shipped artifact is the **evidence manifest** (`tests/test_scan_evidence.py`, USAGE), so the tagline says **evidence-ready / auditável** instead — truthful positioning.
- **Placement:** new tagline line right after the mascot (not woven into the opening line, not a new section).
- **Primer link deferred:** AC asks to link `docs/primers/FORENSICS_AND_EVIDENCE_PRIMER.md` *once it exists (#685)*. #685 is still open and the file does not exist, so no link now (would be dead). Add it when #685 ships.

## Constraints honored

- **ADR-0025** — no "legally admissible" / "admissível em juízo" / "laudo oficial".
- **ADR-0048** — no header/taxonomy changes; atomic 1-line edit per language.
- `lint-only.sh` green (markdown + pt-BR locale).

Closes #693

Made with [Cursor](https://cursor.com)