### PR TITLE
fix(maestro): P0 completão bundle — tmux, sentinels, collect, doas env

### DIFF
--- a/scripts/maestro/Collect-Artifacts.ps1
+++ b/scripts/maestro/Collect-Artifacts.ps1
@@ -8,6 +8,7 @@
  Puxa logs operacionais do repo remoto (<path>/log/) e salva no cofre privado sem expor no GH publico.
 
  #956: scans gravam em <repo>/log/ (benchmark-rc export_audit_trail), nao ~/log/.
+ #968: Join-Path (Linux-safe); nunca [SUCCESS] com diretorio vazio.
 #>
 
 param(
@@ -16,6 +17,14 @@ param(
 
 Set-StrictMode -Version 2
 
+function Get-CollectArtifactCount {
+    param([Parameter(Mandatory = $true)][string]$Dir)
+    if (-not (Test-Path -LiteralPath $Dir)) {
+        return 0
+    }
+    return @(Get-ChildItem -LiteralPath $Dir -File -ErrorAction SilentlyContinue).Count
+}
+
 # 1. Caminho Canônico do Cofre Privado
 $privateReportsDir = (Resolve-Path "$PSScriptRoot/../../docs/private/homelab/reports").Path
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
@@ -23,36 +32,41 @@ $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
 Write-Host "   [Collect] Baixando artefatos de $($Node.hostname)..." -ForegroundColor DarkCyan
 
 $repoPath = [string]$Node.path -replace "^~", "~"
-$localDestDir = "$privateReportsDir\coleta_$($Node.hostname)_$timestamp"
-New-Item -ItemType Directory -Force -Path $localDestDir > $null
+$localDestDir = Join-Path $privateReportsDir "coleta_$($Node.hostname)_$timestamp"
+New-Item -ItemType Directory -Force -Path $localDestDir | Out-Null
 
 $remoteBase = "$($Node.user)@$($Node.hostname)"
 $repoLogPattern = "${remoteBase}:${repoPath}/log/*.log"
 $repoAuditPattern = "${remoteBase}:${repoPath}/log/audit_trail*.log"
 
-$collected = $false
-scp -q -o BatchMode=yes $repoLogPattern "$localDestDir\" > $null 2>&1
-if ($LASTEXITCODE -eq 0) { $collected = $true }
+$usedLegacy = $false
+$scpAttempted = $false
 
-if (-not $collected) {
-    scp -q -o BatchMode=yes $repoAuditPattern "$localDestDir\" > $null 2>&1
-    if ($LASTEXITCODE -eq 0) { $collected = $true }
+scp -q -o BatchMode=yes $repoLogPattern "${localDestDir}/" > $null 2>&1
+$scpAttempted = $true
+
+if ((Get-CollectArtifactCount -Dir $localDestDir) -eq 0) {
+    scp -q -o BatchMode=yes $repoAuditPattern "${localDestDir}/" > $null 2>&1
 }
 
 # Legacy fallback: operator home ~/log (pre-#956); warn once if only legacy exists.
-if (-not $collected) {
+if ((Get-CollectArtifactCount -Dir $localDestDir) -eq 0) {
     $legacyPattern = "${remoteBase}:~/log/*.log"
-    scp -q -o BatchMode=yes $legacyPattern "$localDestDir\" > $null 2>&1
-    if ($LASTEXITCODE -eq 0) {
-        Write-Warning "      [WARNING] Coleta usou fallback ~/log (esperado <repo>/log/ apos #956)."
-        $collected = $true
+    scp -q -o BatchMode=yes $legacyPattern "${localDestDir}/" > $null 2>&1
+    if ((Get-CollectArtifactCount -Dir $localDestDir) -gt 0) {
+        $usedLegacy = $true
     }
 }
 
-if ($collected) {
-    Write-Host "      [SUCCESS] Artefatos salvos em private/homelab/reports/" -ForegroundColor Green
+$artifactCount = Get-CollectArtifactCount -Dir $localDestDir
+if ($artifactCount -gt 0) {
+    if ($usedLegacy) {
+        Write-Warning "      [WARNING] Coleta usou fallback ~/log (esperado <repo>/log/ apos #956)."
+    }
+    Write-Host "      [SUCCESS] $artifactCount artefato(s) em $localDestDir" -ForegroundColor Green
     return $true
-} else {
-    Write-Warning "      [WARNING] Sem artefatos em $($Node.path)/log/ (ou falha scp) em $($Node.hostname)."
-    return $false
 }
+
+$hint = if ($scpAttempted) { "scp executou mas nenhum arquivo aterrou" } else { "scp nao tentado" }
+Write-Error "      [REAL FAIL] Collect: zero artefatos em $localDestDir ($hint; host $($Node.hostname); repo log em $($Node.path)/log/)."
+return $false

--- a/scripts/maestro/Collect-Artifacts.ps1
+++ b/scripts/maestro/Collect-Artifacts.ps1
@@ -5,7 +5,9 @@
 
 .SYNOPSIS
  Coletor de Telemetria Fria (Post-Flight).
- Puxa logs operacionais do Tmux remoto e salva no cofre privado sem expor no GH público.
+ Puxa logs operacionais do repo remoto (<path>/log/) e salva no cofre privado sem expor no GH publico.
+
+ #956: scans gravam em <repo>/log/ (benchmark-rc export_audit_trail), nao ~/log/.
 #>
 
 param(
@@ -20,21 +22,37 @@ $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
 
 Write-Host "   [Collect] Baixando artefatos de $($Node.hostname)..." -ForegroundColor DarkCyan
 
-# 2. Cria uma pasta específica para a coleta desta sessão
-# 2.1 Puxa todos os logs da pasta ~/log/ do nó para a pasta local de coleta, renomeando com Host + Timestamp para não sobrescrever o histórico
+$repoPath = [string]$Node.path -replace "^~", "~"
 $localDestDir = "$privateReportsDir\coleta_$($Node.hostname)_$timestamp"
 New-Item -ItemType Directory -Force -Path $localDestDir > $null
 
-$targetLogPattern = "$($Node.user)@$($Node.hostname):~/log/*.log"
-scp -q -o BatchMode=yes $targetLogPattern "$localDestDir\" > $null 2>&1
+$remoteBase = "$($Node.user)@$($Node.hostname)"
+$repoLogPattern = "${remoteBase}:${repoPath}/log/*.log"
+$repoAuditPattern = "${remoteBase}:${repoPath}/log/audit_trail*.log"
 
-if ($LASTEXITCODE -eq 0) {
+$collected = $false
+scp -q -o BatchMode=yes $repoLogPattern "$localDestDir\" > $null 2>&1
+if ($LASTEXITCODE -eq 0) { $collected = $true }
+
+if (-not $collected) {
+    scp -q -o BatchMode=yes $repoAuditPattern "$localDestDir\" > $null 2>&1
+    if ($LASTEXITCODE -eq 0) { $collected = $true }
+}
+
+# Legacy fallback: operator home ~/log (pre-#956); warn once if only legacy exists.
+if (-not $collected) {
+    $legacyPattern = "${remoteBase}:~/log/*.log"
+    scp -q -o BatchMode=yes $legacyPattern "$localDestDir\" > $null 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        Write-Warning "      [WARNING] Coleta usou fallback ~/log (esperado <repo>/log/ apos #956)."
+        $collected = $true
+    }
+}
+
+if ($collected) {
     Write-Host "      [SUCCESS] Artefatos salvos em private/homelab/reports/" -ForegroundColor Green
-
-    # Opcional de limpeza: limpa a sujeira na borda após coleta bem-sucedida (descomente se quiser)
-    # ssh -q -o BatchMode=yes "$($Node.user)@$($Node.hostname)" "rm -f ~/log/*.log"
     return $true
 } else {
-    Write-Warning "      [WARNING] Sem artefatos (ou falha) em $($Node.hostname)."
+    Write-Warning "      [WARNING] Sem artefatos em $($Node.path)/log/ (ou falha scp) em $($Node.hostname)."
     return $false
 }

--- a/scripts/maestro/Lab-MaestroCommon.ps1
+++ b/scripts/maestro/Lab-MaestroCommon.ps1
@@ -1,0 +1,87 @@
+#Requires -Version 7.6.1
+<#
+.NAME
+ scripts/maestro/Lab-MaestroCommon.ps1
+
+.SYNOPSIS
+ Shared helpers for Maestro handlers (#955 tmux isolation, #954 doas/sudo + env, sentinel contract).
+
+.DESCRIPTION
+ Dot-source from handlers: . "$PSScriptRoot/../Lab-MaestroCommon.ps1" (handlers) or
+ . "$PSScriptRoot/Lab-MaestroCommon.ps1" (Maestro.ps1).
+#>
+
+Set-StrictMode -Version 2
+
+function Get-HandlerTmuxSessionName {
+    param([Parameter(Mandatory = $true)][string]$Persona)
+    # Per-persona session avoids C-c clobber on multi-persona nodes (#955).
+    return "completao_$Persona"
+}
+
+function Get-LabPrivilegeInvoker {
+    <#
+    Returns the non-interactive privilege prefix for remote ensure scripts (#954).
+    doas strips caller env by default; callers must use: $priv env VAR=val bash script.sh
+    #>
+    return @'
+if command -v doas >/dev/null 2>&1; then echo "doas -n"; elif command -v sudo >/dev/null 2>&1; then echo "sudo -n"; else echo "NO_PRIV"; fi
+'@.Trim()
+}
+
+function Build-EnsureRemoteCommand {
+    param(
+        [Parameter(Mandatory = $true)][string]$EnsureScript,
+        [Parameter(Mandatory = $true)][string]$EnsureMode,
+        [hashtable]$EnvVars = @{}
+    )
+    $privProbe = Get-LabPrivilegeInvoker
+    $envPairs = @()
+    foreach ($k in $EnvVars.Keys) {
+        $v = [string]$EnvVars[$k]
+        if ($v -match "[\s'`"$\\]") {
+            throw "Build-EnsureRemoteCommand: unsafe env value for $k"
+        }
+        $envPairs += "${k}=${v}"
+    }
+    $envPrefix = if ($envPairs.Count -gt 0) { "env $($envPairs -join ' ') " } else { "" }
+    return "PRIV=`$($privProbe)` ; if [ `"`$PRIV`" = NO_PRIV ]; then echo '[Ensure] NO doas/sudo on host' >&2; exit 2; fi; `$PRIV $envPrefix bash $EnsureScript $EnsureMode 2>&1"
+}
+
+function Invoke-HandlerTmuxPayload {
+    param(
+        [Parameter(Mandatory = $true)]$Node,
+        [Parameter(Mandatory = $true)][string]$Persona,
+        [Parameter(Mandatory = $true)][string]$PayloadB64,
+        [switch]$SkipSessionCreate
+    )
+    $session = Get-HandlerTmuxSessionName -Persona $Persona
+    $create = if ($SkipSessionCreate) { "" } else {
+        "tmux has-session -t $session 2>/dev/null || tmux new-session -d -s $session ; "
+    }
+    # No C-c: dedicated session per persona (#955).
+    $tmuxCmd = "${create}tmux send-keys -t $session 'echo $PayloadB64 | base64 -d | bash' Enter"
+    ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 `
+        "$($Node.user)@$($Node.hostname)" "$tmuxCmd"
+    return $LASTEXITCODE
+}
+
+function Write-RemoteSentinel {
+    param(
+        [Parameter(Mandatory = $true)]$Node,
+        [Parameter(Mandatory = $true)][string]$SentinelFile,
+        [Parameter(Mandatory = $true)][int]$ExitCode
+    )
+    $dir = Split-Path -Parent $SentinelFile
+    $cmd = "mkdir -p $dir && echo $ExitCode > $SentinelFile"
+    ssh -q -o BatchMode=yes -o ConnectTimeout=15 "$($Node.user)@$($Node.hostname)" "$cmd" > $null 2>&1
+}
+
+function Clear-RemoteSentinel {
+    param(
+        [Parameter(Mandatory = $true)]$Node,
+        [Parameter(Mandatory = $true)][string]$SentinelFile
+    )
+    $cmd = "rm -f $SentinelFile"
+    ssh -q -o BatchMode=yes -o ConnectTimeout=15 "$($Node.user)@$($Node.hostname)" "$cmd" > $null 2>&1
+}

--- a/scripts/maestro/Maestro.ps1
+++ b/scripts/maestro/Maestro.ps1
@@ -39,6 +39,13 @@ $inventory = Get-Content $inventoryPath | ConvertFrom-Json
 Write-Host "--- [Maestro] Iniciando Turno no Lab-Op (Ref: $Ref) ---" -ForegroundColor Cyan
 $warningCount = 0
 $realFailCount = 0
+# Personas that write /tmp/databoar_handler/<persona>_sentinel.txt (#831); web is inline health only.
+$script:SentinelPersonas = @(
+    "baremetal", "docker", "podman", "dockerswarm", "lxd", "microk8s",
+    "target_nfs", "target_cifs", "target_sshfs",
+    "target_postgres", "target_mariadb", "target_mongodb"
+)
+$dispatchedSentinelPersonas = [System.Collections.Generic.List[string]]::new()
 
 # SRE FIX (#950): Fase de Pre-flight Global. O build do artefato de container so
 # faz sentido se ALGUM no do inventario tem persona de container
@@ -118,6 +125,10 @@ $globalReport = foreach ($node in $inventory.lab_members) {
                 if ($LASTEXITCODE -ne 0) {
                     $realFailCount++
                     Write-Warning "      [REAL FAIL] Handler '$persona' em $($node.hostname) saiu com exit $LASTEXITCODE"
+                } elseif ($script:SentinelPersonas -contains $persona) {
+                    if (-not ($dispatchedSentinelPersonas -contains $persona)) {
+                        $dispatchedSentinelPersonas.Add($persona)
+                    }
                 }
             } else {
                 Write-Warning "      [WARNING] Handler ausente para persona '$persona' em $($node.hostname): $handler"
@@ -132,6 +143,17 @@ $onlineHosts = @{}
 foreach ($status in $globalReport) {
     if (($status.SSH -eq "UP") -and $status.Node) {
         $onlineHosts[$status.Node] = $true
+    }
+}
+
+# --- [Fase de Agregacao Real] Poll handler sentinels (#949 / #831) ---
+if (-not $Collect -and $dispatchedSentinelPersonas.Count -gt 0) {
+    $waitHosts = @($onlineHosts.Keys)
+    Write-Host "`n--- [Maestro] Aguardando sentinels reais ($($dispatchedSentinelPersonas.Count) persona(s)) ---" -ForegroundColor DarkGray
+    & "$PSScriptRoot/Wait-HandlerSentinel.ps1" -Personas @($dispatchedSentinelPersonas) -OnlyHosts $waitHosts
+    if ($LASTEXITCODE -ne 0) {
+        $realFailCount++
+        Write-Warning "      [REAL FAIL] Wait-HandlerSentinel reportou falha ou timeout (resultado de scan/provision, nao so injecao tmux)."
     }
 }
 

--- a/scripts/maestro/Sync-WorkingTree.ps1
+++ b/scripts/maestro/Sync-WorkingTree.ps1
@@ -107,7 +107,8 @@ if ($syncOk) {
     Write-Host "      [SUCCESS] $targetHost pronto em $finalPath." -ForegroundColor Green
     $Node.path = $finalPath
 
-    # Sessões tmux só fazem sentido com sync válido.
+    # Legacy tmux name kept pending operator attach workflow (#955 UX question).
+    # Multi-persona live runs inject into completao_<persona> (Lab-MaestroCommon.ps1).
     $tmuxInit = "tmux new-session -d -s completao 2>/dev/null || true ; tmux new-session -d -s monitor 2>/dev/null || true"
     ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$targetUser@$targetHost" "$tmuxInit" > $null 2>&1
 } else {

--- a/scripts/maestro/Sync-WorkingTree.ps1
+++ b/scripts/maestro/Sync-WorkingTree.ps1
@@ -107,7 +107,7 @@ if ($syncOk) {
     Write-Host "      [SUCCESS] $targetHost pronto em $finalPath." -ForegroundColor Green
     $Node.path = $finalPath
 
-    # Legacy tmux name kept pending operator attach workflow (#955 UX question).
+    # Legacy session `completao`: hook reservado p/ status central / observe-from-inside — ver #967.
     # Multi-persona live runs inject into completao_<persona> (Lab-MaestroCommon.ps1).
     $tmuxInit = "tmux new-session -d -s completao 2>/dev/null || true ; tmux new-session -d -s monitor 2>/dev/null || true"
     ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$targetUser@$targetHost" "$tmuxInit" > $null 2>&1

--- a/scripts/maestro/Sync-WorkingTree.ps1
+++ b/scripts/maestro/Sync-WorkingTree.ps1
@@ -6,6 +6,9 @@
 .SYNOPSIS
  Author: Fábio Leitão com apoio da Gemini e Cursosr IDE
  Missão principal: Sub-Orquestrador de sincronismo em pré-flight para o teste Completão funcionar no Lab-Op a partir do repo no gh ou da working tree no ambiente canônico de Dev principal no PC de desenvolvimento.
+
+ #969: rsync e pre-req; se falhar (ex. exit 12 / rsync ausente no remoto), fallback tar|ssh com mesmas exclusoes.
+ Narrow doas+apk rsync install fica para #958.
 #>
 
 param(
@@ -32,13 +35,83 @@ if ($Ref -eq "WorkingTree") {
     Write-Host "   [Ref-Fetch] Preparando versão $Ref em pasta efêmera no $targetHost" -ForegroundColor Yellow
 }
 
+function Test-SyncHashVerify {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepoRoot,
+        [Parameter(Mandatory = $true)][string]$RemoteUser,
+        [Parameter(Mandatory = $true)][string]$RemoteHost,
+        [Parameter(Mandatory = $true)][string]$RemotePath
+    )
+
+    $localPyprojectHash = (Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path $RepoRoot "pyproject.toml")).Hash.ToLower()
+    $localMaestroHash = (Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path $RepoRoot "scripts/maestro/Maestro.ps1")).Hash.ToLower()
+    $verifyCmd = "cd $RemotePath && sha256sum pyproject.toml scripts/maestro/Maestro.ps1 2>/dev/null"
+    $verifyOut = ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "${RemoteUser}@${RemoteHost}" "$verifyCmd"
+    if ($LASTEXITCODE -ne 0 -or -not $verifyOut) {
+        Write-Warning "      [WARNING] Nao foi possivel validar hash remoto pos-sync em $RemoteHost."
+        return $false
+    }
+
+    $remoteHashes = @{}
+    foreach ($line in $verifyOut) {
+        if ($line -match '^([0-9a-fA-F]{64})\s+(.+)$') {
+            $remoteHashes[$matches[2]] = $matches[1].ToLower()
+        }
+    }
+
+    if (($remoteHashes["pyproject.toml"] -ne $localPyprojectHash) -or ($remoteHashes["scripts/maestro/Maestro.ps1"] -ne $localMaestroHash)) {
+        Write-Warning "      [WARNING] Hash mismatch apos sync em $RemoteHost. Sync invalido para run."
+        return $false
+    }
+
+    Write-Host "      [Sync-Verify] Hash check OK (pyproject + Maestro)." -ForegroundColor DarkGray
+    return $true
+}
+
+function Invoke-SyncTarSshFallback {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepoRoot,
+        [Parameter(Mandatory = $true)][string]$RemoteUser,
+        [Parameter(Mandatory = $true)][string]$RemoteHost,
+        [Parameter(Mandatory = $true)][string]$RemotePath,
+        [int]$RsyncExitCode
+    )
+
+    Write-Warning "      [Sync-Fallback #969] rsync exit $RsyncExitCode em $RemoteHost; tentando tar|ssh (mesmas exclusoes que rsync; remoto pode nao ter rsync — ex. alpine)."
+    $escapedRoot = $RepoRoot -replace "'", "'\\''"
+    $tarPipeCmd = @"
+tar -czf - \
+  --exclude='.git' --exclude='.venv' --exclude='__pycache__' --exclude='.pytest_cache' \
+  --exclude='*.bundle' --exclude='docs/private' --exclude='*.log' --exclude='*.xlsx' \
+  --exclude='*.db' --exclude='data-boar-blackbox-audit.txt' --exclude='data-boar-*.tar' \
+  --exclude='.env' --exclude='.env.*' \
+  -C '$escapedRoot' . \
+| ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 \
+  ${RemoteUser}@${RemoteHost} "mkdir -p $RemotePath && tar -xzf - -C $RemotePath"
+"@
+
+    if ($IsWindows) {
+        wsl.exe -e bash -c $tarPipeCmd
+    } else {
+        bash -c $tarPipeCmd
+    }
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "      [Sync-Fallback] tar|ssh falhou em $RemoteHost (exit $LASTEXITCODE). Instalar rsync no remoto ou ver #958 (narrow doas apk)."
+        return $false
+    }
+
+    Write-Host "      [Sync-Fallback] tar|ssh OK em $RemoteHost." -ForegroundColor DarkGray
+    return $true
+}
+
 # 2. Garantir que o diretório existe (Silenciando banners do Linux remoto)
 ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$targetUser@$targetHost" "mkdir -p $finalPath" > $null 2>&1
 
 # 3. Lógica de Transferência
 $syncOk = $false
 if ($Ref -eq "WorkingTree") {
-    # Fluxo Evoluído: rsync (Delta Transfer) via WSL2
+    # Fluxo Evoluído: rsync (Delta Transfer) via WSL2 / bash nativo Linux
     $repoRoot = (Resolve-Path "$PSScriptRoot/../../").Path
 
     Push-Location $repoRoot
@@ -57,34 +130,12 @@ if ($Ref -eq "WorkingTree") {
     $exitCode = $LASTEXITCODE
     Pop-Location
 
-    if ($exitCode -ne 0) {
-        Write-Warning "      [WARNING] O rsync via WSL2 falhou no nó $targetHost (Exit Code $exitCode)."
+    if ($exitCode -eq 0) {
+        $syncOk = Test-SyncHashVerify -RepoRoot $repoRoot -RemoteUser $targetUser -RemoteHost $targetHost -RemotePath $finalPath
     } else {
-        # Verificacao SRE: confirmar que arquivos chave ficaram identicos no host remoto.
-        $localPyprojectHash = (Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path $repoRoot "pyproject.toml")).Hash.ToLower()
-        $localMaestroHash = (Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path $repoRoot "scripts/maestro/Maestro.ps1")).Hash.ToLower()
-        $verifyCmd = "cd $finalPath && sha256sum pyproject.toml scripts/maestro/Maestro.ps1 2>/dev/null"
-        $verifyOut = ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$targetUser@$targetHost" "$verifyCmd"
-        if ($LASTEXITCODE -ne 0 -or -not $verifyOut) {
-            Write-Warning "      [WARNING] Nao foi possivel validar hash remoto pos-rsync em $targetHost."
-        } else {
-            $remoteHashes = @{}
-            foreach ($line in $verifyOut) {
-                if ($line -match '^([0-9a-fA-F]{64})\s+(.+)$') {
-                    $remoteHashes[$matches[2]] = $matches[1].ToLower()
-                }
-            }
-            $hashOk = $true
-            if (($remoteHashes["pyproject.toml"] -ne $localPyprojectHash) -or ($remoteHashes["scripts/maestro/Maestro.ps1"] -ne $localMaestroHash)) {
-                $hashOk = $false
-            }
-
-            if ($hashOk) {
-                Write-Host "      [Sync-Verify] Hash check OK (pyproject + Maestro)." -ForegroundColor DarkGray
-                $syncOk = $true
-            } else {
-                Write-Warning "      [WARNING] Hash mismatch apos rsync em $targetHost. Sync invalido para run."
-            }
+        Write-Warning "      [WARNING] rsync falhou no no $targetHost (exit $exitCode)."
+        if (Invoke-SyncTarSshFallback -RepoRoot $repoRoot -RemoteUser $targetUser -RemoteHost $targetHost -RemotePath $finalPath -RsyncExitCode $exitCode) {
+            $syncOk = Test-SyncHashVerify -RepoRoot $repoRoot -RemoteUser $targetUser -RemoteHost $targetHost -RemotePath $finalPath
         }
     }
 } else {
@@ -117,4 +168,3 @@ if ($syncOk) {
 
 # Retorna boolean puro para o Maestro.
 return [bool]$syncOk
-

--- a/scripts/maestro/Sync-WorkingTree.ps1
+++ b/scripts/maestro/Sync-WorkingTree.ps1
@@ -79,16 +79,7 @@ function Invoke-SyncTarSshFallback {
 
     Write-Warning "      [Sync-Fallback #969] rsync exit $RsyncExitCode em $RemoteHost; tentando tar|ssh (mesmas exclusoes que rsync; remoto pode nao ter rsync — ex. alpine)."
     $escapedRoot = $RepoRoot -replace "'", "'\\''"
-    $tarPipeCmd = @"
-tar -czf - \
-  --exclude='.git' --exclude='.venv' --exclude='__pycache__' --exclude='.pytest_cache' \
-  --exclude='*.bundle' --exclude='docs/private' --exclude='*.log' --exclude='*.xlsx' \
-  --exclude='*.db' --exclude='data-boar-blackbox-audit.txt' --exclude='data-boar-*.tar' \
-  --exclude='.env' --exclude='.env.*' \
-  -C '$escapedRoot' . \
-| ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 \
-  ${RemoteUser}@${RemoteHost} "mkdir -p $RemotePath && tar -xzf - -C $RemotePath"
-"@
+    $tarPipeCmd = "tar -czf - --exclude='.git' --exclude='.venv' --exclude='__pycache__' --exclude='.pytest_cache' --exclude='*.bundle' --exclude='docs/private' --exclude='*.log' --exclude='*.xlsx' --exclude='*.db' --exclude='data-boar-blackbox-audit.txt' --exclude='data-boar-*.tar' --exclude='.env' --exclude='.env.*' -C '$escapedRoot' . | ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 ${RemoteUser}@${RemoteHost} `"mkdir -p $RemotePath && tar -xzf - -C $RemotePath`""
 
     if ($IsWindows) {
         wsl.exe -e bash -c $tarPipeCmd

--- a/scripts/maestro/Wait-HandlerSentinel.ps1
+++ b/scripts/maestro/Wait-HandlerSentinel.ps1
@@ -23,6 +23,7 @@
 param(
     [Parameter(Mandatory = $true)]
     [string[]]$Personas,
+    [string[]]$OnlyHosts = @(),
     [int]$TimeoutSec = 900,
     [int]$PollSec = 10
 )
@@ -41,6 +42,9 @@ $sentinelDir = "/tmp/databoar_handler"
 # Build list of (node, persona) pairs to wait for
 $targets = [System.Collections.Generic.List[PSCustomObject]]::new()
 foreach ($node in $inventory.lab_members) {
+    if ($OnlyHosts.Count -gt 0 -and ($OnlyHosts -notcontains $node.hostname)) {
+        continue
+    }
     foreach ($persona in $Personas) {
         if ($node.personas -contains $persona) {
             $targets.Add([PSCustomObject]@{

--- a/scripts/maestro/handlers/Handle-baremetal.ps1
+++ b/scripts/maestro/handlers/Handle-baremetal.ps1
@@ -32,6 +32,8 @@ param(
     [string]$BenchHealthUrl = ""
 )
 
+. "$PSScriptRoot/../Lab-MaestroCommon.ps1"
+
 # Allowlist: reject Ref values that could inject shell metacharacters (#830)
 $safeRefPattern = '^(WorkingTree|stable|beta|v\d+\.\d+\.\d+(-[\w.]+)?)$'
 if ($Ref -notmatch $safeRefPattern) {
@@ -63,15 +65,14 @@ $sentinelFile = "$sentinelDir/baremetal_sentinel.txt"
 # Backtick-$ (`$) produces a literal $ that survives into the bash command. (#830)
 # Node.path is used as-is: bash handles ~ expansion; base64 encoding removes quoting risk.
 $nodePath    = $Node.path
-$payload     = "cd $nodePath && echo 'Iniciando Baremetal Smoke ($modoTexto)...' && ${benchEnvPrefix}bash ./scripts/lab-completao-host-smoke.sh $smokeArgText ; _rc=`$? ; mkdir -p $sentinelDir ; echo `$_rc > $sentinelFile ; exit `$_rc"
+$payload     = "rm -f $sentinelFile ; cd $nodePath && echo 'Iniciando Baremetal Smoke ($modoTexto)...' && ${benchEnvPrefix}bash ./scripts/lab-completao-host-smoke.sh $smokeArgText ; _rc=`$? ; mkdir -p $sentinelDir ; echo `$_rc > $sentinelFile ; exit `$_rc"
 
 # Base64-encode the payload: eliminates ALL shell-quoting issues in tmux send-keys. (#830)
 $payloadB64  = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($payload))
 
-# Ctrl+C clears the prompt, sleep avoids SIGINT/text race, then type decoded payload.
-$tmuxCmd = "tmux send-keys -t completao C-c ; sleep 0.5 ; tmux send-keys -t completao 'echo $payloadB64 | base64 -d | bash' Enter"
-
-ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$($Node.user)@$($Node.hostname)" "$tmuxCmd"
+# Per-persona tmux session (no C-c clobber) (#955).
+$injectExit = Invoke-HandlerTmuxPayload -Node $Node -Persona "baremetal" -PayloadB64 $payloadB64
+$LASTEXITCODE = $injectExit
 
 if ($LASTEXITCODE -eq 0) {
     Write-Host "      [SUCCESS] Orquestracao injetada no Tmux com sucesso." -ForegroundColor Green

--- a/scripts/maestro/handlers/Handle-docker.ps1
+++ b/scripts/maestro/handlers/Handle-docker.ps1
@@ -30,6 +30,8 @@ param(
     [string]$BenchHealthUrl = ""
 )
 
+. "$PSScriptRoot/../Lab-MaestroCommon.ps1"
+
 # Allowlist: reject Ref values that could inject shell metacharacters (#830)
 $safeRefPattern = '^(WorkingTree|stable|beta|v\d+\.\d+\.\d+(-[\w.]+)?)$'
 if ($Ref -notmatch $safeRefPattern) {
@@ -60,13 +62,12 @@ $sentinelDir  = "/tmp/databoar_handler"
 $sentinelFile = "$sentinelDir/docker_sentinel.txt"
 
 $nodePath = $Node.path
-$payload  = "cd $nodePath && echo 'Iniciando Docker Smoke ($modoTexto)...' && ${benchEnvPrefix}bash ./scripts/lab-completao-host-smoke.sh $smokeArgText ; _rc=`$? ; mkdir -p $sentinelDir ; echo `$_rc > $sentinelFile ; exit `$_rc"
+$payload  = "rm -f $sentinelFile ; cd $nodePath && echo 'Iniciando Docker Smoke ($modoTexto)...' && ${benchEnvPrefix}bash ./scripts/lab-completao-host-smoke.sh $smokeArgText ; _rc=`$? ; mkdir -p $sentinelDir ; echo `$_rc > $sentinelFile ; exit `$_rc"
 
 # Base64-encode to eliminate shell-quoting issues in tmux send-keys. (#830)
 $payloadB64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($payload))
-$tmuxCmd    = "tmux send-keys -t completao C-c ; sleep 0.5 ; tmux send-keys -t completao 'echo $payloadB64 | base64 -d | bash' Enter"
-
-ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$($Node.user)@$($Node.hostname)" "$tmuxCmd"
+$injectExit = Invoke-HandlerTmuxPayload -Node $Node -Persona "docker" -PayloadB64 $payloadB64
+$LASTEXITCODE = $injectExit
 
 if ($LASTEXITCODE -eq 0) {
     Write-Host "      [SUCCESS] Orquestracao Docker.io ou CE injetada no Tmux com sucesso." -ForegroundColor Green

--- a/scripts/maestro/handlers/Handle-dockerswarm.ps1
+++ b/scripts/maestro/handlers/Handle-dockerswarm.ps1
@@ -30,6 +30,8 @@ param(
     [string]$BenchHealthUrl = ""
 )
 
+. "$PSScriptRoot/../Lab-MaestroCommon.ps1"
+
 # Allowlist: reject Ref values that could inject shell metacharacters (#830)
 $safeRefPattern = '^(WorkingTree|stable|beta|v\d+\.\d+\.\d+(-[\w.]+)?)$'
 if ($Ref -notmatch $safeRefPattern) {
@@ -60,13 +62,12 @@ $sentinelDir  = "/tmp/databoar_handler"
 $sentinelFile = "$sentinelDir/dockerswarm_sentinel.txt"
 
 $nodePath = $Node.path
-$payload  = "cd $nodePath && echo 'Iniciando DockerSwarm Smoke ($modoTexto)...' && ${benchEnvPrefix}bash ./scripts/lab-completao-host-smoke.sh $smokeArgText ; _rc=`$? ; mkdir -p $sentinelDir ; echo `$_rc > $sentinelFile ; exit `$_rc"
+$payload  = "rm -f $sentinelFile ; cd $nodePath && echo 'Iniciando DockerSwarm Smoke ($modoTexto)...' && ${benchEnvPrefix}bash ./scripts/lab-completao-host-smoke.sh $smokeArgText ; _rc=`$? ; mkdir -p $sentinelDir ; echo `$_rc > $sentinelFile ; exit `$_rc"
 
 # Base64-encode to eliminate shell-quoting issues in tmux send-keys. (#830)
 $payloadB64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($payload))
-$tmuxCmd    = "tmux send-keys -t completao C-c ; sleep 0.5 ; tmux send-keys -t completao 'echo $payloadB64 | base64 -d | bash' Enter"
-
-ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$($Node.user)@$($Node.hostname)" "$tmuxCmd"
+$injectExit = Invoke-HandlerTmuxPayload -Node $Node -Persona "dockerswarm" -PayloadB64 $payloadB64
+$LASTEXITCODE = $injectExit
 
 if ($LASTEXITCODE -eq 0) {
     Write-Host "      [SUCCESS] Orquestracao Docker Swarm injetada no Tmux com sucesso." -ForegroundColor Green

--- a/scripts/maestro/handlers/Handle-lxd.ps1
+++ b/scripts/maestro/handlers/Handle-lxd.ps1
@@ -30,6 +30,8 @@ param(
     [string]$BenchHealthUrl = ""
 )
 
+. "$PSScriptRoot/../Lab-MaestroCommon.ps1"
+
 # Allowlist: reject Ref values that could inject shell metacharacters (#830)
 $safeRefPattern = '^(WorkingTree|stable|beta|v\d+\.\d+\.\d+(-[\w.]+)?)$'
 if ($Ref -notmatch $safeRefPattern) {
@@ -53,12 +55,17 @@ if ($BenchCompare) { $benchEnv += "LAB_COMPLETAO_BENCH_COMPARE=1" }
 if (-not [string]::IsNullOrWhiteSpace($BenchRunId)) { $benchEnv += "LAB_COMPLETAO_BENCH_RUN_ID=$BenchRunId" }
 $benchEnvPrefix = if ($benchEnv.Count -gt 0) { ($benchEnv -join " ") + " " } else { "" }
 
+# Sentinel path for pass/fail aggregation (#831) - declare before early exits
+$sentinelDir  = "/tmp/databoar_handler"
+$sentinelFile = "$sentinelDir/lxd_sentinel.txt"
+
 # 1. Verifica se LXD esta ativo e lista containers
 $lxcCheck = ssh -q -o BatchMode=yes -o ConnectTimeout=8 "$($Node.user)@$($Node.hostname)" "lxc list --format csv 2>/dev/null | head -n 10 || echo LXD_UNAVAILABLE"
 
 if ($LASTEXITCODE -ne 0 -or $lxcCheck -match "LXD_UNAVAILABLE") {
     Write-Warning "      [ERROR] LXD indisponivel em $($Node.hostname). Verifique 'lxc list'."
-    return
+    Write-RemoteSentinel -Node $Node -SentinelFile $sentinelFile -ExitCode 1
+    exit 1
 }
 
 Write-Host "      [LXD] Containers ativos:" -ForegroundColor DarkGray
@@ -73,25 +80,21 @@ if (-not $containerName) {
         Write-Warning "      [WARN] Nenhum container 'data-boar' encontrado. Usando primeiro RUNNING: $containerName"
     } else {
         Write-Warning "      [ERROR] Nenhum container LXC em estado RUNNING em $($Node.hostname). Smoke nao disparado."
-        return
+        Write-RemoteSentinel -Node $Node -SentinelFile $sentinelFile -ExitCode 1
+        exit 1
     }
 } else {
     $containerName = $containerName -split ',' | Select-Object -First 1
 }
 
-# Sentinel path for pass/fail aggregation (#831)
-$sentinelDir  = "/tmp/databoar_handler"
-$sentinelFile = "$sentinelDir/lxd_sentinel.txt"
-
 # 3. Injeta smoke via tmux -> lxc exec
 # Base64-encode to eliminate shell-quoting issues in lxc exec + tmux send-keys. (#830)
 $nodePath   = $Node.path
 $innerCmd   = "cd $nodePath 2>/dev/null || cd /app && ${benchEnvPrefix}bash ./scripts/lab-completao-host-smoke.sh $smokeArgText"
-$payload    = "lxc exec $containerName -- bash -c '$innerCmd' ; _rc=`$? ; mkdir -p $sentinelDir ; echo `$_rc > $sentinelFile ; exit `$_rc"
+$payload    = "rm -f $sentinelFile ; lxc exec $containerName -- bash -c '$innerCmd' ; _rc=`$? ; mkdir -p $sentinelDir ; echo `$_rc > $sentinelFile ; exit `$_rc"
 $payloadB64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($payload))
-$tmuxCmd    = "tmux send-keys -t completao C-c ; sleep 0.5 ; tmux send-keys -t completao 'echo $payloadB64 | base64 -d | bash' Enter"
-
-ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$($Node.user)@$($Node.hostname)" "$tmuxCmd"
+$injectExit = Invoke-HandlerTmuxPayload -Node $Node -Persona "lxd" -PayloadB64 $payloadB64
+$LASTEXITCODE = $injectExit
 
 if ($LASTEXITCODE -eq 0) {
     Write-Host "      [SUCCESS] Smoke LXD injetado no Tmux em $($Node.hostname) (container: $containerName)." -ForegroundColor Green

--- a/scripts/maestro/handlers/Handle-microk8s.ps1
+++ b/scripts/maestro/handlers/Handle-microk8s.ps1
@@ -29,6 +29,8 @@ param(
     [string]$BenchHealthUrl = ""
 )
 
+. "$PSScriptRoot/../Lab-MaestroCommon.ps1"
+
 # Allowlist: reject Ref values that could inject shell metacharacters (#830)
 $safeRefPattern = '^(WorkingTree|stable|beta|v\d+\.\d+\.\d+(-[\w.]+)?)$'
 if ($Ref -notmatch $safeRefPattern) {
@@ -61,7 +63,8 @@ $k8sCheck = ssh -q -o BatchMode=yes -o ConnectTimeout=8 "$($Node.user)@$($Node.h
 
 if ($LASTEXITCODE -ne 0 -or $k8sCheck -match "MICROK8S_UNAVAILABLE") {
     Write-Warning "      [ERROR] MicroK8s indisponivel em $($Node.hostname). Verifique 'microk8s status'."
-    return
+    Write-RemoteSentinel -Node $Node -SentinelFile $sentinelFile -ExitCode 1
+    exit 1
 }
 
 Write-Host "      [MicroK8s] Status:" -ForegroundColor DarkGray
@@ -75,10 +78,10 @@ $nodePath = $Node.path
 
 if (-not $podName) {
     Write-Warning "      [WARN] Nenhum pod 'data-boar' Running em $($Node.hostname). Fallback para baremetal path."
-    $payload    = "cd $nodePath && ${benchEnvPrefix}bash ./scripts/lab-completao-host-smoke.sh $smokeArgText ; _rc=`$? ; mkdir -p $sentinelDir ; echo `$_rc > $sentinelFile ; exit `$_rc"
+    $payload    = "rm -f $sentinelFile ; cd $nodePath && ${benchEnvPrefix}bash ./scripts/lab-completao-host-smoke.sh $smokeArgText ; _rc=`$? ; mkdir -p $sentinelDir ; echo `$_rc > $sentinelFile ; exit `$_rc"
     $payloadB64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($payload))
-    $tmuxCmd    = "tmux send-keys -t completao C-c ; sleep 0.5 ; tmux send-keys -t completao 'echo $payloadB64 | base64 -d | bash' Enter"
-    ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$($Node.user)@$($Node.hostname)" "$tmuxCmd"
+    $injectExit = Invoke-HandlerTmuxPayload -Node $Node -Persona "microk8s" -PayloadB64 $payloadB64
+    if ($injectExit -ne 0) { exit 1 }
     return
 }
 
@@ -87,11 +90,10 @@ Write-Host "      [MicroK8s] Pod encontrado: $podName" -ForegroundColor DarkGray
 # 3. Injeta smoke via tmux -> kubectl exec
 # Base64-encode to eliminate shell-quoting issues in kubectl exec + tmux send-keys. (#830)
 $innerCmd   = "cd $nodePath 2>/dev/null || cd /app && ${benchEnvPrefix}bash ./scripts/lab-completao-host-smoke.sh $smokeArgText"
-$payload    = "microk8s kubectl exec $podName -- bash -c '$innerCmd' ; _rc=`$? ; mkdir -p $sentinelDir ; echo `$_rc > $sentinelFile ; exit `$_rc"
+$payload    = "rm -f $sentinelFile ; microk8s kubectl exec $podName -- bash -c '$innerCmd' ; _rc=`$? ; mkdir -p $sentinelDir ; echo `$_rc > $sentinelFile ; exit `$_rc"
 $payloadB64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($payload))
-$tmuxCmd    = "tmux send-keys -t completao C-c ; sleep 0.5 ; tmux send-keys -t completao 'echo $payloadB64 | base64 -d | bash' Enter"
-
-ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$($Node.user)@$($Node.hostname)" "$tmuxCmd"
+$injectExit = Invoke-HandlerTmuxPayload -Node $Node -Persona "microk8s" -PayloadB64 $payloadB64
+$LASTEXITCODE = $injectExit
 
 if ($LASTEXITCODE -eq 0) {
     Write-Host "      [SUCCESS] Smoke MicroK8s injetado no Tmux em $($Node.hostname) (pod: $podName)." -ForegroundColor Green

--- a/scripts/maestro/handlers/Handle-podman.ps1
+++ b/scripts/maestro/handlers/Handle-podman.ps1
@@ -31,6 +31,8 @@ param(
     [string]$BenchHealthUrl = ""
 )
 
+. "$PSScriptRoot/../Lab-MaestroCommon.ps1"
+
 # Allowlist: reject Ref values that could inject shell metacharacters (#830)
 $safeRefPattern = '^(WorkingTree|stable|beta|v\d+\.\d+\.\d+(-[\w.]+)?)$'
 if ($Ref -notmatch $safeRefPattern) {
@@ -61,13 +63,12 @@ $sentinelDir  = "/tmp/databoar_handler"
 $sentinelFile = "$sentinelDir/podman_sentinel.txt"
 
 $nodePath = $Node.path
-$payload  = "cd $nodePath && echo 'Iniciando Podman Smoke ($modoTexto)...' && ${benchEnvPrefix}bash ./scripts/lab-completao-host-smoke.sh $smokeArgText ; _rc=`$? ; mkdir -p $sentinelDir ; echo `$_rc > $sentinelFile ; exit `$_rc"
+$payload  = "rm -f $sentinelFile ; cd $nodePath && echo 'Iniciando Podman Smoke ($modoTexto)...' && ${benchEnvPrefix}bash ./scripts/lab-completao-host-smoke.sh $smokeArgText ; _rc=`$? ; mkdir -p $sentinelDir ; echo `$_rc > $sentinelFile ; exit `$_rc"
 
 # Base64-encode to eliminate shell-quoting issues in tmux send-keys. (#830)
 $payloadB64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($payload))
-$tmuxCmd    = "tmux send-keys -t completao C-c ; sleep 0.5 ; tmux send-keys -t completao 'echo $payloadB64 | base64 -d | bash' Enter"
-
-ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$($Node.user)@$($Node.hostname)" "$tmuxCmd"
+$injectExit = Invoke-HandlerTmuxPayload -Node $Node -Persona "podman" -PayloadB64 $payloadB64
+$LASTEXITCODE = $injectExit
 
 if ($LASTEXITCODE -eq 0) {
     Write-Host "      [SUCCESS] Orquestracao Podman injetada no Tmux com sucesso." -ForegroundColor Green

--- a/scripts/maestro/handlers/Handle-target_cifs.ps1
+++ b/scripts/maestro/handlers/Handle-target_cifs.ps1
@@ -17,8 +17,7 @@
  Sentinel (#831): payload writes /tmp/databoar_handler/target_cifs_sentinel.txt with
  the IO monitor result so Maestro can verify CIFS target readiness.
 
- Quote/escape safety (#830): IO monitor payload is base64-encoded before tmux injection;
- ensure script path uses canonical repo path from Node.path.
+ Privilege (#954): doas vs sudo; env VAR=val bash. Deep apply-fail must not mask ready=0.
 #>
 
 param(
@@ -32,18 +31,24 @@ param(
     [string]$BenchHealthUrl = ""
 )
 
+. "$PSScriptRoot/../Lab-MaestroCommon.ps1"
+
 Write-Host "   [Target-CIFS] Certificando alvo CIFS e disparando orquestracao (Deep: $Deep) em $($Node.hostname)..." -ForegroundColor Magenta
 
-$linuxPath    = $Node.path -replace "^~", "`$HOME"
 $repoPath     = $Node.path -replace "^~", "`$HOME"
-# Ensure scripts always use canonical repo path (not ephemeral versioned checkout)
-# so the path matches the narrow sudoers entry exactly.
 $canonicalRepo = ($repoPath -replace "-v[0-9]+\.[0-9]+\.[0-9]+[^/]*$", "")
 $ensureScript = "$canonicalRepo/scripts/labop-smb-server-ensure.sh"
 
+$sentinelDir  = "/tmp/databoar_handler"
+$sentinelFile = "$sentinelDir/target_cifs_sentinel.txt"
+
 # --- Phase 1: SMB server-side ensure (service + port + firewall) ---
 $ensureMode = if ($Deep) { "--apply" } else { "--check" }
-$ensureCmd  = "sudo -n bash $ensureScript $ensureMode 2>&1"
+$ensureEnv = @{}
+if ($Node.PSObject.Properties["lab_op_subnet"] -and $Node.lab_op_subnet) {
+    $ensureEnv["LAB_OP_SUBNET"] = [string]$Node.lab_op_subnet
+}
+$ensureCmd = Build-EnsureRemoteCommand -EnsureScript $ensureScript -EnsureMode $ensureMode -EnvVars $ensureEnv
 
 Write-Host "      [CIFS-Ensure] Running: $ensureMode on $($Node.hostname)" -ForegroundColor DarkGray
 $ensureOut = ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 `
@@ -55,21 +60,17 @@ if ($ensureOut) { $ensureOut | ForEach-Object { Write-Host "        $_" -Foregro
 if ($ensureExit -eq 0) {
     Write-Host "      [SUCCESS] CIFS server-side validated: $($Node.hostname):$($Node.path)" -ForegroundColor Green
 } elseif ($Deep) {
-    Write-Warning "      [WARNING] CIFS ensure --apply returned exit $ensureExit on $($Node.hostname). Continuing (non-fatal)."
+    Write-Warning "      [REAL FAIL] CIFS ensure --apply returned exit $ensureExit on $($Node.hostname)."
+    Write-RemoteSentinel -Node $Node -SentinelFile $sentinelFile -ExitCode 1
+    exit 1
 } else {
     Write-Warning "      [WARNING] CIFS ensure --check returned exit $ensureExit on $($Node.hostname). Run with -Deep to attempt remediation."
 }
 
 # --- Phase 2: IO monitoring in tmux ---
-# Sentinel path for pass/fail aggregation (#831)
-$sentinelDir  = "/tmp/databoar_handler"
-$sentinelFile = "$sentinelDir/target_cifs_sentinel.txt"
-
-# Base64-encode IO monitor payload to eliminate shell-quoting issues. (#830)
-$ioPayload  = "echo TARGET_ACTIVE at \$(date +%H:%M:%S) > ~/.labop-status && mkdir -p ~/log $sentinelDir && vmstat 5 | tee ~/log/target_cifs_io.log ; echo \$? > $sentinelFile"
+$repoLogDir = "$repoPath/log"
+$ioPayload  = "rm -f $sentinelFile ; mkdir -p $repoLogDir $sentinelDir ; echo 0 > $sentinelFile ; echo TARGET_ACTIVE at \$(date +%H:%M:%S) > ~/.labop-status && vmstat 5 | tee $repoLogDir/target_cifs_io.log"
 $payloadB64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($ioPayload))
-$tmuxCmd    = "tmux send-keys -t completao C-c ; sleep 0.5 ; tmux send-keys -t completao 'echo $payloadB64 | base64 -d | bash' Enter"
-ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 `
-    "$($Node.user)@$($Node.hostname)" "$tmuxCmd" > $null 2>&1
+$null = Invoke-HandlerTmuxPayload -Node $Node -Persona "target_cifs" -PayloadB64 $payloadB64
 
-Write-Host "      [CIFS] IO monitor injected in tmux on $($Node.hostname)." -ForegroundColor DarkGreen
+Write-Host "      [CIFS] IO monitor injected in tmux session $(Get-HandlerTmuxSessionName -Persona 'target_cifs') on $($Node.hostname)." -ForegroundColor DarkGreen

--- a/scripts/maestro/handlers/Handle-target_mariadb.ps1
+++ b/scripts/maestro/handlers/Handle-target_mariadb.ps1
@@ -22,10 +22,19 @@ param(
     [string]$BenchHealthUrl = ""
 )
 
+. "$PSScriptRoot/../Lab-MaestroCommon.ps1"
+
 Write-Host "   [Target-MariaDB] Provisionando MariaDB sintetico em $($Node.hostname)..." -ForegroundColor Magenta
+
+$sentinelDir  = "/tmp/databoar_handler"
+$sentinelFile = "$sentinelDir/target_mariadb_sentinel.txt"
 
 $remoteCmd = @'
 set -e
+SENTINEL="__SENTINEL__"
+mkdir -p "$(dirname "$SENTINEL")"
+_rc=0
+trap '_rc=$?; echo $_rc > "$SENTINEL"; exit $_rc' EXIT
 cd __NODE_PATH__/deploy/lab-smoke-stack
 pick_port() {
   local default_port="$1"
@@ -68,6 +77,7 @@ fi
 echo "TARGET_MARIADB_READY port=${CHOSEN_PORT} at $(date +'%H:%M:%S')" > ~/.labop-status
 echo "TARGET_MARIADB_READY port=${CHOSEN_PORT}"
 '@
+$remoteCmd = $remoteCmd.Replace("__SENTINEL__", $sentinelFile)
 $remoteCmd = $remoteCmd.Replace("__NODE_PATH__", [string]$Node.path) -replace "`r", ""
 
 $out = ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$($Node.user)@$($Node.hostname)" "$remoteCmd"
@@ -80,4 +90,6 @@ if ($LASTEXITCODE -eq 0 -and $out -match "TARGET_MARIADB_READY") {
     }
 } else {
     Write-Warning "      [WARNING] Falha ao provisionar target_mariadb em $($Node.hostname)."
+    Write-RemoteSentinel -Node $Node -SentinelFile $sentinelFile -ExitCode 1
+    exit 1
 }

--- a/scripts/maestro/handlers/Handle-target_mongodb.ps1
+++ b/scripts/maestro/handlers/Handle-target_mongodb.ps1
@@ -22,10 +22,19 @@ param(
     [string]$BenchHealthUrl = ""
 )
 
+. "$PSScriptRoot/../Lab-MaestroCommon.ps1"
+
 Write-Host "   [Target-MongoDB] Provisionando MongoDB sintetico em $($Node.hostname)..." -ForegroundColor Magenta
+
+$sentinelDir  = "/tmp/databoar_handler"
+$sentinelFile = "$sentinelDir/target_mongodb_sentinel.txt"
 
 $remoteCmd = @'
 set -e
+SENTINEL="__SENTINEL__"
+mkdir -p "$(dirname "$SENTINEL")"
+_rc=0
+trap '_rc=$?; echo $_rc > "$SENTINEL"; exit $_rc' EXIT
 cd __NODE_PATH__/deploy/lab-smoke-stack
 pick_port() {
   local default_port="$1"
@@ -64,6 +73,7 @@ fi
 echo "TARGET_MONGODB_READY port=${CHOSEN_PORT} at $(date +'%H:%M:%S')" > ~/.labop-status
 echo "TARGET_MONGODB_READY port=${CHOSEN_PORT}"
 '@
+$remoteCmd = $remoteCmd.Replace("__SENTINEL__", $sentinelFile)
 $remoteCmd = $remoteCmd.Replace("__NODE_PATH__", [string]$Node.path) -replace "`r", ""
 
 $out = ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$($Node.user)@$($Node.hostname)" "$remoteCmd"
@@ -76,4 +86,6 @@ if ($LASTEXITCODE -eq 0 -and $out -match "TARGET_MONGODB_READY") {
     }
 } else {
     Write-Warning "      [WARNING] Falha ao provisionar target_mongodb em $($Node.hostname)."
+    Write-RemoteSentinel -Node $Node -SentinelFile $sentinelFile -ExitCode 1
+    exit 1
 }

--- a/scripts/maestro/handlers/Handle-target_nfs.ps1
+++ b/scripts/maestro/handlers/Handle-target_nfs.ps1
@@ -19,6 +19,10 @@
 
  Quote/escape safety (#830): IO monitor payload is base64-encoded before tmux injection;
  ensure script path uses canonical repo path from Node.path.
+
+ Privilege (#954): doas vs sudo via Build-EnsureRemoteCommand; env VAR=val bash so doas
+ does not strip LAB_* (even though ensure auto-detects NFS svc today).
+ Deep (#949 bundle): ensure --apply failure must NOT mask as ready=0.
 #>
 
 param(
@@ -32,24 +36,26 @@ param(
     [string]$BenchHealthUrl = ""
 )
 
+. "$PSScriptRoot/../Lab-MaestroCommon.ps1"
+
 Write-Host "   [Target-NFS] Certificando alvo NFS e disparando orquestracao (Deep: $Deep) em $($Node.hostname)..." -ForegroundColor Magenta
 
-$linuxPath = $Node.path -replace "^~", "`$HOME"
 $repoPath  = $Node.path -replace "^~", "`$HOME"
-# Ensure scripts always use canonical repo path (not ephemeral versioned checkout)
 $canonicalRepo = ($repoPath -replace "-v[0-9]+\.[0-9]+\.[0-9]+[^/]*$", "")
 $ensureScript = "$canonicalRepo/scripts/labop-nfs-server-ensure.sh"
 
+$sentinelDir  = "/tmp/databoar_handler"
+$sentinelFile = "$sentinelDir/target_nfs_sentinel.txt"
+
 # --- Phase 1: NFS server-side ensure (service + export + port + firewall) ---
 $ensureMode = if ($Deep) { "--apply" } else { "--check" }
-# Pass inventory-driven service/pkg info via env vars (sudo -n preserves LAB_* if sudoers allows,
-# or scripts read them when running as root via sudo - they are set in the SSH session env)
-$nfsSvc  = if ($Node.PSObject.Properties["nfs_svc"] -and $Node.nfs_svc) { $Node.nfs_svc } else { "" }
-$pkgMgr  = if ($Node.PSObject.Properties["pkg_mgr"] -and $Node.pkg_mgr) { $Node.pkg_mgr } else { "" }
-$envPrefix = ""
-if ($nfsSvc)  { $envPrefix += "LAB_NFS_SVC='$nfsSvc' " }
-if ($pkgMgr)  { $envPrefix += "LAB_PKG_MGR='$pkgMgr' " }
-$ensureCmd  = "${envPrefix}sudo -n bash $ensureScript $ensureMode 2>&1"
+$ensureEnv = @{}
+if ($Node.PSObject.Properties["nfs_svc"] -and $Node.nfs_svc) { $ensureEnv["LAB_NFS_SVC"] = [string]$Node.nfs_svc }
+if ($Node.PSObject.Properties["pkg_mgr"] -and $Node.pkg_mgr) { $ensureEnv["LAB_PKG_MGR"] = [string]$Node.pkg_mgr }
+if ($Node.PSObject.Properties["lab_op_subnet"] -and $Node.lab_op_subnet) {
+    $ensureEnv["LAB_OP_SUBNET"] = [string]$Node.lab_op_subnet
+}
+$ensureCmd = Build-EnsureRemoteCommand -EnsureScript $ensureScript -EnsureMode $ensureMode -EnvVars $ensureEnv
 
 Write-Host "      [NFS-Ensure] Running: $ensureMode on $($Node.hostname)" -ForegroundColor DarkGray
 $ensureOut = ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 `
@@ -61,21 +67,18 @@ if ($ensureOut) { $ensureOut | ForEach-Object { Write-Host "        $_" -Foregro
 if ($ensureExit -eq 0) {
     Write-Host "      [SUCCESS] NFS server-side validated: $($Node.hostname):$($Node.path)" -ForegroundColor Green
 } elseif ($Deep) {
-    Write-Warning "      [WARNING] NFS ensure --apply returned exit $ensureExit on $($Node.hostname). Continuing (non-fatal)."
+    Write-Warning "      [REAL FAIL] NFS ensure --apply returned exit $ensureExit on $($Node.hostname)."
+    Write-RemoteSentinel -Node $Node -SentinelFile $sentinelFile -ExitCode 1
+    exit 1
 } else {
     Write-Warning "      [WARNING] NFS ensure --check returned exit $ensureExit on $($Node.hostname). Run with -Deep to attempt remediation."
 }
 
 # --- Phase 2: IO monitoring in tmux ---
-# Sentinel path for pass/fail aggregation (#831)
-$sentinelDir  = "/tmp/databoar_handler"
-$sentinelFile = "$sentinelDir/target_nfs_sentinel.txt"
-
-# Base64-encode IO monitor payload to eliminate shell-quoting issues. (#830)
-$ioPayload  = "echo TARGET_ACTIVE at \$(date +%H:%M:%S) > ~/.labop-status && mkdir -p ~/log $sentinelDir && vmstat 5 | tee ~/log/target_nfs_io.log ; echo \$? > $sentinelFile"
+# Early readiness sentinel (0) before long-running vmstat; non-Deep may continue after check warn.
+$repoLogDir = "$repoPath/log"
+$ioPayload  = "rm -f $sentinelFile ; mkdir -p $repoLogDir $sentinelDir ; echo 0 > $sentinelFile ; echo TARGET_ACTIVE at \$(date +%H:%M:%S) > ~/.labop-status && vmstat 5 | tee $repoLogDir/target_nfs_io.log"
 $payloadB64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($ioPayload))
-$tmuxCmd    = "tmux send-keys -t completao C-c ; sleep 0.5 ; tmux send-keys -t completao 'echo $payloadB64 | base64 -d | bash' Enter"
-ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 `
-    "$($Node.user)@$($Node.hostname)" "$tmuxCmd" > $null 2>&1
+$null = Invoke-HandlerTmuxPayload -Node $Node -Persona "target_nfs" -PayloadB64 $payloadB64
 
-Write-Host "      [NFS] IO monitor injected in tmux on $($Node.hostname)." -ForegroundColor DarkGreen
+Write-Host "      [NFS] IO monitor injected in tmux session $(Get-HandlerTmuxSessionName -Persona 'target_nfs') on $($Node.hostname)." -ForegroundColor DarkGreen

--- a/scripts/maestro/handlers/Handle-target_postgres.ps1
+++ b/scripts/maestro/handlers/Handle-target_postgres.ps1
@@ -22,10 +22,19 @@ param(
     [string]$BenchHealthUrl = ""
 )
 
+. "$PSScriptRoot/../Lab-MaestroCommon.ps1"
+
 Write-Host "   [Target-Postgres] Provisionando Postgres sintetico em $($Node.hostname)..." -ForegroundColor Magenta
+
+$sentinelDir  = "/tmp/databoar_handler"
+$sentinelFile = "$sentinelDir/target_postgres_sentinel.txt"
 
 $remoteCmd = @'
 set -e
+SENTINEL="__SENTINEL__"
+mkdir -p "$(dirname "$SENTINEL")"
+_rc=0
+trap '_rc=$?; echo $_rc > "$SENTINEL"; exit $_rc' EXIT
 cd __NODE_PATH__/deploy/lab-smoke-stack
 pick_port() {
   local default_port="$1"
@@ -67,6 +76,7 @@ fi
 echo "TARGET_POSTGRES_READY port=${CHOSEN_PORT} at $(date +'%H:%M:%S')" > ~/.labop-status
 echo "TARGET_POSTGRES_READY port=${CHOSEN_PORT}"
 '@
+$remoteCmd = $remoteCmd.Replace("__SENTINEL__", $sentinelFile)
 $remoteCmd = $remoteCmd.Replace("__NODE_PATH__", [string]$Node.path) -replace "`r", ""
 
 $out = ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$($Node.user)@$($Node.hostname)" "$remoteCmd"
@@ -79,4 +89,6 @@ if ($LASTEXITCODE -eq 0 -and $out -match "TARGET_POSTGRES_READY") {
     }
 } else {
     Write-Warning "      [WARNING] Falha ao provisionar target_postgres em $($Node.hostname)."
+    Write-RemoteSentinel -Node $Node -SentinelFile $sentinelFile -ExitCode 1
+    exit 1
 }

--- a/scripts/maestro/handlers/Handle-target_sshfs.ps1
+++ b/scripts/maestro/handlers/Handle-target_sshfs.ps1
@@ -14,9 +14,10 @@
  versao do Maestro, sem assumir IPs ou caminhos fixos.
 
  Sentinel (#831): IO monitor payload writes /tmp/databoar_handler/target_sshfs_sentinel.txt
- with the vmstat start result so Maestro can verify SSHFS target readiness.
+ with early readiness (0) before long-running vmstat.
 
  Quote/escape safety (#830): IO monitor payload is base64-encoded before tmux injection.
+ Per-persona tmux session (#955).
 #>
 
 param(
@@ -30,10 +31,15 @@ param(
     [string]$BenchHealthUrl = ""
 )
 
+. "$PSScriptRoot/../Lab-MaestroCommon.ps1"
+
 Write-Host "   [Target-SSHFS] Certificando alvo de dados e disparando orquestracao concentrada (Deep: $Deep) em $($Node.hostname)..." -ForegroundColor Magenta
 
-# Traducao de SRE: Converte o '~' do JSON para a variavel $HOME do Linux
 $linuxPath = $Node.path -replace "^~", "`$HOME"
+$repoPath  = $Node.path -replace "^~", "`$HOME"
+
+$sentinelDir  = "/tmp/databoar_handler"
+$sentinelFile = "$sentinelDir/target_sshfs_sentinel.txt"
 
 # Validacao Resiliente: 'test -d' confia no Exit Code silencioso
 $checkCmd = "test -d `"$linuxPath`""
@@ -42,16 +48,13 @@ ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o Server
 if ($LASTEXITCODE -eq 0) {
     Write-Host "      [SUCCESS] Target SSHFS validado. $($Node.hostname):$($Node.path) esta pronto." -ForegroundColor Green
 
-    # Sentinel path for pass/fail aggregation (#831)
-    $sentinelDir  = "/tmp/databoar_handler"
-    $sentinelFile = "$sentinelDir/target_sshfs_sentinel.txt"
-
-    # Base64-encode IO monitor payload to eliminate shell-quoting issues. (#830)
-    $ioPayload  = "echo TARGET_ACTIVE at \$(date +%H:%M:%S) > ~/.labop-status && mkdir -p ~/log $sentinelDir && echo Monitorando IO/Load vmstat 5... && vmstat 5 | tee ~/log/target_io.log ; echo \$? > $sentinelFile"
+    $repoLogDir = "$repoPath/log"
+    $ioPayload  = "rm -f $sentinelFile ; mkdir -p $repoLogDir $sentinelDir ; echo 0 > $sentinelFile ; echo TARGET_ACTIVE at \$(date +%H:%M:%S) > ~/.labop-status && echo Monitorando IO/Load vmstat 5... && vmstat 5 | tee $repoLogDir/target_io.log"
     $payloadB64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($ioPayload))
-    $tmuxCmd    = "tmux send-keys -t completao C-c ; sleep 0.5 ; tmux send-keys -t completao 'echo $payloadB64 | base64 -d | bash' Enter"
-    ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$($Node.user)@$($Node.hostname)" "$tmuxCmd"
+    $null = Invoke-HandlerTmuxPayload -Node $Node -Persona "target_sshfs" -PayloadB64 $payloadB64
 
 } else {
     Write-Warning "      [WARNING] O diretorio $($Node.path) nao foi encontrado no alvo $($Node.hostname)."
+    Write-RemoteSentinel -Node $Node -SentinelFile $sentinelFile -ExitCode 1
+    exit 1
 }

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -887,7 +887,7 @@ def test_target_nfs_deep_apply_fail_is_real_fail() -> None:
 
 
 def test_collect_artifacts_uses_repo_log_path() -> None:
-    """#956: post-flight collect pulls from <repo>/log/, not only ~/log/."""
+    """#956/#968: post-flight collect pulls from <repo>/log/; Join-Path; REAL FAIL if empty."""
     root = _project_root()
     text = (root / "scripts" / "maestro" / "Collect-Artifacts.ps1").read_text(
         encoding="utf-8", errors="replace"
@@ -895,6 +895,24 @@ def test_collect_artifacts_uses_repo_log_path() -> None:
     assert "/log/*.log" in text
     assert "audit_trail" in text
     assert "~/log/*.log" in text  # legacy fallback only
+    assert "Join-Path" in text
+    assert "[REAL FAIL] Collect" in text
+    assert "Get-CollectArtifactCount" in text
+    assert "${localDestDir}/" in text
+    assert "$localDestDir\\" not in text
+
+
+def test_sync_working_tree_tar_fallback_on_rsync_failure() -> None:
+    """#969: rsync failure triggers tar|ssh fallback with same exclude set."""
+    root = _project_root()
+    text = (root / "scripts" / "maestro" / "Sync-WorkingTree.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "Invoke-SyncTarSshFallback" in text
+    assert "Sync-Fallback #969" in text
+    assert "tar -czf -" in text
+    assert "tar -xzf -" in text
+    assert "--exclude='docs/private'" in text
 
 
 def test_maestro_calls_wait_handler_sentinel_for_real_results() -> None:

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -127,6 +127,15 @@ def test_db_target_handlers_use_compose_contract() -> None:
     assert "LAB_MONGO_PORT_CANDIDATES" in mongo
     assert "TARGET_MONGODB_READY port=" in mongo
     assert "LAB_TARGET_DB_AUTOCLEAN" in mongo
+    for text, persona in (
+        (mariadb, "target_mariadb"),
+        (postgres, "target_postgres"),
+        (mongo, "target_mongodb"),
+    ):
+        assert f"{persona}_sentinel.txt" in text, (
+            f"DB handler must write {persona}_sentinel.txt (#953)"
+        )
+        assert "__SENTINEL__" in text or "SENTINEL=" in text
 
 
 def test_handle_web_health_contract() -> None:
@@ -576,7 +585,7 @@ def test_smoke_handlers_use_base64_payload_for_tmux() -> None:
     ]
     for persona in tmux_handlers:
         text = _handler_text(root, persona)
-        assert "base64" in text, (
+        assert "base64" in text.lower() or "Invoke-HandlerTmuxPayload" in text, (
             f"Handle-{persona}.ps1 must base64-encode the tmux payload (#830); "
             "raw single-quoted payloads break on paths or values with special chars"
         )
@@ -802,3 +811,119 @@ def test_maestro_runs_container_build_when_container_persona_present(warm_pwsh) 
     assert built, (
         "Build-ContainerArtefact did NOT run even though a node has a docker persona (#950)"
     )
+
+
+# ---------------------------------------------------------------------------
+# P0 bundle #955/#953/#956/#949/#954 — sentinel/collect/tmux/priv regressions
+# ---------------------------------------------------------------------------
+
+_TMUX_SMOKE_HANDLERS = [
+    "Handle-baremetal.ps1",
+    "Handle-docker.ps1",
+    "Handle-podman.ps1",
+    "Handle-dockerswarm.ps1",
+    "Handle-lxd.ps1",
+    "Handle-microk8s.ps1",
+    "Handle-target_nfs.ps1",
+    "Handle-target_cifs.ps1",
+    "Handle-target_sshfs.ps1",
+]
+
+
+def test_handlers_no_shared_completao_cc_clobber() -> None:
+    """#955: multi-persona nodes must not C-c the shared 'completao' session."""
+    root = _project_root()
+    hits: list[str] = []
+    for name in _TMUX_SMOKE_HANDLERS:
+        text = (root / "scripts" / "maestro" / "handlers" / name).read_text(
+            encoding="utf-8", errors="replace"
+        )
+        if "send-keys -t completao C-c" in text:
+            hits.append(name)
+    assert not hits, f"Remove shared-session C-c clobber in: {', '.join(hits)}"
+
+
+def test_handlers_use_per_persona_tmux_helper() -> None:
+    """#955: handlers dot-source Lab-MaestroCommon and inject via Invoke-HandlerTmuxPayload."""
+    root = _project_root()
+    for name in _TMUX_SMOKE_HANDLERS:
+        text = (root / "scripts" / "maestro" / "handlers" / name).read_text(
+            encoding="utf-8", errors="replace"
+        )
+        assert "Lab-MaestroCommon.ps1" in text, (
+            f"{name} must dot-source Lab-MaestroCommon.ps1"
+        )
+        assert "Invoke-HandlerTmuxPayload" in text, (
+            f"{name} must use Invoke-HandlerTmuxPayload (#955)"
+        )
+
+
+def test_target_nfs_cifs_use_priv_env_bash_ensure() -> None:
+    """#954: ensure runs as `$PRIV env ... bash` (doas strips caller env without env prefix)."""
+    root = _project_root()
+    for name in ("Handle-target_nfs.ps1", "Handle-target_cifs.ps1"):
+        text = (root / "scripts" / "maestro" / "handlers" / name).read_text(
+            encoding="utf-8", errors="replace"
+        )
+        assert "Build-EnsureRemoteCommand" in text
+        assert "command -v doas" in (
+            root / "scripts" / "maestro" / "Lab-MaestroCommon.ps1"
+        ).read_text(encoding="utf-8", errors="replace")
+        assert "`$PRIV $envPrefix bash" in (
+            root / "scripts" / "maestro" / "Lab-MaestroCommon.ps1"
+        ).read_text(encoding="utf-8", errors="replace")
+
+
+def test_target_nfs_deep_apply_fail_is_real_fail() -> None:
+    """#954/#949 bundle: Deep ensure --apply failure must exit non-zero and write sentinel 1."""
+    root = _project_root()
+    text = (
+        root / "scripts" / "maestro" / "handlers" / "Handle-target_nfs.ps1"
+    ).read_text(encoding="utf-8", errors="replace")
+    assert "elseif ($Deep)" in text
+    assert "[REAL FAIL] NFS ensure --apply" in text
+    assert "Write-RemoteSentinel" in text
+    assert "exit 1" in text
+
+
+def test_collect_artifacts_uses_repo_log_path() -> None:
+    """#956: post-flight collect pulls from <repo>/log/, not only ~/log/."""
+    root = _project_root()
+    text = (root / "scripts" / "maestro" / "Collect-Artifacts.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "/log/*.log" in text
+    assert "audit_trail" in text
+    assert "~/log/*.log" in text  # legacy fallback only
+
+
+def test_maestro_calls_wait_handler_sentinel_for_real_results() -> None:
+    """#949: Maestro polls Wait-HandlerSentinel after dispatch (real pass/fail, not inject-only)."""
+    root = _project_root()
+    text = (root / "scripts" / "maestro" / "Maestro.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "Wait-HandlerSentinel.ps1" in text
+    assert "dispatchedSentinelPersonas" in text
+    assert "-OnlyHosts" in text
+    assert "Wait-HandlerSentinel reportou falha" in text
+
+
+def test_wait_handler_sentinel_supports_only_hosts_filter() -> None:
+    """#949: limit polling to hosts that ran this Maestro turn."""
+    root = _project_root()
+    text = (root / "scripts" / "maestro" / "Wait-HandlerSentinel.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "OnlyHosts" in text
+    assert "-notcontains $node.hostname" in text
+
+
+def test_smoke_handlers_clear_sentinel_before_run() -> None:
+    """Bundle guard: stale sentinel from prior run must be removed (rm -f) before smoke."""
+    root = _project_root()
+    for persona in ("baremetal", "docker", "podman", "dockerswarm", "lxd", "microk8s"):
+        text = _handler_text(root, persona)
+        assert "rm -f $sentinelFile" in text or "rm -f $sentinelFile ;" in text, (
+            f"Handle-{persona}.ps1 must rm -f sentinel before run"
+        )


### PR DESCRIPTION
## Summary

Maestro P0 bundle for completão E2E toward release gate **#406** (gate **stays open** until a green multi-host lab run).

- **#955** — Per-persona tmux sessions (`completao_<persona>`) via `Lab-MaestroCommon.ps1` / `Invoke-HandlerTmuxPayload`; no shared-session `C-c` clobber.
- **#953** — DB handlers (postgres/mariadb/mongodb) write `/tmp/databoar_handler/<persona>_sentinel.txt` on exit.
- **#956** — `Collect-Artifacts.ps1` pulls from `<repo>/log/*.log` (+ audit trail); legacy `~/log` fallback with warning.
- **#949** — `Maestro.ps1` calls `Wait-HandlerSentinel.ps1` with dispatched personas and `-OnlyHosts`; failures increment `$realFailCount`.
- **#954** — NFS/CIFS ensure via `Build-EnsureRemoteCommand`: `$PRIV env VAR=val bash …` (doas strips caller env by default). Deep `--apply` failure writes sentinel `1` and exits before IO monitor (no masking as ready=0).

Regression guards added in `tests/test_maestro_scripts.py` (48 maestro tests; full `check-all.sh` green locally).

**Note:** Legacy `completao` tmux session still created in `Sync-WorkingTree.ps1` (comment only); live scans attach to `completao_<persona>`. UX follow-up pending operator preference on `tmux attach -t completao`.

Closes #955
Closes #953
Closes #956
Closes #949
Closes #954

Related: #406 (release gate — **not** closed by this PR; needs lab E2E)

## Test plan

- [x] `./scripts/check-all.sh`
- [x] `./scripts/quick-test.sh --path tests/test_maestro_scripts.py`
- [ ] Lab Maestro/completão E2E on fleet (alpine doas + multi-persona node) before closing #406


Made with [Cursor](https://cursor.com)