### PR TITLE
docs(use-cases): backup/data-protection criticality-overlay storyboard + GTM partner-channel thesis

### DIFF
--- a/docs/plans/PLAN_NEXT_WAVE_PLATFORM_AND_GTM.md
+++ b/docs/plans/PLAN_NEXT_WAVE_PLATFORM_AND_GTM.md
@@ -31,6 +31,16 @@ Define the next three execution fronts after:
 - Keep private personal/professional details in `docs/private/` and produce public-safe derivatives.
 - Align learning roadmap with shipping roadmap so certifications and academic work directly improve product value.
 
+## Partner channel thesis — data-protection / backup vendors (criticality overlay)
+
+Natural enterprise channel that complements **N2's** partner-friendly accelerator narrative. Backup / data-protection platforms (e.g. **Cohesity**, **Rubrik**, **Veeam**, **Commvault**, **Veritas**) already own the **install base** and already **fan data out** into snapshots, DR sites, and long-retention tiers — but their **own maturity checklists** ask the customer whether they have visibility into **which data is most critical / most sensitive**. That is exactly Data Boar's output.
+
+- **Positioning (one line):** the platform **asks** “do you know which data is most critical?”; Data Boar is the **answer** — a criticality/sensitivity **evidence overlay**, not a backup, restore, or recoverability claim.
+- **Why it qualifies leads cheaply:** the gap is **self-identified by the vendor's own assessment**, so the discovery workshop attaches to an existing budget conversation instead of creating a new one.
+- **Scope discipline:** keep it an **evidence overlay** — no recoverability guarantees, no DR product claims, no vendor certification. Ingest **restored/mounted read-only copies** and **export catalogues** as scan roots; reuse the file/compressed/SQL pipeline (ties to N2 scope-import accelerators).
+- **Buyer-facing narrative (generic, no vendor names):** [../use-cases/BACKUP_AND_DATA_PROTECTION_ESTATE_CRITICALITY.md](../use-cases/BACKUP_AND_DATA_PROTECTION_ESTATE_CRITICALITY.md) ([pt-BR](../use-cases/BACKUP_AND_DATA_PROTECTION_ESTATE_CRITICALITY.pt_BR.md)).
+- **Promotion gate:** stays a thesis until **repeatable revenue evidence** appears; only then promote a row in `PLANS_TODO.md` (*Partner / sector demand*) — do **not** add buyer-facing links into `docs/plans/`.
+
 ## Deliverables
 
 - One tracked doc slice per front.

