### PR TITLE
chore(deps): bump pypdf to 6.13.3 (GHSA-jm82-fx9c-mx94)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1496,9 +1496,9 @@ pyparsing==3.3.2 \
     #   matplotlib
     #   oletools
     #   pip-requirements-parser
-pypdf==6.13.2 \
-    --hash=sha256:5a96a17dbdfbf9c2ab24c0a13fa0aba182be22ba6f283098712c16fc242f509f \
-    --hash=sha256:6eeb9e57693f29d41bd01255d02660cbbb41fd7fc818a982677389a35e4f2083
+pypdf==6.13.3 \
+    --hash=sha256:c6e3f86afb625791510b02ad5480e94b63970bb957df75d44657c282ecc52224 \
+    --hash=sha256:f3cb822769725f1bac658c406cfc9460399043f3750c2d3e4650e0a85eacabd7
     # via data-boar
 pytest==9.0.3 \
     --hash=sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9 \

--- a/uv.lock
+++ b/uv.lock
@@ -3279,11 +3279,11 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.13.2"
+version = "6.13.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/0a/48fe05c6bb3aa4bb4d2a4079a383d33c0dfec1edf613a642f07d8b8b5c2e/pypdf-6.13.2.tar.gz", hash = "sha256:5a96a17dbdfbf9c2ab24c0a13fa0aba182be22ba6f283098712c16fc242f509f", size = 6479250, upload-time = "2026-06-10T16:42:34.5Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/18/9947cc201af9ccf76720fd3347bf4f70eb882ce3fcf4cb05f7443e4cf871/pypdf-6.13.3.tar.gz", hash = "sha256:f3cb822769725f1bac658c406cfc9460399043f3750c2d3e4650e0a85eacabd7", size = 6484063, upload-time = "2026-06-17T15:22:00.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/17/378943705992f74e451a06de3401ce68e3213763c81e44d0614559c45599/pypdf-6.13.2-py3-none-any.whl", hash = "sha256:6eeb9e57693f29d41bd01255d02660cbbb41fd7fc818a982677389a35e4f2083", size = 346555, upload-time = "2026-06-10T16:42:32.37Z" },
+    { url = "https://files.pythonhosted.org/packages/94/56/2967e621598987905fb8cdfadd8f8de6b5c68c9351f0523c4df8409f28f1/pypdf-6.13.3-py3-none-any.whl", hash = "sha256:c6e3f86afb625791510b02ad5480e94b63970bb957df75d44657c282ecc52224", size = 347288, upload-time = "2026-06-17T15:21:59.512Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

A newly disclosed advisory **GHSA-jm82-fx9c-mx94** affects **pypdf 6.13.2**
(fix in **6.13.3**). `Dependency audit` (pip-audit, not `continue-on-error`)
was green on the last 3 `main` runs and now fails on this advisory, so it
**blocks every PR** -- including the 1.7.4 gate (#942) -- and would fail the
next `main` run. Deps were otherwise unchanged.

## Change

`pyproject` already allows it (`pypdf>=6.13.0`); only lock + export move:

```
uv lock --upgrade-package pypdf        # 6.13.2 -> 6.13.3
uv export --frozen --no-emit-project -o requirements.txt
```

## Validation

- `pip-audit` (same CI ignore list): **no known vulnerabilities** (was 1).
- `./scripts/check-all.sh`: **1472 passed, 10 skipped**.
- HELD safeguard: pypdf is used only by the filesystem/PDF connectors, not the
  benchmarked OpenCore prefilter or pro worker path, so the 200k Rust ratio is
  invariant to this bump. The recorded evidence test stays green and a
  functional bench re-run preserved hit parity (100000/100000). The empirical
  Rust A/B (>=0.574x) runs on a Rust-active lab host as part of the gate
  completão acceptance.

Lifts the deps freeze for exactly one security patch, principled (no hot-path
edge) -- not blind.

Made with [Cursor](https://cursor.com)