### PR TITLE
test(release): CI guard stable-com-gate-aberto + denylist 1.7.5 — refs #978 (b)

### DIFF
--- a/security/version_policy.yaml
+++ b/security/version_policy.yaml
@@ -1,0 +1,22 @@
+# Release/version policy guardrails (ADR-0072/0073, GitHub #978).
+# Operator: set release_gate.open to false only after #406 closes.
+
+release_gate:
+  issue_number: 406
+  open: true
+
+forbidden_version_literals:
+  - "1.7.5-beta"
+  - "v1.7.5-beta"
+  - 'version = "1.7.5"'
+  - "version = '1.7.5'"
+
+# Paths where forbidden literals may appear (negation docs, policy, tests, ADR tombstones).
+scan_allowlist_path_substrings:
+  - "security/version_policy.yaml"
+  - "tests/test_release_version_policy.py"
+  - "docs/adr/ADR-0073"
+  - "docs/adr/ADR-0061"
+  - "docs/VERSIONING"
+  - "CHANGELOG.md"
+  - "AGENTS.md"

--- a/tests/test_release_version_policy.py
+++ b/tests/test_release_version_policy.py
@@ -1,0 +1,77 @@
+"""Release/version policy guards (#978, ADR-0072/0073).
+
+- While release gate #406 is OPEN: pyproject version must be pre-release.
+- Denylist phantom version strings (e.g. 1.7.5) in tracked files.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import tomllib
+import yaml
+from packaging.version import Version
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+POLICY_PATH = REPO_ROOT / "security" / "version_policy.yaml"
+
+
+def _tracked_files() -> list[Path]:
+    out = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "ls-files", "-z"],
+        check=True,
+        capture_output=True,
+    )
+    return [REPO_ROOT / part for part in out.stdout.decode("utf-8").split("\0") if part]
+
+
+def _load_policy() -> dict:
+    with POLICY_PATH.open(encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def _project_version() -> str:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as handle:
+        data = tomllib.load(handle)
+    return str(data["project"]["version"])
+
+
+def test_release_gate_open_requires_prerelease_on_main() -> None:
+    """Stable-looking pyproject version blocked while release gate is open."""
+    policy = _load_policy()
+    gate = policy.get("release_gate") or {}
+    if not gate.get("open"):
+        pytest.skip("release_gate.open is false — operator closed #406")
+
+    version = Version(_project_version())
+    assert version.is_prerelease, (
+        f"release gate #{gate.get('issue_number', 406)} is OPEN but "
+        f"pyproject.toml version {version} is not pre-release (-beta/-rc). "
+        "See ADR-0072 and docs/VERSIONING.md."
+    )
+
+
+def test_forbidden_version_literals_absent_from_tracked_files() -> None:
+    """Denylist strings (phantom roadmap) must not appear outside allowlisted paths."""
+    policy = _load_policy()
+    forbidden: list[str] = list(policy.get("forbidden_version_literals") or [])
+    allow_substrings: list[str] = list(
+        policy.get("scan_allowlist_path_substrings") or []
+    )
+
+    hits: list[str] = []
+    for path in _tracked_files():
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        if any(sub in rel for sub in allow_substrings):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        for literal in forbidden:
+            if literal in text:
+                hits.append(f"{rel}: contains forbidden {literal!r}")
+
+    assert not hits, "Forbidden version literals found:\n" + "\n".join(hits)


### PR DESCRIPTION
## Summary
- Add `security/version_policy.yaml` with `release_gate.open: true` (#406) and denylist for `1.7.5-beta` literals
- Add `tests/test_release_version_policy.py`: enforces pre-release in `pyproject.toml` while gate open; scans tracked files for forbidden version strings

## Test plan
- [x] `uv run pytest tests/test_release_version_policy.py -v`
- [ ] CI green

Part of post-#970 houseclean slice 5b. Does not close #406 or bump stable.


Made with [Cursor](https://cursor.com)