--- a/docs/use-cases/BACKUP_AND_DATA_PROTECTION_ESTATE_CRITICALITY.md
+++ b/docs/use-cases/BACKUP_AND_DATA_PROTECTION_ESTATE_CRITICALITY.md
@@ -1,0 +1,42 @@
+# Use-case storyboard — backup / data-protection estate, criticality overlay
+
+**Português (Brasil):** [BACKUP_AND_DATA_PROTECTION_ESTATE_CRITICALITY.pt_BR.md](BACKUP_AND_DATA_PROTECTION_ESTATE_CRITICALITY.pt_BR.md)
+
+Documentation storyboard for organisations that already run an **enterprise backup, recovery, and data-protection platform** and need a **criticality / sensitivity overlay** on top of it. **Not** a backup/DR product, **not** a recoverability guarantee, and **not** a certification of any data-protection vendor.
+
+## Cast (generic roles)
+
+- **Organisation:** Enterprise or mid-market team that operates an **immutable-snapshot / cyber-resilience / backup platform** (DR copies, long-retention archives) across primary and secondary storage.
+- **Data subjects:** Employees, customers, and partners whose records live inside the protected estate (databases, file shares, mail, app data) — and, by extension, **every copy** the protection platform fans out.
+- **Systems:** Production shares/DBs that are **sources** of the backup estate, **restored/mounted read-only** copies, export catalogues, and the protection platform's own inventory/reports.
+
+## Storyboard (flow)
+
+1. **Protection without criticality** — the platform answers “is everything recoverable?”, but its own **maturity checklist** asks the harder question: “do you have visibility into **which** data is most critical or most sensitive?” That row stays blank.
+2. **The blind copy** — protection fans data out into snapshots, DR sites, and long-retention tiers; sensitive and critical records are now **multiplied** across the estate with **no criticality label**.
+3. **Boar sniffs (scoped, read-only)** — point Data Boar at **restored/mounted copies** or source shares/DBs on **read-only** access; PII density, sensitive categories, minors, and national-ID-like runs surface in the report heatmap.
+4. **Criticality overlay** — findings become the **criticality/sensitivity layer** the protection platform lacks: which shares, tables, and paths concentrate regulated data, and where retention and immutability matter most.
+5. **Human moment** — owners decide retention tiers, legal hold, and access scope; **counsel** interprets. The product does **not** decide criticality classes, perform backup/restore, or assert recoverability.
+
+## How Data Boar helps without deciding
+
+- **Answers the checklist gap** the protection platform itself raises (“which data is most critical?”) with **technical evidence**, not a recoverability claim.
+- **Prioritises** where sensitive data concentrates so retention, immutability, and DR spend can **follow criticality** instead of treating every copy alike.
+- **Does not** back up, restore, replicate, or certify recoverability; it **maps**, it does not protect.
+
+## Partner opportunity
+
+Partners who already sell or operate **enterprise backup / data-protection platforms** attach Data Boar as the **criticality and sensitivity discovery layer** that closes the “do you know what's most critical?” gap on the **vendor's own maturity assessment**. Sold as a **fixed-scope discovery workshop** against the existing install base, then handed to IT/DPO for retention and access decisions. The argument writes itself: the platform **asks** the question; Data Boar is the **answer**.
+
+## Product alignment (maintainers)
+
+Prioritise surfaces that ingest **restored/mounted copies and export catalogues** as scan roots (filesystem + compressed + SQL sampling on read-only mounts) and **criticality/sensitivity reporting** (heatmap, gravity tiers, jurisdiction hints). Keep positioning as an **evidence overlay**, not protection. **Do not** link execution sequencing from this buyer-facing page into `docs/plans/`; use the **Internal and reference** section of [docs/README.md](../README.md) as the maintainer entry point.
+
+**Signal strengths for this vertical:** `file_scan`, compressed-archive handling, optional SQL connectors, heatmap / compliance outputs, [REPORTS_AND_COMPLIANCE_OUTPUTS.md](../REPORTS_AND_COMPLIANCE_OUTPUTS.md), [ADDING_CONNECTORS.md](../ADDING_CONNECTORS.md).
+
+## Related docs
+
+- [use-cases/README.md](README.md) ([pt-BR](README.pt_BR.md))
+- [SERVICE_TIERS_SCOPE_TEMPLATE.md](../ops/SERVICE_TIERS_SCOPE_TEMPLATE.md) ([pt-BR](../ops/SERVICE_TIERS_SCOPE_TEMPLATE.pt_BR.md))
+- [DECISION_MAKER_VALUE_BRIEF.md](../DECISION_MAKER_VALUE_BRIEF.md) ([pt-BR](../DECISION_MAKER_VALUE_BRIEF.pt_BR.md))
+- [USAGE.md](../USAGE.md) ([pt-BR](../USAGE.pt_BR.md))

