### PR TITLE
chore(release): UNDO unauthorized 1.7.4 promotion → 1.7.4-rc-2 — refs #970

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ Human-readable summary of user-facing changes. **Detailed release notes:** [docs
 
 ---
 
-## 1.7.4 (2026-06-11)
+## 1.7.4-rc-2 (unreleased — gate #406 pendente)
+
+> **Tombstone:** **`1.7.4` = VOID** — nunca lançada; promovida sem gate (**#970**, PR **#840** prematuro). Release real nasce **`1.7.4.201`** (fix-1 pós-GA; **`.200` = GA queimada). Ver **#971**.
 
 ### Added
 

--- a/core/about.py
+++ b/core/about.py
@@ -11,7 +11,7 @@ def _package_version() -> str:
 
         return version("data-boar")
     except Exception:
-        return "1.7.4"
+        return "1.7.4-rc-2"
 
 
 def get_http_user_agent() -> str:

--- a/docs/releases/1.7.4.md
+++ b/docs/releases/1.7.4.md
@@ -1,10 +1,10 @@
-# Release 1.7.4 / tag v1.7.4
+# Release 1.7.4 (DRAFT / UNRELEASED)
 
-**Status:** **Final** — `version = "1.7.4"` on `main`. Git tag `v1.7.4`, GitHub Release, and Docker Hub push **await operator** (gate decision, no CI-only publish).
+**Status:** **DRAFT / UNRELEASED** — **`1.7.4` = VOID** (promovida sem gate **#406**; **#970**). **`main`** trabalha em **`1.7.4-rc-2`** até o gate fechar. **Sem** tag **`v1.7.4`**, GitHub Release, ou Docker Hub publish.
 
-**Release date:** 2026-06-11
+**Alvo pós-gate:** **`1.7.4.201`** (fix-1 pós-GA; **`.200` = GA queimada**) — ver **#971**. **Não** confundir com o número **`1.7.4`** tombstone.
 
-**Working line before final:** **`1.7.4-rc`** — see [1.7.4-rc.md](1.7.4-rc.md).
+**Working line:** **`1.7.4-rc-2`** — ver [1.7.4-rc.md](1.7.4-rc.md) (histórico **`1.7.4-rc`**).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-boar"
-version = "1.7.4"
+version = "1.7.4-rc-2"
 description = "Data Boar — compliance-aware discovery and mapping of personal and sensitive data across databases, files, and APIs (LGPD, GDPR, CCPA, and configurable frameworks)."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -757,7 +757,7 @@ validation = [
 
 [[package]]
 name = "data-boar"
-version = "1.7.4"
+version = "1.7.4-rc-2"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-doc" },


### PR DESCRIPTION
## Summary

Forward-fix (#970): reverte bump não autorizado `1.7.4` → **`1.7.4-rc-2`** até o gate **#406** fechar.

- `pyproject.toml`, `core/about.py`, `uv.lock` (bloco `data-boar` only)
- `CHANGELOG.md`: heading `1.7.4-rc-2` + tombstone (`1.7.4` VOID; alvo futuro `1.7.4.201` / #971)
- `docs/releases/1.7.4.md`: DRAFT/UNRELEASED (sem tag/release Docker)

**Não** fecha #406 nem #970. **Sem** tag/release/docker.

## Test plan

- [x] `pytest tests/test_about_version_matches_pyproject.py`
- [x] pre-commit no commit (`52ce8d0e`, assinatura **G**)


Made with [Cursor](https://cursor.com)