### PR TITLE
docs: fix adoption-path doc drift in entry docs (#945)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Boar
 
-> **Try it in 30 seconds (no real data):** `./scripts/demo.sh` — generates synthetic corpus, starts the dashboard at `http://127.0.0.1:8088/pt-br/`. Requires `uv` ([install](https://docs.astral.sh/uv/getting-started/installation/)). Docker: `docker run --rm -p 8088:8088 fabioleitao/data_boar:latest demo`.
+> **Try it in 30 seconds (no real data) — any OS (Docker):** `docker run --rm -p 8088:8088 fabioleitao/data_boar:latest demo` → open `http://127.0.0.1:8088/pt-br/`. **Linux/macOS shell (local `uv`, no Docker):** `./scripts/demo.sh` (requires `uv` — [install](https://docs.astral.sh/uv/getting-started/installation/)). **Windows or step-by-step:** [5-min QuickStart](QUICKSTART.md). All demo paths use synthetic data and plaintext loopback (`--allow-insecure-http`).
 
 **Data Boar** — enterprise data discovery and risk governance: compliance-aware mapping of personal and sensitive data across your data soup (intelligence engine, not a single-jurisdiction “audit app”).
 
@@ -38,23 +38,7 @@ Multilingual and legacy encodings are supported; **configurable timeouts** and *
 
 **Typical scenarios:** Preparing for an audit or regulator request; mapping data before a migration or DLP rollout; raising compliance awareness without a full war room; supporting data privacy consultants as the technical evidence layer in LGPD adequacy engagements.
 
-> **Current release:** **1.7.3**. **Docker Hub:** **`fabioleitao/data_boar:1.7.3`** or **`latest`**. Summary: [CHANGELOG.md](CHANGELOG.md). Full notes: [docs/releases/1.7.3.md](docs/releases/1.7.3.md) and the [GitHub Releases page](https://github.com/FabioLeitao/data-boar/releases). Prior golden: **`v1.7.2-safe`** / **`1.7.2+safe`** — [docs/releases/1.7.2-safe.md](docs/releases/1.7.2-safe.md).
-> **Working pre-release on `main`:** **`1.7.4-rc`** — draft GitHub **pre-release** notes: [docs/releases/1.7.4-rc.md](docs/releases/1.7.4-rc.md) (does **not** move Docker **`latest`**; stable remains **1.7.3** until **1.7.4** final).
-> **Documentation note:** This README and `docs/USAGE.md` are the canonical English references. When features or options change, update **both** languages to keep them in sync.
-
-### Release **1.7.4** final — README checklist (blocked by **#406**)
-
-Do **not** tick these until release gate **[#406](https://github.com/FabioLeitao/data-boar/issues/406)** completes and **`1.7.4`** final is published ([issue #425](https://github.com/FabioLeitao/data-boar/issues/425)).
-
-- [ ] **Current release** banner: **1.7.3** → **1.7.4**
-- [ ] **Docker Hub:** confirm **`fabioleitao/data_boar:1.7.4`** and consumer **`latest`** moved per **[VERSIONING.md](docs/VERSIONING.md)** / **[DOCKER_IMAGE_RELEASE_ORDER.md](docs/ops/DOCKER_IMAGE_RELEASE_ORDER.md)**
-- [ ] **Working pre-release** line: remove or repoint (for example next **`1.7.5-rc`**)
-- [ ] README link to **`docs/releases/1.7.4.md`** in the shipping-notes row once final
-- [ ] **CHANGELOG:** fold **`Unreleased`** into **`## 1.7.4 (YYYY-MM-DD)`** using the GitHub/tag date
-- [ ] **README.pt_BR.md:** mirror banner + checklist completion
-- [ ] Confirm **`docs/USAGE.md`** (+ pt-BR) match any ship-time install/version callouts (**CONTRIBUTING** remains EN-canonical workflow)
-
-**Product blog (narrative updates, shorter posts):** [databoar.wordpress.com](https://databoar.wordpress.com) — canonical technical documentation remains in this repository (`docs/`).
+> **Current release & changelog:** [CHANGELOG.md](CHANGELOG.md) · full notes under [docs/releases/](docs/releases/) · [GitHub Releases](https://github.com/FabioLeitao/data-boar/releases). **Docker Hub:** [fabioleitao/data_boar](https://hub.docker.com/r/fabioleitao/data_boar) (`latest` + pinned tags).
 
 ---
 
@@ -100,7 +84,7 @@ Data Boar runs as a **one-shot CLI** audit or as a **REST API** (default port 80
 | Testing, security, contributing                                   | [docs/TESTING.md](docs/TESTING.md) · [SECURITY.md](SECURITY.md) · [CONTRIBUTING.md](CONTRIBUTING.md)                                                                                                                                         |
 | **`pip` from PyPI                                                 | **`pip install data-boar`** when published; until then **git clone** + **`uv sync`** — see [CONTRIBUTING.md — Repository and install identity](CONTRIBUTING.md#repository-and-install-identity-data-boar).                                     |
 
-**Quick start (from repo root):** On **Linux (native, not Docker)**, install system libraries **before** `uv sync`—see [Technical guide — Requirements and environment preparation](docs/TECH_GUIDE.md#requirements-and-environment-preparation) (example `apt` line includes `libpq-dev`, `unixodbc-dev`, and related headers; add `default-libmysqlclient-dev` if building **mysqlclient**). Then `uv sync` → prepare `config.yaml` (see `deploy/config.example.yaml` and [USAGE](docs/USAGE.md)) → `uv run python main.py --config config.yaml --validate-config` to pre-flight targets (no scan) → `uv run python main.py --config config.yaml` for one-shot, or `uv run python main.py --config config.yaml --web --allow-insecure-http` for plaintext API/dashboard (default bind `127.0.0.1`, e.g. [http://127.0.0.1:8088/](http://127.0.0.1:8088/); for TLS use `--https-cert-file` / `--https-key-file`; use `--host 0.0.0.0` only with network controls). Full flags: `uv run python main.py --help`. **Do not commit** root `config.yaml` (`.gitignore`); it may contain LAN paths and secrets—see [CONTRIBUTING.md](CONTRIBUTING.md#public-repo-hygiene-lan-credentials).
+**Quick start:** the [5-min QuickStart](QUICKSTART.md) walks through both paths (Docker or local `uv`, copy-paste); the full flag and configuration reference is in [USAGE.md](docs/USAGE.md). On **Linux (native, not Docker)**, install system libraries **before** `uv sync` — see [Technical guide — Requirements and environment preparation](docs/TECH_GUIDE.md#requirements-and-environment-preparation). **Do not commit** root `config.yaml` (`.gitignore`); it may contain LAN paths and secrets — see [CONTRIBUTING.md](CONTRIBUTING.md#public-repo-hygiene-lan-credentials).
 
 **Full documentation index** (browse all topics and languages): [docs/README.md](docs/README.md) · [docs/README.pt_BR.md](docs/README.pt_BR.md).
 
@@ -110,4 +94,4 @@ Data Boar runs as a **one-shot CLI** audit or as a **REST API** (default port 80
 
 **License and copyright:** [LICENSE](LICENSE) ([pt-BR](LICENSE.pt_BR.md)) · [NOTICE](NOTICE) ([pt-BR](NOTICE.pt_BR.md)) · [docs/COPYRIGHT_AND_TRADEMARK.md](docs/COPYRIGHT_AND_TRADEMARK.md) ([pt-BR](docs/COPYRIGHT_AND_TRADEMARK.pt_BR.md)).
 
-**Maintainer:** [Fabio Leitao on GitHub](https://github.com/FabioLeitao) — Docker Hub namespace `fabioleitao`. The **product blog** link is above; other personal professional social links are not embedded in this README — see the GitHub profile (policy: `**tests/test_pii_guard.py`**, `**docs/ops/COMMIT_AND_PR.md**`). Set the GitHub profile **Website** field to `https://databoar.wordpress.com` if you want a one-click entry point to the blog.
+**Maintainer:** [Fabio Leitao on GitHub](https://github.com/FabioLeitao) — Docker Hub namespace `fabioleitao`. **Product blog** (narrative updates, shorter posts): [databoar.wordpress.com](https://databoar.wordpress.com) — canonical technical documentation stays in this repository (`docs/`). Other personal professional social links are not embedded in this README — see the GitHub profile (policy: `**tests/test_pii_guard.py`**, `**docs/ops/COMMIT_AND_PR.md**`).

--- a/README.pt_BR.md
+++ b/README.pt_BR.md
@@ -36,23 +36,7 @@ Idiomas e encodings legados são suportados; **timeouts configuráveis** e **end
 
 **Cenários típicos:** Preparação para auditoria ou pedido do regulador; mapeamento de dados antes de migração ou implantação de DLP; conscientização de conformidade sem war room completo.
 
-> **Release atual:** **1.7.3**. **Docker Hub:** **`fabioleitao/data_boar:1.7.3`** ou **`latest`**. Resumo: [CHANGELOG.md](CHANGELOG.md). Notas: [docs/releases/1.7.3.md](docs/releases/1.7.3.md) e [Releases no GitHub](https://github.com/FabioLeitao/data-boar/releases). Golden anterior: **`v1.7.2-safe`** / **`1.7.2+safe`** — [docs/releases/1.7.2-safe.md](docs/releases/1.7.2-safe.md).
-> **Pré-release em `main`:** **`1.7.4-rc`** — rascunho de **pré-release** no GitHub: [docs/releases/1.7.4-rc.md](docs/releases/1.7.4-rc.md) (**não** move o **`latest`** do Docker; o estável continua **1.7.3** até **`1.7.4`** final).
-> **Documentação:** Este README e o `docs/USAGE.pt_BR.md` são as referências em português. Quando funcionalidades ou opções mudarem, atualize **ambos** os idiomas para mantê-los sincronizados.
-
-### Release **1.7.4** final — checklist do README (bloqueado pelo **#406**)
-
-Não execute estes itens até o gate de release **[#406](https://github.com/FabioLeitao/data-boar/issues/406)** fechar e o **`1.7.4`** final estar publicado ([issue #425](https://github.com/FabioLeitao/data-boar/issues/425)).
-
-- [ ] Banner **Release atual**: **1.7.3** → **1.7.4**
-- [ ] **Docker Hub:** confirmar **`fabioleitao/data_boar:1.7.4`** + **`latest`** conforme **[VERSIONING.md](docs/VERSIONING.md)** / **[DOCKER_IMAGE_RELEASE_ORDER.md](docs/ops/DOCKER_IMAGE_RELEASE_ORDER.pt_BR.md)**
-- [ ] Linha **pré-release**: remover ou apontar (por exemplo próximo **`1.7.5-rc`**)
-- [ ] Link **`docs/releases/1.7.4.md`** na linha de notas assim que shippar
-- [ ] **CHANGELOG:** mover **`Unreleased`** para **`## 1.7.4 (AAAA-MM-DD)`** com data do tag/GitHub Release
-- [ ] **README.md**: espelhar o mesmo fechamento (EN source)
-- [ ] Confirmar **`docs/USAGE`** (EN + pt-BR) alinhados a **instalação**/versão se necessário (**CONTRIBUTING**: EN é canônico técnico)
-
-**Blog do produto** (atualizações em formato narrativo, posts mais curtos): [databoar.wordpress.com](https://databoar.wordpress.com) — a documentação técnica canônica continua neste repositório (`docs/`).
+> **Release atual e changelog:** [CHANGELOG.md](CHANGELOG.md) · notas completas em [docs/releases/](docs/releases/) · [Releases no GitHub](https://github.com/FabioLeitao/data-boar/releases). **Docker Hub:** [fabioleitao/data_boar](https://hub.docker.com/r/fabioleitao/data_boar) (`latest` + tags fixas).
 
 ---
 
@@ -98,7 +82,7 @@ Se você precisa de:
 - **Testes, segurança, contribuição:** [docs/TESTING.pt_BR.md](docs/TESTING.pt_BR.md) · [SECURITY.pt_BR.md](SECURITY.pt_BR.md) · [CONTRIBUTING.pt_BR.md](CONTRIBUTING.pt_BR.md)
 - **pip via PyPI:** **`pip install data-boar`** quando publicado; até lá **git clone** + **`uv sync`** — veja [CONTRIBUTING.pt_BR.md — Repositório e identidade](CONTRIBUTING.pt_BR.md#repositório-e-identidade-de-instalação-data-boar).
 
-**Início rápido (na raiz do repositório):** Em **Linux nativo (sem Docker)**, instale as bibliotecas de sistema **antes** de `uv sync` — veja [Guia técnico — Requisitos e preparação do ambiente](docs/TECH_GUIDE.pt_BR.md#requisitos-e-preparação-do-ambiente) (o exemplo com `apt` inclui `libpq-dev`, `unixodbc-dev` e cabeçalhos relacionados; acrescente `default-libmysqlclient-dev` se for compilar **mysqlclient**). Depois `uv sync` → prepare `config.yaml` (veja `deploy/config.example.yaml` e [USAGE](docs/USAGE.pt_BR.md)) → `uv run python main.py --config config.yaml` para execução única, ou `uv run python main.py --config config.yaml --web --allow-insecure-http` para API/dashboard em HTTP texto plano (bind padrão `127.0.0.1`, ex. <http://127.0.0.1:8088/>; para TLS use `--https-cert-file` / `--https-key-file`; use `--host 0.0.0.0` só com controles de rede). Lista de flags: `uv run python main.py --help`. **Não commite** o `config.yaml` da raiz (`.gitignore`); pode conter caminhos da LAN e segredos—veja a seção **Higiene do repositório público** em [CONTRIBUTING.pt_BR.md](CONTRIBUTING.pt_BR.md).
+**Início rápido:** o [QuickStart de 5 min](QUICKSTART.md) cobre os dois caminhos (Docker ou `uv` local, copia-e-cola); a referência completa de flags e configuração está em [USAGE.pt_BR.md](docs/USAGE.pt_BR.md). Em **Linux nativo (sem Docker)**, instale as bibliotecas de sistema **antes** de `uv sync` — veja [Guia técnico — Requisitos e preparação do ambiente](docs/TECH_GUIDE.pt_BR.md#requisitos-e-preparação-do-ambiente). **Não commite** o `config.yaml` da raiz (`.gitignore`); pode conter caminhos da LAN e segredos — veja a seção **Higiene do repositório público** em [CONTRIBUTING.pt_BR.md](CONTRIBUTING.pt_BR.md).
 
 **Índice completo da documentação** (todos os tópicos e idiomas): [docs/README.md](docs/README.md) · [docs/README.pt_BR.md](docs/README.pt_BR.md).
 
@@ -108,4 +92,4 @@ Se você precisa de:
 
 **Licença e direitos autorais:** [LICENSE](LICENSE) ([pt-BR](LICENSE.pt_BR.md)) · [NOTICE](NOTICE) ([pt-BR](NOTICE.pt_BR.md)) · [docs/COPYRIGHT_AND_TRADEMARK.pt_BR.md](docs/COPYRIGHT_AND_TRADEMARK.pt_BR.md) ([EN](docs/COPYRIGHT_AND_TRADEMARK.md)).
 
-**Mantenedor:** [Fabio Leitao no GitHub](https://github.com/FabioLeitao) — namespace `fabioleitao` no Docker Hub. O link do **blog do produto** está acima; outras redes sociais profissionais pessoais não ficam embutidas neste README — ver o perfil no GitHub (política: **`tests/test_pii_guard.py`**, **`docs/ops/COMMIT_AND_PR.md`**). No GitHub, use o campo **Website** do perfil com `https://databoar.wordpress.com` se quiser um atalho ao blog.
+**Mantenedor:** [Fabio Leitao no GitHub](https://github.com/FabioLeitao) — namespace `fabioleitao` no Docker Hub. **Blog do produto** (atualizações em formato narrativo, posts mais curtos): [databoar.wordpress.com](https://databoar.wordpress.com) — a documentação técnica canônica continua neste repositório (`docs/`). Outras redes sociais profissionais pessoais não ficam embutidas neste README — ver o perfil no GitHub (política: **`tests/test_pii_guard.py`**, **`docs/ops/COMMIT_AND_PR.md`**).

--- a/docs/TECH_GUIDE.md
+++ b/docs/TECH_GUIDE.md
@@ -122,8 +122,8 @@ uv run python main.py --config config.yaml --diff <session_a_uuid> <session_b_uu
 uv run python main.py --config config.yaml --export-dsar <session_uuid>
 uv run python main.py --config config.yaml --export-dsar <session_uuid> --dsar-output dsar_export.json
 
-# Start the API server (equivalent to python main.py --web)
-uv run python main.py --config config.yaml --web --port 8088
+# Start the API server (plaintext opt-in; see the transport gate under "REST API")
+uv run python main.py --config config.yaml --web --allow-insecure-http --port 8088
 ```
 
 Optional NoSQL support (MongoDB, Redis):
@@ -273,30 +273,39 @@ python main.py --config config.yaml --tenant "Acme Corp" --technician "Alice V."
 ### REST API (default port 8088)
 
 ```bash
-# Start API with default port 8088
-python main.py --config config.yaml --web
+# Start API with default port 8088 (plaintext is an explicit opt-in — see gate below)
+python main.py --config config.yaml --web --allow-insecure-http
 
 # Start API on a custom port
-python main.py --config config.yaml --web --port 9090
+python main.py --config config.yaml --web --allow-insecure-http --port 9090
 
-# Equivalent (bypassing main.py CLI)
+# TLS instead of plaintext (recommended off loopback)
+python main.py --config config.yaml --web --https-cert-file server.crt --https-key-file server.key --port 8088
+```
+
+**Transport gate:** `main.py --web` requires **either** HTTPS (`--https-cert-file` / `--https-key-file`, or the `api` block in config) **or** an explicit `--allow-insecure-http` (loopback / lab only). Otherwise it exits with code **2** and an error on stderr — so a copy-paste `--web` **without** this flag fails before any scan. This mirrors [USAGE.md](USAGE.md#rest-api-server---web).
+
+```bash
+# Not recommended for adoption: bypasses main.py's transport gate AND
+# configure_dashboard_transport, so GET /status reports mode: not_configured.
 uvicorn api.routes:app --host 0.0.0.0 --port 8088
 ```
 
 ## CLI arguments (reference)
 
-| Argument            | Mode                   | Description                                                                                                                                                                                                                  | Examples                                             |
-| ---------           | ------                 | -------------                                                                                                                                                                                                                | ----------                                           |
-| `--config PATH`     | CLI & API              | Path to YAML/JSON config file. Defaults to `config.yaml` if omitted.                                                                                                                                                         | `--config config.yaml`, `--config configs/prod.yaml` |
-| `--web`             | API only               | Start the REST API instead of running a one-shot scan.                                                                                                                                                                       | `--web`                                              |
-| `--port N`          | API only               | Port for the REST API when `--web` is set. Defaults to `8088`. Ignored in one-shot CLI mode.                                                                                                                                 | `--web --port 9090`                                  |
-| `--reset-data`      | CLI only (maintenance) | **Dangerous**: wipe all scan sessions, findings and failures from SQLite, delete generated reports/heatmaps under `report.output_dir`, and record the wipe event in `data_wipe_log` for auditability. Does not start a scan. | `--reset-data`                                       |
-| `--tenant NAME`     | CLI only (one-shot)    | Optional customer / tenant name for this scan. Stored in `scan_sessions.tenant_name`, shown on dashboard and in the **Report info** sheet.                                                                                   | `--tenant "Acme Corp"`                               |
-| `--technician NAME` | CLI only (one-shot)    | Optional technician / operator responsible for this scan. Stored in `scan_sessions.technician_name`, shown on dashboard and in the **Report info** sheet.                                                                    | `--technician "Alice V."`                         |
+**The full, authoritative CLI reference (all 22 flags — `--config`, `--web`, `--host`, `--port`, `--https-cert-file` / `--https-key-file`, `--allow-insecure-http`, `--validate-config`, `--diff`, `--fail-on-new-high`, `--export-dsar` / `--dsar-output`, `--export-audit-trail`, `--scan-compressed`, `--content-type-check`, `--scan-stego`, `--jurisdiction-hint`, `--reset-data`, `--tenant`, `--technician`, …) lives in [USAGE.md §1 — Command-line interface](USAGE.md#1-command-line-interface-cli).** It is the single source of truth (kept in sync with `main.py`); this guide does not duplicate a partial copy. The live list is always `uv run python main.py --help`.
+
+Quick orientation for the most common ones:
+
+- `--config PATH` — YAML/JSON config (defaults to `config.yaml`). Used by CLI **and** API.
+- `--web` — start the REST API / dashboard instead of a one-shot scan (needs the transport gate above: `--allow-insecure-http` or TLS).
+- `--port N` / `--host HOST` — bind for `--web` (default `127.0.0.1:8088`; `--host 0.0.0.0` only with network controls).
+- `--validate-config` — pre-flight targets, no scan (exit 0 if OK).
+- `--reset-data` — **dangerous**: wipe sessions/findings/reports from SQLite (audited in `data_wipe_log`).
 
 When using the API (`--web`), the server loads config from **`CONFIG_PATH`** (environment variable) or `config.yaml` in the working directory if `--config` is not provided on the CLI.
 
-**Web dashboard:** With the server running, open <http://localhost:8088/en/> (or `/pt-br/`) for a simple dashboard: scan status, quantity/quality of discovered data (DB/FS findings, failures), **progress graph over time** (total findings and a risk score per session), optional inputs for **tenant/customer** and **technician/operator** before starting a scan, recent sessions (including tenant/technician columns), and links to **Reports** (list and download) and **Configuration** (edit YAML in the browser). Unprefixed `/` redirects to the negotiated locale (cookie, `Accept-Language`, config).
+**Web dashboard:** With the server running, open <http://localhost:8088/en/> (or `/pt-br/`) for a simple dashboard: scan status, quantity/quality of discovered data (DB/FS findings, failures), **progress graph over time** (total findings and a risk score per session), optional inputs for **tenant/customer** and **technician/operator** before starting a scan, recent sessions (including tenant/technician columns), and links to **Reports** (list and download) and **Configuration** (edit YAML in the browser). Unprefixed `/` redirects to the negotiated locale (cookie, `Accept-Language`, config). Reports download both ways: the API endpoints above (`/report`, `/reports/{session_id}`) **and** the browser **Download** button on the **Reports** page — for a step-by-step non-technical walkthrough (open `/en/` → set tenant/technician → **Start scan** → **Reports** → **Download**), see [USAGE.md — Web dashboard](USAGE.md#web-dashboard).
 
 ## API routes (summary)
 
@@ -640,6 +649,8 @@ docker run -d -p 8088:8088 -v /path/to/your/data:/data -e CONFIG_PATH=/data/conf
 ```
 
 Prepare `/data/config.yaml` from `deploy/config.example.yaml` (see [deploy/DEPLOY.md](deploy/DEPLOY.md) ([pt-BR](deploy/DEPLOY.pt_BR.md))). You can decide to use this image as an instanced container instead of pulling the code from Git and building locally.
+
+> **Docker report output:** `report.output_dir` defaults to `.` (the container working directory). Inside a container that path is **ephemeral** — the Excel/heatmap files vanish when the container stops. Point `report.output_dir` at a **mounted volume** (for example `/data` in the example above) so reports land on the host, **or** retrieve them through the dashboard **Download** button / the `/report` and `/reports/{session_id}` API endpoints.
 
 ### Build from source
 

--- a/docs/TECH_GUIDE.pt_BR.md
+++ b/docs/TECH_GUIDE.pt_BR.md
@@ -122,8 +122,8 @@ uv run python main.py --config config.yaml --diff <session_a_uuid> <session_b_uu
 uv run python main.py --config config.yaml --export-dsar <session_uuid>
 uv run python main.py --config config.yaml --export-dsar <session_uuid> --dsar-output dsar_export.json
 
-# Iniciar o servidor da API (equivalente a python main.py --web)
-uv run python main.py --config config.yaml --web --port 8088
+# Iniciar o servidor da API (texto plano explícito; veja o gate de transporte em "API REST")
+uv run python main.py --config config.yaml --web --allow-insecure-http --port 8088
 ```
 
 Suporte opcional NoSQL (MongoDB, Redis):
@@ -273,30 +273,39 @@ python main.py --config config.yaml --tenant "Acme Corp" --technician "Alice V."
 ### API REST (porta padrão 8088)
 
 ```bash
-# Iniciar API na porta padrão 8088
-python main.py --config config.yaml --web
+# Iniciar API na porta padrão 8088 (texto plano é aceite explícito — veja o gate abaixo)
+python main.py --config config.yaml --web --allow-insecure-http
 
 # Iniciar API em porta customizada
-python main.py --config config.yaml --web --port 9090
+python main.py --config config.yaml --web --allow-insecure-http --port 9090
 
-# Equivalente (sem usar a CLI do main.py)
+# TLS em vez de texto plano (recomendado fora do loopback)
+python main.py --config config.yaml --web --https-cert-file server.crt --https-key-file server.key --port 8088
+```
+
+**Gate de transporte:** `main.py --web` exige **ou** HTTPS (`--https-cert-file` / `--https-key-file`, ou o bloco `api` na config) **ou** o aceite explícito `--allow-insecure-http` (apenas loopback / laboratório). Caso contrário, termina com código **2** e erro no stderr — então um `--web` copiado-e-colado **sem** essa flag falha antes de qualquer varredura. Espelha [USAGE.pt_BR.md](USAGE.pt_BR.md#servidor-api---web).
+
+```bash
+# Não recomendado para adoção: ignora o gate de transporte do main.py E o
+# configure_dashboard_transport, então GET /status reporta mode: not_configured.
 uvicorn api.routes:app --host 0.0.0.0 --port 8088
 ```
 
 ## Argumentos da CLI (referência)
 
-| Argumento           | Modo                     | Descrição                                                                                                                                                                                                             | Exemplos                                             |
-| ---------           | ------                   | -------------                                                                                                                                                                                                         | ----------                                           |
-| `--config PATH`     | CLI e API                | Caminho do arquivo de config YAML/JSON. Padrão `config.yaml` se omitido.                                                                                                                                              | `--config config.yaml`, `--config configs/prod.yaml` |
-| `--web`             | Somente API              | Iniciar a API REST em vez de executar uma varredura única.                                                                                                                                                            | `--web`                                              |
-| `--port N`          | Somente API              | Porta da API REST quando `--web` está definido. Padrão `8088`. Ignorado no modo CLI único.                                                                                                                            | `--web --port 9090`                                  |
-| `--reset-data`      | Somente CLI (manutenção) | **Perigoso**: apaga todas as sessões de varredura, achados e falhas do SQLite, remove relatórios/heatmaps gerados em `report.output_dir` e registra o evento em `data_wipe_log` para auditoria. Não inicia varredura. | `--reset-data`                                       |
-| `--tenant NAME`     | Somente CLI (único)      | Nome opcional de customer/tenant para esta varredura. Armazenado em `scan_sessions.tenant_name`, exibido no dashboard e na planilha **Report info**.                                                                  | `--tenant "Acme Corp"`                               |
-| `--technician NAME` | Somente CLI (único)      | Nome opcional do técnico/operador responsável por esta varredura. Armazenado em `scan_sessions.technician_name`, exibido no dashboard e na planilha **Report info**.                                                  | `--technician "Alice V."`                         |
+**A referência completa e autoritativa da CLI (todas as 22 flags — `--config`, `--web`, `--host`, `--port`, `--https-cert-file` / `--https-key-file`, `--allow-insecure-http`, `--validate-config`, `--diff`, `--fail-on-new-high`, `--export-dsar` / `--dsar-output`, `--export-audit-trail`, `--scan-compressed`, `--content-type-check`, `--scan-stego`, `--jurisdiction-hint`, `--reset-data`, `--tenant`, `--technician`, …) está em [USAGE.pt_BR.md §1 — Interface de linha de comando](USAGE.pt_BR.md#1-interface-de-linha-de-comando-cli).** É a única fonte de verdade (mantida em sincronia com `main.py`); este guia não duplica uma cópia parcial. A lista viva é sempre `uv run python main.py --help`.
+
+Orientação rápida para as mais comuns:
+
+- `--config PATH` — config YAML/JSON (padrão `config.yaml`). Usada por CLI **e** API.
+- `--web` — sobe a API REST / dashboard em vez da varredura única (precisa do gate de transporte acima: `--allow-insecure-http` ou TLS).
+- `--port N` / `--host HOST` — bind do `--web` (padrão `127.0.0.1:8088`; `--host 0.0.0.0` só com controles de rede).
+- `--validate-config` — pré-voo dos alvos, sem varredura (exit 0 se OK).
+- `--reset-data` — **perigoso**: apaga sessões/achados/relatórios do SQLite (auditado em `data_wipe_log`).
 
 Ao usar a API (`--web`), o servidor carrega a config de **`CONFIG_PATH`** (variável de ambiente) ou `config.yaml` no diretório de trabalho se `--config` não for informado na CLI.
 
-**Dashboard web:** Com o servidor em execução, abra <http://localhost:8088/en/> (ou `/pt-br/`) para um dashboard simples: status da varredura, quantidade/qualidade dos dados descobertos (achados DB/FS, falhas), **gráfico de progresso ao longo do tempo** (total de achados e score de risco por sessão), campos opcionais para **tenant/customer** e **technician/operator** antes de iniciar uma varredura, sessões recentes (incluindo colunas tenant/technician) e links para **Reports** (lista e download) e **Configuration** (editar YAML no navegador). O `/` sem prefixo redireciona para o locale negociado (cookie, `Accept-Language`, config).
+**Dashboard web:** Com o servidor em execução, abra <http://localhost:8088/en/> (ou `/pt-br/`) para um dashboard simples: status da varredura, quantidade/qualidade dos dados descobertos (achados DB/FS, falhas), **gráfico de progresso ao longo do tempo** (total de achados e score de risco por sessão), campos opcionais para **tenant/customer** e **technician/operator** antes de iniciar uma varredura, sessões recentes (incluindo colunas tenant/technician) e links para **Reports** (lista e download) e **Configuration** (editar YAML no navegador). O `/` sem prefixo redireciona para o locale negociado (cookie, `Accept-Language`, config). O relatório baixa de duas formas: pelos endpoints da API acima (`/report`, `/reports/{session_id}`) **e** pelo botão **Download** na página **Reports** — para um passo a passo não técnico (abrir `/en/` → preencher tenant/technician → **Start scan** → **Reports** → **Download**), veja [USAGE.pt_BR.md — Painel web](USAGE.pt_BR.md#urls-principais).
 
 ## Rotas da API (resumo)
 
@@ -620,6 +629,8 @@ docker run -d -p 8088:8088 -v /path/to/your/data:/data -e CONFIG_PATH=/data/conf
 ```
 
 Prepare `/data/config.yaml` a partir de `deploy/config.example.yaml` (veja [deploy/DEPLOY.md](deploy/DEPLOY.md) ([pt-BR](deploy/DEPLOY.pt_BR.md))). Você pode optar por usar esta imagem como container instanciado em vez de puxar o código do Git e construir localmente.
+
+> **Saída do relatório no Docker:** `report.output_dir` tem padrão `.` (o diretório de trabalho do container). Dentro de um container esse caminho é **efêmero** — os arquivos Excel/heatmap somem quando o container para. Aponte `report.output_dir` para um **volume montado** (por exemplo `/data` no exemplo acima) para os relatórios caírem no host, **ou** recupere-os pelo botão **Download** do dashboard / pelos endpoints `/report` e `/reports/{session_id}` da API.
 
 ### Construir a partir do código
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -197,6 +197,14 @@ Pre-built images are on Docker Hub: `fabioleitao/data_boar:latest` ([hub.docker.
 
 When the API server is running, a **simple web dashboard** is available in the browser. **HTML pages use a locale prefix** (`/en/…`, `/pt-br/…` by default). Visiting `/`, `/config`, `/reports`, `/help`, or `/about` without a prefix **redirects** to the best match: **`db_locale` cookie** (if valid), then **`Accept-Language`**, then **`locale.default_locale`** in config (see `locale` block below). **JSON API routes** (`/status`, `/scan`, `/reports/{session_id}`, …) stay **without** a locale prefix.
 
+**Walkthrough (non-technical, first run):**
+
+1. **Open** the dashboard in a browser: `http://127.0.0.1:8088/en/` (or `/pt-br/`). It must be running first — see [REST API server (`--web`)](#rest-api-server---web) (plaintext needs `--allow-insecure-http`; off-loopback use TLS).
+2. **(Optional) Tag the run:** type a **tenant/customer** and **technician/operator** in the form fields — these appear on the report's **Report info** sheet.
+3. **Start scan:** click **Start scan**. The page polls status while the audit runs (`POST /scan` under the hood).
+4. **Open Reports:** when the scan finishes, go to the **Reports** page (`/en/reports`).
+5. **Download:** click **Download** on the session row to get the Excel report (and heatmap). No shell or API call needed.
+
 | Page              | URL (examples)                            | Description                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | ---               | ---                                       | ---                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | **Dashboard**     | `http://<host>:<port>/en/`               | Scan status (running/idle, current session, findings count), quantity/quality summary (DB findings, FS findings, failures, total), **“Progress over time” chart** (total findings + risk score per session), form inputs for **tenant/customer** and **technician/operator** before starting a scan, and a “Start scan” button. Recent sessions table shows session ID, started date, tenant, technician, findings, failures, and a download link. |

--- a/docs/USAGE.pt_BR.md
+++ b/docs/USAGE.pt_BR.md
@@ -160,6 +160,14 @@ Imagens pré-construídas estão no Docker Hub: `fabioleitao/data_boar:latest` (
 
 As páginas HTML usam **prefixo de idioma** (`/en/…`, `/pt-br/…`). Acessar `/`, `/reports`, `/config`, `/help` ou `/about` **sem** prefixo redireciona conforme cookie `db_locale`, cabeçalho `Accept-Language` e `locale.default_locale` no YAML (veja bloco `locale` em [USAGE.md](USAGE.md)). As rotas JSON da API continuam **sem** prefixo.
 
+**Passo a passo (não técnico, primeira execução):**
+
+1. **Abra** o painel no navegador: `http://127.0.0.1:8088/pt-br/` (ou `/en/`). O servidor precisa estar no ar antes — veja [Servidor API (`--web`)](#servidor-api---web) (texto plano exige `--allow-insecure-http`; fora do loopback use TLS).
+2. **(Opcional) Identifique a execução:** preencha **tenant/cliente** e **técnico/operador** nos campos do formulário — aparecem na planilha **Report info** do relatório.
+3. **Inicie a varredura:** clique em **Start scan**. A página acompanha o status enquanto a auditoria roda (`POST /scan` por baixo).
+4. **Abra Reports:** ao terminar, vá para a página **Reports** (`/pt-br/reports`).
+5. **Baixe:** clique em **Download** na linha da sessão para obter o relatório Excel (e o heatmap). Sem shell nem chamada de API.
+
 - **Dashboard:** `http://<host>:<port>/en/` (ou `/pt-br/`)
 - **Reports:** `http://<host>:<port>/en/reports`
 - **Configuration:** `http://<host>:<port>/en/config`

--- a/docs/ops/COMPLETAO_MESTRE_RELEASE_CHECKLIST_PROMPT.md
+++ b/docs/ops/COMPLETAO_MESTRE_RELEASE_CHECKLIST_PROMPT.md
@@ -142,6 +142,20 @@ Priorize a integridade do Windows dev workstation; ele é sua base de comando. S
 
 ---
 
+## Release 1.7.4 final — README checklist (migrated from README, #945)
+
+Moved out of the landing `README.md` (audience: evaluator / CISO, not internal release process — see #945). **Do not** tick these until release gate **[#406](https://github.com/FabioLeitao/data-boar/issues/406)** completes and **`1.7.4`** final is published ([issue #425](https://github.com/FabioLeitao/data-boar/issues/425)).
+
+- [ ] **Current release** banner: **1.7.3** → **1.7.4**
+- [ ] **Docker Hub:** confirm **`fabioleitao/data_boar:1.7.4`** and consumer **`latest`** moved per **[VERSIONING.md](../VERSIONING.md)** / **[DOCKER_IMAGE_RELEASE_ORDER.md](DOCKER_IMAGE_RELEASE_ORDER.md)**
+- [ ] **Working pre-release** line: remove or repoint (for example next **`1.7.5-rc`**)
+- [ ] README link to **`docs/releases/1.7.4.md`** in the shipping-notes row once final
+- [ ] **CHANGELOG:** fold **`Unreleased`** into **`## 1.7.4 (YYYY-MM-DD)`** using the GitHub/tag date
+- [ ] **README.pt_BR.md:** mirror banner completion
+- [ ] Confirm **`docs/USAGE.md`** (+ pt-BR) match any ship-time install/version callouts (**CONTRIBUTING** remains EN-canonical workflow)
+
+---
+
 ## Related
 
 - **[`COMPLETAO_OPERATOR_PROMPT_LIBRARY.md`](COMPLETAO_OPERATOR_PROMPT_LIBRARY.md)** — **`tier:`** shorthand + **`completao-chat-starter.ps1`**

--- a/docs/ops/COMPLETAO_MESTRE_RELEASE_CHECKLIST_PROMPT.pt_BR.md
+++ b/docs/ops/COMPLETAO_MESTRE_RELEASE_CHECKLIST_PROMPT.pt_BR.md
@@ -136,6 +136,20 @@ Priorize a integridade do Windows dev workstation; ele é sua base de comando. S
 
 ---
 
+## Release 1.7.4 final — checklist da README (migrado da README, #945)
+
+Retirado da landing `README.md` (público: avaliador / CISO, não processo interno de release — ver #945). **Não** marque estes itens até o gate de release **[#406](https://github.com/FabioLeitao/data-boar/issues/406)** concluir e o **`1.7.4`** final ser publicado ([issue #425](https://github.com/FabioLeitao/data-boar/issues/425)).
+
+- [ ] Banner **release atual**: **1.7.3** → **1.7.4**
+- [ ] **Docker Hub:** confirmar **`fabioleitao/data_boar:1.7.4`** e o **`latest`** de consumo movidos conforme **[VERSIONING.md](../VERSIONING.md)** / **[DOCKER_IMAGE_RELEASE_ORDER.md](DOCKER_IMAGE_RELEASE_ORDER.md)**
+- [ ] Linha de **pré-release de trabalho**: remover ou repontar (por exemplo, próximo **`1.7.5-rc`**)
+- [ ] Link da README para **`docs/releases/1.7.4.md`** na linha de notas quando final
+- [ ] **CHANGELOG:** dobrar **`Unreleased`** em **`## 1.7.4 (YYYY-MM-DD)`** usando a data do GitHub/tag
+- [ ] **README.pt_BR.md:** espelhar a conclusão do banner
+- [ ] Confirmar que **`docs/USAGE.md`** (+ pt-BR) batem com qualquer aviso de instalação/versão no momento do ship (**CONTRIBUTING** permanece o fluxo canônico em EN)
+
+---
+
 ## Ligações
 
 - **[`COMPLETAO_OPERATOR_PROMPT_LIBRARY.pt_BR.md`](COMPLETAO_OPERATOR_PROMPT_LIBRARY.pt_BR.md)** — taxonomia **`tier:`** + **`completao-chat-starter.ps1`**


### PR DESCRIPTION
## Summary

Fix doc-drift in the **entry docs** (`TECH_GUIDE`, `README` 30s-guide) vs source of truth (`origin/main`, `main.py`, `USAGE`). Audited read-only per #945; `USAGE`/code are integral — drift was in entry surfaces.

### ADOPTION-BLOCKERS
1. **TECH_GUIDE `--web` exit-2** — added `--allow-insecure-http` to every `--web` example + a transport-gate sentence mirroring `USAGE`; marked the `uvicorn` form "not recommended for adoption" (bypasses the gate → `mode: not_configured`).
2. **README 30s-guide bash-only** — Docker (any OS) is now the primary command; `./scripts/demo.sh` marked **Linux/macOS shell**; Windows/Python routed to QuickStart. Verified: `demo.sh` passes `--allow-insecure-http`; `docker run … demo` is a supported entrypoint arg.
3. **TECH_GUIDE CLI table 6/22** — replaced the partial table with a pointer to **USAGE §1** (single source of truth) + a short orientation list.

### README audience (per #945 comments)
4. Removed the usage instruction (long Quick start paragraph) → pointer to QuickStart + USAGE (kept Linux-libs and don't-commit-config caveats).
5. Removed the mid-page release/management block → one-line release pointer. 3 of 4 pieces already had a home (VERSIONING/CHANGELOG/docs/releases, CONTRIBUTING, AGENTS/blog); the **1.7.4-final checklist was preserved first** in `docs/ops/COMPLETAO_MESTRE_RELEASE_CHECKLIST_PROMPT.md` (+ pt-BR) before removal. Blog moved into the Maintainer footer.

### CONFUSING
- Numbered **Web dashboard walkthrough** added to `USAGE` (open `/en/` → tenant/technician → Start scan → Reports → Download).
- **Docker `output_dir`** note in TECH_GUIDE (default `.` is ephemeral → mount a volume or use dashboard/API).
- **Report-retrieval** cross-link (browser Download) added to TECH_GUIDE.

### Verified
- **QUICKSTART.md** audited with the same ruler — already clean (PowerShell primary + bash details, `--allow-insecure-http` present, Docker supported, output_dir pointer). No change needed.

All EN ↔ pt-BR pairs mirrored. `USAGE` not touched beyond the listed walkthrough. Release gate **not** closed.

## Test plan
- [x] `./scripts/check-all.sh` green (pre-commit + 1472 passed)
- [ ] CI green on PR

Closes #945

Made with [Cursor](https://cursor.com)