--- a/docs/use-cases/BACKUP_AND_DATA_PROTECTION_ESTATE_CRITICALITY.pt_BR.md
+++ b/docs/use-cases/BACKUP_AND_DATA_PROTECTION_ESTATE_CRITICALITY.pt_BR.md
@@ -1,0 +1,42 @@
+# Storyboard de caso de uso — parque de backup / proteção de dados, camada de criticidade
+
+**English:** [BACKUP_AND_DATA_PROTECTION_ESTATE_CRITICALITY.md](BACKUP_AND_DATA_PROTECTION_ESTATE_CRITICALITY.md)
+
+Storyboard em documentação para organizações que já operam uma **plataforma corporativa de backup, recuperação e proteção de dados** e precisam de uma **camada de criticidade / sensibilidade** sobre ela. **Não** é produto de backup/DR, **não** garante recuperabilidade e **não** certifica nenhum fornecedor de proteção de dados.
+
+## Elenco (papéis genéricos)
+
+- **Organização:** Equipe enterprise ou mid-market que opera uma **plataforma de snapshots imutáveis / ciber-resiliência / backup** (cópias de DR, arquivos de retenção longa) entre armazenamento primário e secundário.
+- **Titulares:** Funcionários, clientes e parceiros cujos registros vivem dentro do parque protegido (bancos, compartilhamentos, e-mail, dados de aplicação) — e, por extensão, **cada cópia** que a plataforma de proteção espalha.
+- **Sistemas:** Compartilhamentos/bancos de produção que são **fontes** do parque de backup, cópias **restauradas/montadas somente leitura**, catálogos de exportação e os próprios inventários/relatórios da plataforma de proteção.
+
+## Storyboard (fluxo)
+
+1. **Proteção sem criticidade** — a plataforma responde “está tudo recuperável?”, mas o **checklist de maturidade** dela mesma faz a pergunta mais difícil: “você tem visibilidade sobre **quais** dados são mais críticos ou mais sensíveis?” Essa linha fica em branco.
+2. **A cópia cega** — a proteção espalha os dados em snapshots, sites de DR e camadas de retenção longa; registros sensíveis e críticos agora estão **multiplicados** pelo parque **sem rótulo de criticidade**.
+3. **Boar fareja (com escopo, somente leitura)** — aponte o Data Boar para **cópias restauradas/montadas** ou compartilhamentos/bancos de origem em acesso **somente leitura**; densidade de PII, categorias sensíveis, menores e sequências tipo documento nacional aparecem no mapa de calor do relatório.
+4. **Camada de criticidade** — os achados viram a **camada de criticidade/sensibilidade** que falta à plataforma de proteção: quais compartilhamentos, tabelas e caminhos concentram dado regulado e onde retenção e imutabilidade mais importam.
+5. **Momento humano** — os donos decidem camadas de retenção, retenção legal (legal hold) e escopo de acesso; **assessoria** interpreta. O produto **não** decide classes de criticidade, **não** faz backup/restore e **não** afirma recuperabilidade.
+
+## Como o Data Boar ajuda sem decidir
+
+- **Responde ao gap do checklist** que a própria plataforma de proteção levanta (“quais dados são mais críticos?”) com **evidência técnica**, não com promessa de recuperabilidade.
+- **Prioriza** onde o dado sensível se concentra para que retenção, imutabilidade e gasto de DR possam **seguir a criticidade** em vez de tratar toda cópia igual.
+- **Não** faz backup, restauração, replicação nem certifica recuperabilidade; ele **mapeia**, não protege.
+
+## Oportunidade para parceiros
+
+Parceiros que já vendem ou operam **plataformas corporativas de backup / proteção de dados** acoplam o Data Boar como a **camada de descoberta de criticidade e sensibilidade** que fecha o gap “você sabe o que é mais crítico?” na **própria avaliação de maturidade do fornecedor**. Vendido como **oficina de descoberta de escopo fixo** sobre a base instalada e depois repassado ao TI/DPO para decisões de retenção e acesso. O argumento se escreve sozinho: a plataforma **faz** a pergunta; o Data Boar é a **resposta**.
+
+## Alinhamento de produto (maintainers)
+
+Priorize superfícies que ingerem **cópias restauradas/montadas e catálogos de exportação** como raízes de varredura (filesystem + compactados + amostragem SQL em montagens somente leitura) e **relatórios de criticidade/sensibilidade** (mapa de calor, camadas de gravidade, dicas de jurisdição). Mantenha o posicionamento como **camada de evidência**, não de proteção. **Não** coloque links de sequenciamento desta página voltada a compradores para `docs/plans/`; use a seção **Internal and reference** do [docs/README.pt_BR.md](../README.pt_BR.md) como entrada para maintainers.
+
+**Sinais fortes neste vertical:** `file_scan`, tratamento de arquivos compactados, conectores SQL opcionais, mapa de calor / saídas de compliance, [REPORTS_AND_COMPLIANCE_OUTPUTS.pt_BR.md](../REPORTS_AND_COMPLIANCE_OUTPUTS.pt_BR.md), [ADDING_CONNECTORS.pt_BR.md](../ADDING_CONNECTORS.pt_BR.md).
+
+## Documentação relacionada
+
+- [use-cases/README.pt_BR.md](README.pt_BR.md) ([EN](README.md))
+- [SERVICE_TIERS_SCOPE_TEMPLATE.pt_BR.md](../ops/SERVICE_TIERS_SCOPE_TEMPLATE.pt_BR.md) ([EN](../ops/SERVICE_TIERS_SCOPE_TEMPLATE.md))
+- [DECISION_MAKER_VALUE_BRIEF.pt_BR.md](../DECISION_MAKER_VALUE_BRIEF.pt_BR.md) ([EN](../DECISION_MAKER_VALUE_BRIEF.md))
+- [USAGE.pt_BR.md](../USAGE.pt_BR.md) ([EN](../USAGE.md))

--- a/docs/use-cases/README.md
+++ b/docs/use-cases/README.md
@@ -22,6 +22,7 @@ Each storyboard includes **Partner opportunity** (how to qualify a lead) and **P
 | [REAL_ESTATE_AND_CONDOMINIUM_MANAGEMENT.md](REAL_ESTATE_AND_CONDOMINIUM_MANAGEMENT.md) | Rental / condo / property SMB, high document churn | Unit folders, contracts, consumption logs, simple CRM exports |
 | [NGO_MIGRANT_WELCOME_AND_HUMANITARIAN_FILES.md](NGO_MIGRANT_WELCOME_AND_HUMANITARIAN_FILES.md) | Humanitarian intake; ethics-first minimisation | Intake spreadsheets, scans (where allowed), messaging exports |
 | [EDTECH_LMS_EXPORTS_AND_MINORS.md](EDTECH_LMS_EXPORTS_AND_MINORS.md) | LMS rosters, guardians, minors; due diligence hygiene | LMS CSV/JSON, tickets, optional roster SQL |
