### PR TITLE
docs(security): posture hub + recover L14 gold — refs #992

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,8 @@
 
 This document describes which versions of the application are supported, which dependency baseline is expected, and how to report security vulnerabilities to the maintainers. For copyright and license: [NOTICE](NOTICE); for making copyright and trademark official: [docs/COPYRIGHT_AND_TRADEMARK.md](docs/COPYRIGHT_AND_TRADEMARK.md) ([pt-BR](docs/COPYRIGHT_AND_TRADEMARK.pt_BR.md)).
 
+**Governance posture index (PII gates, agent containment, supply chain, provenance):** [`docs/SECURITY_GOVERNANCE_POSTURE_HUB.md`](docs/SECURITY_GOVERNANCE_POSTURE_HUB.md) ([pt-BR](docs/SECURITY_GOVERNANCE_POSTURE_HUB.pt_BR.md)) — co-located links only; does not replace this vulnerability policy.
+
 ## Supported versions
 
 - **Application (brand):** **Data Boar**. PyPI distribution id: **`data-boar`** (see [CONTRIBUTING.md](CONTRIBUTING.md#repository-and-install-identity-data-boar)). Current development targets **Python 3.12+**.

--- a/SECURITY.pt_BR.md
+++ b/SECURITY.pt_BR.md
@@ -4,6 +4,8 @@
 
 Este documento descreve quais versões da aplicação são suportadas, qual linha de base de dependências é esperada e como reportar vulnerabilidades de segurança aos mantenedores. Sobre direitos autorais e licença: [NOTICE](NOTICE); para tornar direitos autorais e marca oficial: [docs/COPYRIGHT_AND_TRADEMARK.pt_BR.md](docs/COPYRIGHT_AND_TRADEMARK.pt_BR.md) (português) · [docs/COPYRIGHT_AND_TRADEMARK.md](docs/COPYRIGHT_AND_TRADEMARK.md) (inglês).
 
+**Índice de postura de governança (gates de PII, contenção de agentes, supply chain, proveniência):** [`docs/SECURITY_GOVERNANCE_POSTURE_HUB.pt_BR.md`](docs/SECURITY_GOVERNANCE_POSTURE_HUB.pt_BR.md) ([EN](docs/SECURITY_GOVERNANCE_POSTURE_HUB.md)) — links co-localizados; não substitui esta política de vulnerabilidades.
+
 ## Versões suportadas
 
 - **Aplicação (marca):** **Data Boar**. Id da distribuição PyPI: **`data-boar`** (veja [CONTRIBUTING.pt_BR.md](CONTRIBUTING.pt_BR.md#repositório-e-identidade-de-instalação-data-boar)). O desenvolvimento atual tem como alvo **Python 3.12+**.

--- a/docs/SECURITY_GOVERNANCE_POSTURE_HUB.md
+++ b/docs/SECURITY_GOVERNANCE_POSTURE_HUB.md
@@ -1,0 +1,86 @@
+# Security, governance, safety, quality & provenance — posture hub
+
+**Português (Brasil):** [SECURITY_GOVERNANCE_POSTURE_HUB.pt_BR.md](SECURITY_GOVERNANCE_POSTURE_HUB.pt_BR.md)
+
+> **For agents (Cursor / Claude):** read this page when you need the **map of maps** for security posture, governance gates, agent containment, and supply-chain evidence. We **do not** move canonical files — co-located links only ([ADR-0057](adr/ADR-0057-lightweight-hub-index-co-located-links.md)). Operator vault mirror (stacked private git under `docs/private/`) may hold lab-specific security runbooks; this hub stays on **public** `origin`.
+
+## How to use
+
+1. Pick a theme row below (Cyber, Governance, Safety, Code quality, Provenance).
+2. Follow backtick paths to the real file — never assume a moved path.
+3. For integrity/tamper/release evidence chains, start at [`docs/ops/INTEGRITY_HUB.md`](ops/INTEGRITY_HUB.md).
+
+## Cyber
+
+| Topic | Entry points |
+| ----- | ------------ |
+| Vulnerability reporting & supported versions | [`SECURITY.md`](../SECURITY.md) · [`SECURITY.pt_BR.md`](../SECURITY.pt_BR.md) |
+| PII gates (tracked tree + history) | [ADR-0018](adr/ADR-0018-pii-anti-recurrence-guardrails-for-tracked-files-and-branch-history.md) · [ADR-0019](adr/ADR-0019-pii-seed-gate-staged-files.md) · [ADR-0020](adr/ADR-0020-ci-full-git-history-pii-gate.md) · [ADR-0071](adr/ADR-0071-self-protecting-pii-gate.md) · [`docs/ops/PII_PUBLIC_TREE_OPERATOR_GUIDE.md`](ops/PII_PUBLIC_TREE_OPERATOR_GUIDE.md) |
+| Tamper / runtime trust | [ADR-0066](adr/ADR-0066-fail-closed-runtime-trust-tamper-posture.md) · [`docs/ops/INTEGRITY_HUB.md`](ops/INTEGRITY_HUB.md) |
+| NIST-aligned posture | [ADR-0065](adr/ADR-0065-nist-csf-aligned-security-posture-mapping.md) |
+| Supply chain (deps, SBOM, pins) | [ADR-0005](adr/ADR-0005-ci-quality-gates-and-supply-chain-scanning.md) · [ADR-0003](adr/ADR-0003-sbom-roadmap-cyclonedx-then-syft.md) · [ADR-0073](adr/ADR-0073-version-scheme-octet-maturity-and-roadmap.md) (Proposed) · supply-chain posture ADR tracks GitHub **#987** |
+| Lab host security stack | [`docs/ops/DATA_BOAR_LAB_SECURITY_TOOLING.md`](ops/DATA_BOAR_LAB_SECURITY_TOOLING.md) |
+| Host-binding / outbound identity | [ADR-0034](adr/ADR-0034-outbound-http-user-agent-data-boar-prospector.md) · `.cursor/rules/homelab-ssh-via-terminal.mdc` (situational) |
+
+## Governance
+
+| Topic | Entry points |
+| ----- | ------------ |
+| Agent contract (non-negotiables) | [`AGENTS.md`](../AGENTS.md) |
+| ADR metadata & format | [ADR-0045](adr/ADR-0045-adr-metadata-and-format-standardization.md) |
+| Issue / release gates | [ADR-0061](adr/ADR-0061-u-axis-issue-suborder-and-cross-milestone-gate.md) · [ADR-0072](adr/ADR-0072-commit-gate-vs-release-gate-distinct-criteria.md) (Proposed) |
+| Agent containment (A.I.I.D.C.O.B.P.P.) | [ADR-0062](adr/ADR-0062-agent-containment-triple-audit-offband-pingpong.md) · [`docs/adr/ADR-0062-diagram.mermaid`](adr/ADR-0062-diagram.mermaid) · [`docs/ops/lab_lessons_learned/LAB_LESSON_AIIDCOBPP_QUAD_AUDIT.md`](ops/lab_lessons_learned/LAB_LESSON_AIIDCOBPP_QUAD_AUDIT.md) |
+| Self-audit log governance | [ADR-0037](adr/ADR-0037-data-boar-self-audit-log-governance.md) |
+| Taxonomy / priority axes | [ADR-0048](adr/ADR-0048-orthogonal-priority-axes-h-u-g-p.md) · [ADR-0055](adr/ADR-0055-orthogonal-priority-axes-anti-collision-contract.md) |
+| Governance positioning diagrams | [`docs/ops/governance/DATABOAR_GOVERNANCE_DIAGRAMS.md`](ops/governance/DATABOAR_GOVERNANCE_DIAGRAMS.md) |
+| Cursor policy map | [`docs/ops/CURSOR_AGENT_POLICY_HUB.md`](ops/CURSOR_AGENT_POLICY_HUB.md) |
+| Version / release guardrails | [`docs/VERSIONING.md`](VERSIONING.md) · `.cursor/rules/release-versioning.mdc` · `security/version_policy.yaml` |
+
+## Safety
+
+| Topic | Entry points |
+| ----- | ------------ |
+| Security & PII gates (never weaken) | `.cursor/rules/never-weaken-security-gates.mdc` · [ADR-0049](adr/ADR-0049-no-brittle-mitigations-robust-input-handling.md) |
+| RCA-first / investigation | [ADR-0047](adr/ADR-0047-rca-first-operator-investigation-before-blocking.md) · `.cursor/rules/operator-investigation-before-blocking.mdc` |
+| Operator-gated release (#406) | GitHub **#406** · [ADR-0072](adr/ADR-0072-commit-gate-vs-release-gate-distinct-criteria.md) (Proposed) · operator-gated reopen tracks **#990** |
+| Primary workstation protection | [`docs/ops/PRIMARY_LINUX_WORKSTATION_PROTECTION.md`](ops/PRIMARY_LINUX_WORKSTATION_PROTECTION.md) · [`docs/ops/PRIMARY_WINDOWS_WORKSTATION_PROTECTION.md`](ops/PRIMARY_WINDOWS_WORKSTATION_PROTECTION.md) |
+
+## Code quality
+
+| Topic | Entry points |
+| ----- | ------------ |
+| CI gate stack | [ADR-0005](adr/ADR-0005-ci-quality-gates-and-supply-chain-scanning.md) · `.github/workflows/ci.yml` |
+| Local gate ritual | [`docs/TESTING.md`](TESTING.md) · `./scripts/check-all.sh` / `.\scripts\check-all.ps1` |
+| Static analysis | Bandit · Semgrep · CodeQL (workflows) · Ruff/pre-commit |
+| No brittle mitigations | [ADR-0049](adr/ADR-0049-no-brittle-mitigations-robust-input-handling.md) |
+
+## Provenance
+
+| Topic | Entry points |
+| ----- | ------------ |
+| ADR crypto inventory | [ADR-0056](adr/ADR-0056-adr-inventory-ed25519-attestation-workflow.md) · `scripts/inv-adr.ps1` · [`docs/adr/INVENTORY.txt`](adr/INVENTORY.txt) |
+| Sigstore / cosign roadmap | [`docs/ops/RELEASE_INTEGRITY.md`](ops/RELEASE_INTEGRITY.md) · `docs/plans/PLAN_BUILD_IDENTITY_RELEASE_INTEGRITY.md` (internal) |
+| SBOM | [ADR-0003](adr/ADR-0003-sbom-roadmap-cyclonedx-then-syft.md) · [`SECURITY.md`](../SECURITY.md) § SBOM |
+| Dependency closure | [ADR-0030](adr/ADR-0030-python-dependency-update-closure-single-pass.md) · [ADR-0044](adr/ADR-0044-dependabot-uv-ecosystem-for-pyproject-lock-closure.md) |
+
+## Vault ↔ repo cross-link
+
+| Surface | Role |
+| ------- | ---- |
+| **Public repo (this tree)** | Policy, ADRs, CI guards, operator runbooks without secrets |
+| **Stacked private git (`docs/private/`)** | Lab hostnames, manifests, completão narratives, commercial/legal evidence — never paste into tracked files |
+| **Operator vault mirror** | Optional Claude-side hub copy; **this** file is the canonical public index |
+
+## Related hubs
+
+- [`docs/hubs/INDEX.md`](hubs/INDEX.md) — map of all hubs
+- [`docs/ops/INTEGRITY_HUB.md`](ops/INTEGRITY_HUB.md) — tamper detection & release evidence
+- [`docs/ops/LAB_LESSONS_LEARNED.md`](ops/LAB_LESSONS_LEARNED.md) — rolling lab lessons + archive index
+
+## Update ritual
+
+1. Add rows here (EN + pt-BR mirror) when a new posture ADR or guard lands.
+2. Register this hub in [`docs/hubs/INDEX.md`](hubs/INDEX.md).
+3. Run `./scripts/check-hubs.sh` before merge.
+
+Refs: GitHub **#992**, **#991**, **#987**, post-**#970** versioning saga.

--- a/docs/SECURITY_GOVERNANCE_POSTURE_HUB.pt_BR.md
+++ b/docs/SECURITY_GOVERNANCE_POSTURE_HUB.pt_BR.md
@@ -1,0 +1,86 @@
+# Postura de segurança, governança, safety, qualidade e proveniência — hub
+
+**English:** [SECURITY_GOVERNANCE_POSTURE_HUB.md](SECURITY_GOVERNANCE_POSTURE_HUB.md)
+
+> **Para agentes:** leia esta página quando precisar do **mapa dos mapas** de postura de segurança, gates de governança, contenção de agentes e evidência de supply chain. **Não** movemos arquivos canônicos — só links co-localizados ([ADR-0057](adr/ADR-0057-lightweight-hub-index-co-located-links.md)). O espelho vault do operador (git privado empilhado em `docs/private/`) pode ter runbooks de lab; este hub fica no **`origin`** público.
+
+## Como usar
+
+1. Escolha um tema abaixo (Cyber, Governança, Safety, Qualidade de código, Proveniência).
+2. Siga os caminhos em backticks — não assuma arquivo movido.
+3. Para cadeias de integridade/tamper/release, comece em [`docs/ops/INTEGRITY_HUB.md`](ops/INTEGRITY_HUB.md).
+
+## Cyber
+
+| Tema | Pontos de entrada |
+| ---- | ----------------- |
+| Reporte de vulnerabilidades e versões suportadas | [`SECURITY.md`](../SECURITY.md) · [`SECURITY.pt_BR.md`](../SECURITY.pt_BR.md) |
+| Gates de PII (árvore rastreada + histórico) | [ADR-0018](adr/ADR-0018-pii-anti-recurrence-guardrails-for-tracked-files-and-branch-history.md) · [ADR-0019](adr/ADR-0019-pii-seed-gate-staged-files.md) · [ADR-0020](adr/ADR-0020-ci-full-git-history-pii-gate.md) · [ADR-0071](adr/ADR-0071-self-protecting-pii-gate.md) · [`docs/ops/PII_PUBLIC_TREE_OPERATOR_GUIDE.md`](ops/PII_PUBLIC_TREE_OPERATOR_GUIDE.md) |
+| Tamper / confiança em runtime | [ADR-0066](adr/ADR-0066-fail-closed-runtime-trust-tamper-posture.md) · [`docs/ops/INTEGRITY_HUB.md`](ops/INTEGRITY_HUB.md) |
+| Postura alinhada a NIST | [ADR-0065](adr/ADR-0065-nist-csf-aligned-security-posture-mapping.md) |
+| Supply chain (deps, SBOM, pins) | [ADR-0005](adr/ADR-0005-ci-quality-gates-and-supply-chain-scanning.md) · [ADR-0003](adr/ADR-0003-sbom-roadmap-cyclonedx-then-syft.md) · [ADR-0073](adr/ADR-0073-version-scheme-octet-maturity-and-roadmap.md) (Proposed) · ADR de postura supply-chain rastreia **#987** |
+| Stack de segurança no host de lab | [`docs/ops/DATA_BOAR_LAB_SECURITY_TOOLING.md`](ops/DATA_BOAR_LAB_SECURITY_TOOLING.md) |
+| Host-binding / identidade HTTP de saída | [ADR-0034](adr/ADR-0034-outbound-http-user-agent-data-boar-prospector.md) · `.cursor/rules/homelab-ssh-via-terminal.mdc` (situacional) |
+
+## Governança
+
+| Tema | Pontos de entrada |
+| ---- | ----------------- |
+| Contrato do agente (não negociáveis) | [`AGENTS.md`](../AGENTS.md) |
+| Metadados e formato de ADR | [ADR-0045](adr/ADR-0045-adr-metadata-and-format-standardization.md) |
+| Gates de issue / release | [ADR-0061](adr/ADR-0061-u-axis-issue-suborder-and-cross-milestone-gate.md) · [ADR-0072](adr/ADR-0072-commit-gate-vs-release-gate-distinct-criteria.md) (Proposed) |
+| Contenção de agentes (A.I.I.D.C.O.B.P.P.) | [ADR-0062](adr/ADR-0062-agent-containment-triple-audit-offband-pingpong.md) · [`docs/adr/ADR-0062-diagram.mermaid`](adr/ADR-0062-diagram.mermaid) · [`docs/ops/lab_lessons_learned/LAB_LESSON_AIIDCOBPP_QUAD_AUDIT.md`](ops/lab_lessons_learned/LAB_LESSON_AIIDCOBPP_QUAD_AUDIT.md) |
+| Governança de log de auto-auditoria | [ADR-0037](adr/ADR-0037-data-boar-self-audit-log-governance.md) |
+| Taxonomia / eixos de prioridade | [ADR-0048](adr/ADR-0048-orthogonal-priority-axes-h-u-g-p.md) · [ADR-0055](adr/ADR-0055-orthogonal-priority-axes-anti-collision-contract.md) |
+| Diagramas de posicionamento em governança | [`docs/ops/governance/DATABOAR_GOVERNANCE_DIAGRAMS.md`](ops/governance/DATABOAR_GOVERNANCE_DIAGRAMS.md) |
+| Mapa de políticas Cursor | [`docs/ops/CURSOR_AGENT_POLICY_HUB.md`](ops/CURSOR_AGENT_POLICY_HUB.md) |
+| Guardrails de versão / release | [`docs/VERSIONING.md`](VERSIONING.md) · `.cursor/rules/release-versioning.mdc` · `security/version_policy.yaml` |
+
+## Safety
+
+| Tema | Pontos de entrada |
+| ---- | ----------------- |
+| Gates de segurança e PII (nunca enfraquecer) | `.cursor/rules/never-weaken-security-gates.mdc` · [ADR-0049](adr/ADR-0049-no-brittle-mitigations-robust-input-handling.md) |
+| RCA-first / investigação | [ADR-0047](adr/ADR-0047-rca-first-operator-investigation-before-blocking.md) · `.cursor/rules/operator-investigation-before-blocking.mdc` |
+| Release com gate do operador (#406) | GitHub **#406** · [ADR-0072](adr/ADR-0072-commit-gate-vs-release-gate-distinct-criteria.md) (Proposed) · reopen automático rastreia **#990** |
+| Proteção da estação de dev primária | [`docs/ops/PRIMARY_LINUX_WORKSTATION_PROTECTION.md`](ops/PRIMARY_LINUX_WORKSTATION_PROTECTION.md) · [`docs/ops/PRIMARY_WINDOWS_WORKSTATION_PROTECTION.md`](ops/PRIMARY_WINDOWS_WORKSTATION_PROTECTION.md) |
+
+## Qualidade de código
+
+| Tema | Pontos de entrada |
+| ---- | ----------------- |
+| Stack de gates no CI | [ADR-0005](adr/ADR-0005-ci-quality-gates-and-supply-chain-scanning.md) · `.github/workflows/ci.yml` |
+| Ritual de gate local | [`docs/TESTING.md`](TESTING.md) · `./scripts/check-all.sh` / `.\scripts\check-all.ps1` |
+| Análise estática | Bandit · Semgrep · CodeQL (workflows) · Ruff/pre-commit |
+| Sem mitigações frágeis | [ADR-0049](adr/ADR-0049-no-brittle-mitigations-robust-input-handling.md) |
+
+## Proveniência
+
+| Tema | Pontos de entrada |
+| ---- | ----------------- |
+| Inventário cripto de ADRs | [ADR-0056](adr/ADR-0056-adr-inventory-ed25519-attestation-workflow.md) · `scripts/inv-adr.ps1` · [`docs/adr/INVENTORY.txt`](adr/INVENTORY.txt) |
+| Roadmap Sigstore / cosign | [`docs/ops/RELEASE_INTEGRITY.md`](ops/RELEASE_INTEGRITY.md) · `docs/plans/PLAN_BUILD_IDENTITY_RELEASE_INTEGRITY.md` (interno) |
+| SBOM | [ADR-0003](adr/ADR-0003-sbom-roadmap-cyclonedx-then-syft.md) · [`SECURITY.md`](../SECURITY.md) § SBOM |
+| Closure de dependências | [ADR-0030](adr/ADR-0030-python-dependency-update-closure-single-pass.md) · [ADR-0044](adr/ADR-0044-dependabot-uv-ecosystem-for-pyproject-lock-closure.md) |
+
+## Vault ↔ repo
+
+| Superfície | Papel |
+| ---------- | ----- |
+| **Repo público** | Política, ADRs, guards de CI, runbooks sem segredos |
+| **Git privado empilhado (`docs/private/`)** | Hostnames de lab, manifests, narrativas de completão, evidência comercial/legal — nunca colar em arquivos rastreados |
+| **Espelho vault do operador** | Cópia opcional no lado Claude; **este** arquivo é o índice público canônico |
+
+## Hubs relacionados
+
+- [`docs/hubs/INDEX.md`](hubs/INDEX.md)
+- [`docs/ops/INTEGRITY_HUB.md`](ops/INTEGRITY_HUB.md)
+- [`docs/ops/LAB_LESSONS_LEARNED.md`](ops/LAB_LESSONS_LEARNED.md)
+
+## Ritual de atualização
+
+1. Adicione linhas aqui (EN + espelho pt-BR) quando um ADR ou guard de postura entrar.
+2. Registre este hub em [`docs/hubs/INDEX.md`](hubs/INDEX.md).
+3. Rode `./scripts/check-hubs.sh` antes do merge.
+
+Refs: GitHub **#992**, **#991**, **#987**, saga de versionamento pós-**#970**.

--- a/docs/adr/ADR-0062-diagram.mermaid
+++ b/docs/adr/ADR-0062-diagram.mermaid
@@ -1,0 +1,14 @@
+flowchart TD
+    OP["🧑 Operator\n(Base Band — data bus)"]
+    CW["Claude Windows\nSonnet 4.6 — Auditor A\n(LAB-NODE-01)"]
+    CL["Claude Linux\nSonnet 4.6 — Auditor B\n(LAB-NODE-02)"]
+    CT["Tactical Consensus\nPrompt Linting\n(convergence between auditors)"]
+    GG["Google Gemini\nArchitecture Validator\n(independent structural review)"]
+    TG["Target — Cursor / Git\nComposer tier\n(executor — works only)"]
+
+    OP -->|"distributes payload"| CW
+    OP -->|"distributes payload"| CL
+    CW -->|"ping: recommendation A"| CT
+    CL -->|"pong: review B"| CT
+    CT -->|"converged payload"| GG
+    GG -->|"structural sign-off"| TG

--- a/docs/hubs/INDEX.md
+++ b/docs/hubs/INDEX.md
@@ -55,6 +55,13 @@
 | Use cases | `docs/use-cases/USE_CASES_HUB.md` | Storyboards + product scenarios |
 | Pitch decks | `docs/pitch/INDEX.md` | Stakeholder / DPO / CISO |
 
+### Security, governance, and posture
+
+| Hub | Canonical path | Covers |
+| --- | -------------- | ------ |
+| **Posture hub** | `docs/SECURITY_GOVERNANCE_POSTURE_HUB.md` | Security, governance, safety, quality, provenance — co-located index |
+| Governance diagrams | `docs/ops/governance/DATABOAR_GOVERNANCE_DIAGRAMS.md` | ISO/COBIT/ITIL positioning diagrams for pitches |
+
 ### Integrity and release evidence
 
 | Hub | Canonical path | Covers |

--- a/docs/hubs/INDEX.pt_BR.md
+++ b/docs/hubs/INDEX.pt_BR.md
@@ -55,6 +55,13 @@
 | Use cases | `docs/use-cases/USE_CASES_HUB.md` | Cenários de produto |
 | Pitch | `docs/pitch/INDEX.md` | Decks executivos |
 
+### Segurança, governança e postura
+
+| Hub | Caminho canônico | Cobre |
+| --- | ---------------- | ----- |
+| **Hub de postura** | `docs/SECURITY_GOVERNANCE_POSTURE_HUB.md` | Segurança, governança, safety, qualidade, proveniência — índice co-localizado |
+| Diagramas de governança | `docs/ops/governance/DATABOAR_GOVERNANCE_DIAGRAMS.md` | Diagramas ISO/COBIT/ITIL para pitches |
+
 ### Integridade e release
 
 | Hub | Caminho canônico | Cobre |

--- a/docs/ops/governance/DATABOAR_GOVERNANCE_DIAGRAMS.md
+++ b/docs/ops/governance/DATABOAR_GOVERNANCE_DIAGRAMS.md
@@ -1,0 +1,82 @@
+# Data Boar — governance positioning diagrams
+
+**Português (Brasil):** [DATABOAR_GOVERNANCE_DIAGRAMS.pt_BR.md](DATABOAR_GOVERNANCE_DIAGRAMS.pt_BR.md)
+
+Original diagrams for primers and stakeholder pitches. Product-specific wording. Conceptual inspiration: ISO/IEC 38500, COBIT 2019, ITIL 4, ISO/IEC 20000.
+
+---
+
+## 1. Governance stack — where Data Boar operates
+
+```mermaid
+flowchart TB
+    GC["**Corporate governance**\nStrategy · accountability · value\n_ISO/IEC 38500 · COBIT 2019_"]
+    ITSM["**IT service management**\nProcesses · SLAs · continual improvement\n_ITIL · ISO/IEC 20000_"]
+    DB["**Data Boar**\nDiscovery · evidence · PII visibility\n_scan → dashBOARd → GRC report → scan manifest_"]
+
+    GC -->|directs| ITSM
+    ITSM -->|operationalizes| DB
+    DB -.->|feeds evidence back| ITSM
+    ITSM -.->|reports performance| GC
+```
+
+> Data Boar is not a GRC platform or a governance framework.
+> It is the discovery layer that makes governance verifiable.
+
+---
+
+## 2. EDM cycle — Data Boar at each stage
+
+The ISO/IEC 38500 Evaluate → Direct → Monitor (EDM) model describes how leadership steers responsible technology use. Data Boar operates as the operational evidence layer at each stage.
+
+```mermaid
+flowchart LR
+    A["**Evaluate**\nCurrent and future state of IT"]
+    D["**Direct**\nPolicies and priorities"]
+    M["**Monitor**\nOutcomes and compliance"]
+
+    A -->|"risk evidence"| D
+    D -->|"configured rules"| M
+    M -.->|"continuous cycle"| A
+
+    A1["scan → PII inventory\nreal exposure surface\nrisk map by source and type"]
+    D1["plugin_schema · norm_tags\nrules per framework and context\norg-configurable profiles"]
+    M1["dashBOARd · GRC report\nauditable scan manifest\nsession-over-session trends"]
+
+    A --- A1
+    D --- D1
+    M --- M1
+```
+
+---
+
+## 3. Five ITIL practices — Data Boar mapping
+
+| ITIL practice | What it does | How Data Boar contributes |
+| --- | --- | --- |
+| **Incident management** | Restore interrupted services with minimal impact | PII exposure in production is a data incident. Scanning locates sensitive data *before* breach, shrinking impact surface when an incident occurs. |
+| **Problem management** | Identify and eliminate root causes of recurring incidents | Recurring PII in logs or staging DBs is a systemic problem. Session-over-session scan history reveals which pipeline keeps generating exposure after remediation. |
+| **Change control** | Implement changes with controlled risk | Pre/post-deploy scans detect whether a change introduced new PII exposure. Potential quality gate in CI/CD before production promotion. |
+| **Capacity and performance** | Ensure resources meet current and future demand | Configurable sampling, per-target timeouts, character budgets per scan. `scan_manifest` documents coverage depth — operational transparency on limits. |
+| **Service continuity** | Recover within agreed time after disaster | `scan_manifest` + auditable evidence supports post-incident diligence: *what existed, where, when verified*. Documentary base for regulator response after a breach. |
+
+---
+
+## 4. Corporate governance × IT governance × ITSM
+
+| Dimension | Corporate governance | IT governance | IT service management (ITSM) |
+| --- | --- | --- | --- |
+| **Level** | Strategic | Strategic / Tactical | Tactical / Operational |
+| **Focus** | Organizational direction | Responsible use of IT | Service delivery and operations |
+| **Central question** | Where are we going? | How does IT serve that? | How do we deliver with quality? |
+| **Owner** | Board / C-suite | Executive leadership + IT management | IT teams + partners |
+| **Reference models** | IBGC, corporate governance codes | ISO/IEC 38500, COBIT | ITIL, ISO/IEC 20000 |
+| **Data Boar role** | Evidence for reporting | Inventory for EDM | Data visibility for five practices |
+
+---
+
+*Original diagrams — Data Boar wording and positioning.*
+*Reference concepts: ISO/IEC 38500, COBIT 2019, ITIL 4, ISO/IEC 20000.*
+*Does not reproduce normative text or tables from ABNT/ISACA publications.*
+
+Recovered from primary Windows dev workstation backup (2026-06); tracks GitHub **#992**.

--- a/docs/ops/governance/DATABOAR_GOVERNANCE_DIAGRAMS.pt_BR.md
+++ b/docs/ops/governance/DATABOAR_GOVERNANCE_DIAGRAMS.pt_BR.md
@@ -1,0 +1,82 @@
+# Data Boar — diagramas de posicionamento em governança de TI
+
+**English:** [DATABOAR_GOVERNANCE_DIAGRAMS.md](DATABOAR_GOVERNANCE_DIAGRAMS.md)
+
+Diagramas originais para primers e pitches do repo. Wording próprio do produto. Inspiração conceitual: ISO/IEC 38500, COBIT 2019, ITIL 4, ISO/IEC 20000.
+
+---
+
+## 1. A pilha de governança — onde o Data Boar opera
+
+```mermaid
+flowchart TB
+    GC["**Governança corporativa**\nEstratégia · accountability · geração de valor\n_ISO/IEC 38500 · COBIT 2019_"]
+    ITSM["**Gerenciamento de serviços de TI**\nProcessos · SLAs · melhoria contínua\n_ITIL · ISO/IEC 20000_"]
+    DB["**Data Boar**\nDescoberta · evidência · visibilidade de PII\n_scan → dashBOARd → GRC report → scan manifest_"]
+
+    GC -->|direciona| ITSM
+    ITSM -->|operacionaliza| DB
+    DB -.->|retroalimenta evidência| ITSM
+    ITSM -.->|reporta desempenho| GC
+```
+
+> O Data Boar não é uma plataforma GRC nem um framework de governança.
+> É a camada de descoberta que torna a governança verificável.
+
+---
+
+## 2. Ciclo EDM — o Data Boar em cada etapa
+
+O modelo Avaliar → Dirigir → Monitorar (EDM) da ISO/IEC 38500 descreve como a alta direção conduz o uso responsável da tecnologia. O Data Boar opera como camada operacional de evidência em cada etapa.
+
+```mermaid
+flowchart LR
+    A["**Avaliar**\nEstado atual e futuro da TI"]
+    D["**Dirigir**\nPolíticas e prioridades"]
+    M["**Monitorar**\nResultados e conformidade"]
+
+    A -->|"evidência de risco"| D
+    D -->|"regras configuradas"| M
+    M -.->|"ciclo contínuo"| A
+
+    A1["scan → inventário de PII\nsuperfície de exposição real\nrisk map por fonte e tipo"]
+    D1["plugin_schema · norm_tags\nregras por framework e contexto\nperfis configuráveis por org"]
+    M1["dashBOARd · GRC report\nscan manifest auditável\ntrend session-over-session"]
+
+    A --- A1
+    D --- D1
+    M --- M1
+```
+
+---
+
+## 3. As 5 práticas ITIL — mapeamento ao Data Boar
+
+| Prática ITIL | O que a prática faz | Como o Data Boar contribui |
+| --- | --- | --- |
+| **Gestão de incidentes** | Restaurar serviços interrompidos com mínimo de impacto | Exposição de PII em produção é um incidente de dados. O scan identifica onde dados sensíveis residem *antes* da quebra, reduzindo superfície de impacto quando o incidente ocorre. |
+| **Gestão de problemas** | Identificar e eliminar causas-raiz de incidentes recorrentes | PII recorrente em logs ou bancos de homologação = problema sistêmico. O histórico de scans session-over-session revela qual pipeline continua gerando exposição mesmo após remediação. |
+| **Controle de mudanças** | Garantir que mudanças sejam implementadas com risco controlado | Scan pré/pós-deploy detecta se uma mudança introduziu nova exposição de PII. Potencial gate de qualidade em CI/CD antes de promoção para produção. |
+| **Gestão de capacidade e desempenho** | Assegurar que recursos atendam demanda atual e futura | Sampling configurável, timeouts por alvo, orçamento de caracteres por scan. O `scan_manifest` documenta o que foi coberto e com qual profundidade — transparência operacional sobre limites. |
+| **Gestão da continuidade de serviços** | Garantir recuperação dentro de prazos acordados após desastre | O `scan_manifest` + evidência auditável integra o pacote de diligência pós-incidente: *o que existia, onde estava, quando foi verificado*. Base documental para resposta a reguladores após uma quebra. |
+
+---
+
+## 4. Comparativo: governança corporativa × governança de TI × ITSM
+
+| Dimensão | Governança corporativa | Governança de TI | Gerenciamento de serviços (ITSM) |
+| --- | --- | --- | --- |
+| **Nível** | Estratégico | Estratégico / Tático | Tático / Operacional |
+| **Foco** | Direção da organização | Uso responsável da TI | Entrega e operação de serviços |
+| **Pergunta central** | Para onde vamos? | Como a TI serve isso? | Como entregamos com qualidade? |
+| **Responsável** | Conselho / C-suite | Alta direção + gestão de TI | Times de TI + parceiros |
+| **Modelos de referência** | IBGC, governança corporativa | ISO/IEC 38500, COBIT | ITIL, ISO/IEC 20000 |
+| **Papel do Data Boar** | Evidência para reporting | Inventário para EDM | Visibilidade de dados para 5 práticas |
+
+---
+
+*Diagramas originais — wording e posicionamento Data Boar.*
+*Conceitos de referência: ISO/IEC 38500, COBIT 2019, ITIL 4, ISO/IEC 20000.*
+*Não reproduz texto normativo ou tabelas das publicações ABNT/ISACA.*
+
+Recuperado do backup da estação Windows primária (2026-06); rastreia GitHub **#992**.

--- a/docs/ops/lab_lessons_learned/LAB_LESSON_AIIDCOBPP_QUAD_AUDIT.md
+++ b/docs/ops/lab_lessons_learned/LAB_LESSON_AIIDCOBPP_QUAD_AUDIT.md
@@ -1,0 +1,157 @@
+# Lab lesson — A.I.I.D.C.O.B.P.P. quad-audit pattern
+
+**Português (Brasil):** [LAB_LESSON_AIIDCOBPP_QUAD_AUDIT.pt_BR.md](LAB_LESSON_AIIDCOBPP_QUAD_AUDIT.pt_BR.md)
+
+**Date:** 2026-05-22/23 (session end)
+**Protocol:** A.I.I.D.C.O.B.P.P. (see below)
+**Status:** Empirically validated in lab production
+**Reference ADR:** [ADR-0062](../../adr/ADR-0062-agent-containment-triple-audit-offband-pingpong.md)
+**Diagram:** [`docs/adr/ADR-0062-diagram.mermaid`](../../adr/ADR-0062-diagram.mermaid)
+
+Recovered from primary Windows dev workstation backup into public archive (GitHub **#992**). Hostname codenames in the original draft were removed per PII policy; topology uses **LAB-NODE-01/02** placeholders aligned with ADR-0062.
+
+---
+
+## What is A.I.I.D.C.O.B.P.P.?
+
+**A**gent
+**I**solation
+**I**ndependent
+**D**ual (expanded to N)
+**C**ross-validation
+**O**ffband
+**B**us
+**P**ing
+**P**ong
+
+In plain language: independent agent isolation with offband cross-validation via a ping-pong bus.
+
+The canonical pattern name remains **triple-audit** (three original auditors). With a fourth auditor (mobile Claude) the configuration became **quad-audit**, but the protocol filename stays `triple-audit` — it is a pattern name, not a rigid counter. ADR-0062 **Extensibility** documents scaling to N auditors.
+
+---
+
+## Context — why the protocol exists
+
+During wave-656 (PR #658), the Cursor agent exhibited rule-sequencing drift (`.mdc` rules), ignoring imperative scope boundaries. The agent operated autonomously beyond authorization, creating regression risk and off-band token consumption.
+
+IDE-native barriers (Cursor rules, `AGENTS.md`) are necessary but insufficient to contain chronic non-determinism in long autonomous sessions.
+
+**Conclusion:** No single agent — however well instructed — can be the arbiter of its own compliance.
+
+---
+
+## Protocol topology
+
+```
+Operator
+│   ↓ distributes payload
+├── Auditor A: Claude Windows (LAB-NODE-01) — field, repo access
+├── Auditor B: Claude Linux  (LAB-NODE-02) — local topology verification
+├── Auditor C: Gemini        — structural validation / control tower
+└── Auditor D: Claude mobile — aerial view (shallow context)
+         ↓ convergence
+    Cursor / Git (executor — works only)
+```
+
+**Fundamental rule:** Auditors do **not** communicate with each other. The Operator is the physical data bus routing payloads via manual ping-pong.
+
+> LLM consensus ≠ source of truth. The source of truth is the repository.
+
+---
+
+## What we learned
+
+### 1. Blind spots are systematic, not accidental
+
+Three LLMs converged on a wrong ADR filename without consulting the repo. Consensus amplified the error. Only repository verification corrected all three simultaneously.
+
+### 2. Auditors with different context depth are complementary
+
+- Auditors A/B/C were inside the forest — precise on trees, missed forest-level gaps.
+- Auditor D (mobile, shallow context) surfaced eight documentary gaps, translation asymmetries, and format weeds the trio missed.
+- The combination beats any single auditor.
+
+### 3. Product CI detected PII that LLMs missed
+
+`test_public_tree_no_l14_codename.py` blocked merge of an ADR draft containing real workstation codenames. Three LLM layers missed it; the automated guardrail intercepted before merge.
+
+**Largest empirical validation:** the product detected PII in its own development process.
+
+### 4. Rust guard changed the check-all ritual
+
+A commit added `cargo fmt + cargo check + cargo test` to `check-all.ps1` without documenting rationale. Runtime grew from ~2–3 min to ~6 min, making routine pre-commit impractical and increasing `--no-verify` use.
+
+### 5. ADR-0045 existed but was not consulted
+
+ADR-0061 and ADR-0062 were drafted without the canonical MADR format from ADR-0045 — YAML lint errors, missing required fields, wrong metadata shape.
+
+### 6. Issues created without P labels or milestone
+
+Issues #668–#675 had correct bodies but no P labels or milestone — direct taxonomy contract violation (ADR-0055).
+
+---
+
+## Blameless incident table
+
+| Incident | Root cause | Who caught it |
+| --- | --- | --- |
+| Real hostname codenames in ADR draft | LLMs did not verify vs repo | CI (`test_public_tree_no_l14_codename.py`) |
+| Stale `INVENTORY.txt` hash | ADR fix did not refresh hash | Gemini (after CI log analysis) |
+| ADR-0061/0062 off ADR-0045 format | ADR-0045 not consulted | Mobile auditor (aerial) + Windows auditor |
+| #668–#675 missing labels/milestone | Manual browser creation | Linux auditor (post-compaction) |
+| Rust guard in check-all | Cursor added without documented reason | Windows auditor (git log) |
+
+---
+
+## When to use
+
+- Critical waves (G2/G3) touching security, IP, or architecture
+- After autonomous agent scope drift in the prior session
+- When long context may bias primary auditors
+- **Not** for routine P3/backlog — toil does not pay
+
+---
+
+## Operating steps (summary)
+
+1. Operator defines payload; opens isolated auditor sessions.
+2. Ping-pong A ↔ B until convergence; escalate structural review to C; use D for forest-level gaps.
+3. Only after auditor convergence → Cursor executes with explicit PASSO / ALLOW gates.
+4. CI green → Operator merges (never the agent).
+5. Final aerial pass on created artifacts; apply taxonomy if needed; local `check-all` as closing gate.
+
+---
+
+## ROI observed (wave-656 session)
+
+| Metric | Value |
+| --- | --- |
+| PRs merged | 4 (#658, #665, #666, #667) |
+| Issues created | 8 (#668–#675) |
+| ADRs produced | 2 (ADR-0061, ADR-0062) |
+| PII removed before merge | workstation codenames in ADR draft |
+| Forest-level gaps (auditor D) | 8 documentary items |
+| Final check-all | 1224 passed, 4 skipped, 0 failed |
+
+For lower-severity future waves, triple-audit (A+B+C) without D is acceptable.
+
+---
+
+## Naming
+
+- **Pattern name:** `triple-audit-offband-pingpong`
+- **ADR filename:** `ADR-0062-agent-containment-triple-audit-offband-pingpong.md` — do not rename
+- **Quad-audit:** descriptive term for four-auditor configuration, not a separate protocol name
+
+---
+
+## References
+
+- [ADR-0062](../../adr/ADR-0062-agent-containment-triple-audit-offband-pingpong.md)
+- [ADR-0061](../../adr/ADR-0061-u-axis-issue-suborder-and-cross-milestone-gate.md)
+- [ADR-0045](../../adr/ADR-0045-adr-metadata-and-format-standardization.md)
+- [ADR-0055](../../adr/ADR-0055-orthogonal-priority-axes-anti-collision-contract.md)
+- [`docs/SECURITY_GOVERNANCE_POSTURE_HUB.md`](../../SECURITY_GOVERNANCE_POSTURE_HUB.md)
+- Issues #668–#675 · PRs #658, #665, #666, #667
+
+Roster reconciliation with current harness usage tracks GitHub **#991** (ADR-0062 amendment).

--- a/docs/ops/lab_lessons_learned/LAB_LESSON_AIIDCOBPP_QUAD_AUDIT.pt_BR.md
+++ b/docs/ops/lab_lessons_learned/LAB_LESSON_AIIDCOBPP_QUAD_AUDIT.pt_BR.md
@@ -1,0 +1,90 @@
+# Lab lesson — padrão quad-audit A.I.I.D.C.O.B.P.P.
+
+**English:** [LAB_LESSON_AIIDCOBPP_QUAD_AUDIT.md](LAB_LESSON_AIIDCOBPP_QUAD_AUDIT.md)
+
+**Data:** 2026-05-22/23 (fim da sessão)
+**Protocolo:** A.I.I.D.C.O.B.P.P. (ver abaixo)
+**Status:** Validado empiricamente em produção de lab
+**ADR de referência:** [ADR-0062](../../adr/ADR-0062-agent-containment-triple-audit-offband-pingpong.md)
+**Diagrama:** [`docs/adr/ADR-0062-diagram.mermaid`](../../adr/ADR-0062-diagram.mermaid)
+
+Recuperado do backup da estação Windows primária para arquivo público (GitHub **#992**). Codinomes de hostname do rascunho original foram removidos conforme política de PII; a topologia usa placeholders **LAB-NODE-01/02** alinhados ao ADR-0062.
+
+---
+
+## O que é o A.I.I.D.C.O.B.P.P.?
+
+**A**gent · **I**solation · **I**ndependent · **D**ual (expandido para N) · **C**ross-validation · **O**ffband · **B**us · **P**ing · **P**ong
+
+Em português: isolamento de agentes independentes com validação cruzada offband via barramento ping-pong.
+
+O nome canônico do padrão permanece **triple-audit**. Com um quarto auditor (Claude mobile) a configuração virou **quad-audit**, mas o nome do protocolo não é um contador rígido. A seção **Extensibility** do ADR-0062 documenta escala para N auditores.
+
+---
+
+## Contexto
+
+Na wave-656 (PR #658), o agente Cursor apresentou desvio de sequenciamento de regras (`.mdc`), ignorando limites imperativos de escopo e gerando risco de regressão e consumo off-band de tokens.
+
+Barreiras nativas da IDE (regras Cursor, `AGENTS.md`) são necessárias mas insuficientes para conter não-determinismo crônico em sessões longas.
+
+**Conclusão:** Nenhum agente único pode ser árbitro da própria conformidade.
+
+---
+
+## Topologia
+
+```
+Operador
+│   ↓ distribui payload
+├── Auditor A: Claude Windows (LAB-NODE-01)
+├── Auditor B: Claude Linux  (LAB-NODE-02)
+├── Auditor C: Gemini
+└── Auditor D: Claude mobile (visão aérea)
+         ↓ convergência
+    Cursor / Git (executor — labora apenas)
+```
+
+**Regra fundamental:** Os auditores **não** se comunicam entre si. O Operador é o barramento físico.
+
+> Consenso de LLMs ≠ fonte da verdade. A fonte da verdade é o repositório.
+
+---
+
+## Aprendizados principais
+
+1. **Blind spots são sistemáticos** — três LLMs convergiram para filename errado de ADR sem consultar o repo.
+2. **Profundidades de contexto complementares** — auditor D (mobile) viu gaps de floresta que A/B/C perderam.
+3. **CI do produto detectou PII** que LLMs deixaram passar (`test_public_tree_no_l14_codename.py`).
+4. **Guard Rust no check-all** alongou o ritual (~6 min) sem documentação de motivo.
+5. **ADR-0045 não foi consultado** ao redigir ADR-0061/0062.
+6. **Issues #668–#675** criadas sem labels P nem milestone (ADR-0055).
+
+---
+
+## Quando usar
+
+- Waves críticas (G2/G3) com impacto em segurança, IP ou arquitetura
+- Após desvio de escopo do agente autônomo na sessão anterior
+- **Não** usar para backlog P3 rotineiro
+
+---
+
+## ROI observado (sessão wave-656)
+
+| Métrica | Valor |
+| --- | --- |
+| PRs mergeados | 4 (#658, #665, #666, #667) |
+| Issues criadas | 8 (#668–#675) |
+| ADRs produzidos | 2 (ADR-0061, ADR-0062) |
+| PII removido antes do merge | codinomes de estação no rascunho de ADR |
+| Gaps de floresta (auditor D) | 8 itens documentais |
+| check-all final | 1224 passed, 4 skipped, 0 failed |
+
+---
+
+## Referências
+
+- [ADR-0062](../../adr/ADR-0062-agent-containment-triple-audit-offband-pingpong.md) · [ADR-0061](../../adr/ADR-0061-u-axis-issue-suborder-and-cross-milestone-gate.md) · [ADR-0045](../../adr/ADR-0045-adr-metadata-and-format-standardization.md)
+- [`docs/SECURITY_GOVERNANCE_POSTURE_HUB.md`](../../SECURITY_GOVERNANCE_POSTURE_HUB.md)
+- Reconciliação de roster com harness atual: GitHub **#991**

--- a/docs/ops/lab_lessons_learned/README.md
+++ b/docs/ops/lab_lessons_learned/README.md
@@ -11,6 +11,7 @@ This directory holds **immutable, dated** snapshots of lab QA / SRE evidence (me
 | Artifact | Rule |
 | -------- | ---- |
 | **Dated snapshot** | `LAB_LESSONS_LEARNED_YYYY_MM_DD.md` (calendar date of the **session end** in the operator timezone used for the write-up; **one file per session** unless the operator explicitly splits). |
+| **Named lesson** | `LAB_LESSON_<TOPIC>.md` (+ optional `.pt_BR.md`) for durable patterns validated by ADRs — e.g. [`LAB_LESSON_AIIDCOBPP_QUAD_AUDIT.md`](LAB_LESSON_AIIDCOBPP_QUAD_AUDIT.md) (ADR-0062, GitHub **#992**). |
 | **Hub** | [`docs/ops/LAB_LESSONS_LEARNED.md`](../LAB_LESSONS_LEARNED.md) — short **current** narrative + archive index + **follow-up** pointers into **`docs/plans/PLANS_TODO.md`**. |
 | **Private completão narrative** | `docs/private/homelab/COMPLETAO_SESSION_*.md` — hostnames, LAN, operator commentary; **never** copy those verbatim into this archive. |
 


### PR DESCRIPTION
## Summary
- Add `docs/SECURITY_GOVERNANCE_POSTURE_HUB.md` (+ pt_BR): co-located index for cyber, governance, safety, code quality, provenance (ADR-0057 pattern)
- Recover from L14 backup: `LAB_LESSON_AIIDCOBPP_QUAD_AUDIT` (sanitized — no hostname codenames), `DATABOAR_GOVERNANCE_DIAGRAMS`, `ADR-0062-diagram.mermaid`
- Register hub in `docs/hubs/INDEX.md`; link from `SECURITY.md`

## Not in this PR
- PDF decks (operator exposure decision — stay private)
- ADR-0045/0062 amendments (#993, #991)
- Drift reconciliation roster (#991)

## Test plan
- [x] `bash scripts/check-hubs.sh`
- [x] `pytest tests/test_docs_external_no_plan_links.py tests/test_public_tree_no_l14_codename.py`
- [x] pre-commit on commit
- [x] CI green

Does not close #992 or #406. No ADR attest.


Made with [Cursor](https://cursor.com)