+| [BACKUP_AND_DATA_PROTECTION_ESTATE_CRITICALITY.md](BACKUP_AND_DATA_PROTECTION_ESTATE_CRITICALITY.md) | Backup / data-protection estate; criticality overlay on the install base | Restored/mounted read-only copies, source shares/DBs, export catalogues |
 
 ## Adding future storyboards
 

--- a/docs/use-cases/README.pt_BR.md
+++ b/docs/use-cases/README.pt_BR.md
@@ -22,6 +22,7 @@ Cada storyboard inclui **Oportunidade para parceiros** (como qualificar um lead)
 | [REAL_ESTATE_AND_CONDOMINIUM_MANAGEMENT.pt_BR.md](REAL_ESTATE_AND_CONDOMINIUM_MANAGEMENT.pt_BR.md) | Locação / condomínio / gestão predial PME, alto fluxo documental | Pastas por unidade, contratos, registos de consumo, exportações simples de CRM |
 | [NGO_MIGRANT_WELCOME_AND_HUMANITARIAN_FILES.pt_BR.md](NGO_MIGRANT_WELCOME_AND_HUMANITARIAN_FILES.pt_BR.md) | Triagem humanitária; minimização ética em primeiro lugar | Planilhas de triagem, digitalizações (onde permitido), exportações de mensagens |
 | [EDTECH_LMS_EXPORTS_AND_MINORS.pt_BR.md](EDTECH_LMS_EXPORTS_AND_MINORS.pt_BR.md) | Listas LMS, responsáveis, menores; higiene para due diligence | CSV/JSON do LMS, tickets, SQL opcional de listas |
+| [BACKUP_AND_DATA_PROTECTION_ESTATE_CRITICALITY.pt_BR.md](BACKUP_AND_DATA_PROTECTION_ESTATE_CRITICALITY.pt_BR.md) | Parque de backup / proteção de dados; camada de criticidade sobre a base instalada | Cópias restauradas/montadas somente leitura, compartilhamentos/bancos de origem, catálogos de exportação |
 
 ## Incluir novos storyboards no futuro
 


### PR DESCRIPTION
## Summary

Captures the **data-protection / backup vendor partnership** angle as versioned docs, respecting the repo's audience-segmentation and CI guardrails.

The thesis: backup / data-protection platforms own the install base and fan data out into snapshots, DR sites, and long-retention tiers — yet their **own maturity checklists** ask the customer whether they have visibility into **which data is most critical / most sensitive**. That gap is exactly Data Boar's output. *The platform asks the question; Data Boar is the answer.*

## Changes

- **New buyer-facing storyboard (EN + pt-BR mirror)** — `docs/use-cases/BACKUP_AND_DATA_PROTECTION_ESTATE_CRITICALITY.md` (+ `.pt_BR.md`). Follows the existing storyboard structure (Cast / Storyboard flow / How Data Boar helps without deciding / Partner opportunity / Product alignment / Related docs). Kept **generic per convention** (no vendor names): a criticality/sensitivity evidence overlay on a protected estate; scan restored/mounted read-only copies + export catalogues.
- **Index registration** — added the pair to `docs/use-cases/README.md` and `README.pt_BR.md` tables.
- **Internal GTM plan** — `docs/plans/PLAN_NEXT_WAVE_PLATFORM_AND_GTM.md` gains a *Partner channel thesis* naming the vendor category (Cohesity, Rubrik, Veeam, Commvault, Veritas) as the enterprise channel, tied to N2's accelerator narrative, with a promotion gate (only becomes a `PLANS_TODO` row once repeatable revenue evidence exists).

## Convention notes

- Buyer-facing storyboards stay **generic and vendor-neutral** (`not a vendor certification`); the specific vendor names live only in the internal `docs/plans/` GTM doc.
- No buyer-facing doc links into `docs/plans/` (ADR-0004 audience-segmentation guard).

## Validation

Full CI (`uv` / pytest / Rust) could not build in this environment — `mysqlclient`'s native build fails without system MySQL/pkg-config. The relevant doc guards were replicated and run directly:

- ✅ markdownlint (MD009/012/024/036/051/060/031/034) — all 5 files clean
- ✅ pt-BR locale guard — no pt-PT markers
- ✅ external-docs no-plan-links guard — buyer-facing storyboards clean
- ✅ `scripts/check_hubs.py` OK · PII gatekeeper no hits

Docs-only change; please confirm CI is green on the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DtPQkCLi3eXiEynBFagPcF)_