### PR TITLE
ci(security): supply-chain Layer 1 — refs #988

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,3 +52,15 @@ updates:
       prefix: "ci(actions)"
     cooldown:
       default-days: 7
+
+  # Base image digest pins in Dockerfile (ADR-0074 / #988).
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels: ["dependencies", "docker"]
+    commit-message:
+      prefix: "deps(docker)"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,21 @@ jobs:
       - name: Run pip audit
         run: uv run pip-audit --ignore-vuln PYSEC-2024-277 --ignore-vuln PYSEC-2026-89 --ignore-vuln PYSEC-2025-183 --ignore-vuln PYSEC-2026-217
 
+  dependency-review:
+    name: Dependency review (PR)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@56339e523c0409420f6c2c9a2f4292bbb3c07dd3 # v4.8.0
+
   sonar:
     name: SonarQube / SonarCloud
     runs-on: ubuntu-latest
@@ -227,7 +242,7 @@ jobs:
   slack-notify-on-failure:
     name: Slack CI failure notify
     if: ${{ always() && contains(needs.*.result, 'failure') }}
-    needs: [test, lint, bandit, audit, sonar]
+    needs: [test, lint, bandit, audit, dependency-review, sonar]
     uses: ./.github/workflows/slack-ci-failure-notify.yml
     with:
       run_name: CI

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -82,7 +82,7 @@ jobs:
       # Supply-chain Layer 1 (ADR-0074 / GitHub #988): Rust SCA before merge.
       - name: Install cargo-audit and cargo-deny
         run: |
-          cargo install cargo-audit --version 0.21.2 --locked --force
+          cargo install cargo-audit --version 0.22.2 --locked --force
           cargo install cargo-deny --version 0.17.0 --locked --force
 
       - name: cargo audit (RUSTSEC)

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Install cargo-audit and cargo-deny
         run: |
           cargo install cargo-audit --version 0.22.2 --locked --force
-          cargo install cargo-deny --version 0.17.0 --locked --force
+          cargo install cargo-deny --version 0.19.9 --locked --force
 
       - name: cargo audit (RUSTSEC)
         run: cargo audit

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -76,7 +76,17 @@ jobs:
       - name: cargo test
         run: cargo test --all-targets --locked
 
-      # `-D warnings` promotes every clippy lint to an error so the job fails
-      # on any new warning introduced in the crate.
       - name: cargo clippy (deny warnings)
         run: cargo clippy --all-targets --locked -- -D warnings
+
+      # Supply-chain Layer 1 (ADR-0074 / GitHub #988): Rust SCA before merge.
+      - name: Install cargo-audit and cargo-deny
+        run: |
+          cargo install cargo-audit --version 0.21.2 --locked --force
+          cargo install cargo-deny --version 0.17.0 --locked --force
+
+      - name: cargo audit (RUSTSEC)
+        run: cargo audit
+
+      - name: cargo deny check
+        run: cargo deny check advisories bans licenses sources

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@
 # Rolling 3.13 slim: aligns with CI (3.12 + 3.13), requires-python >=3.12, and Docker Scout
 # base-image recommendations (fewer base CVEs vs. 3.12-slim at last scan).
 # Digest pin (ADR-0074 / #988): tag-only FROM is tag-moving risk; Dependabot docker ecosystem
-# proposes digest bumps. Human tag comment for review.
-FROM python:3.13-slim@sha256:3a2c25932e66f706172de831a1b283d491c53ef876cd7fc55a62bcf9a6dd2c61 AS builder # python:3.13-slim
+# proposes digest bumps. Human tag comment for review (python:3.13-slim).
+FROM python:3.13-slim@sha256:3a2c25932e66f706172de831a1b283d491c53ef876cd7fc55a62bcf9a6dd2c61 AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential gcc g++ pkg-config \
@@ -37,7 +37,8 @@ RUN pip uninstall -y wheel || true && \
 # -----------------------------------------------------------------------------
 # Stage 2: minimal runtime (no build tools, only runtime libs + app)
 # -----------------------------------------------------------------------------
-FROM python:3.13-slim@sha256:3a2c25932e66f706172de831a1b283d491c53ef876cd7fc55a62bcf9a6dd2c61 # python:3.13-slim
+# python:3.13-slim (digest pin; same as builder stage).
+FROM python:3.13-slim@sha256:3a2c25932e66f706172de831a1b283d491c53ef876cd7fc55a62bcf9a6dd2c61
 
 LABEL org.opencontainers.image.description="LGPD/GDPR/CCPA audit. Default: web API and frontend on port 8088. Override command for CLI one-shot."
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@
 # -----------------------------------------------------------------------------
 # Rolling 3.13 slim: aligns with CI (3.12 + 3.13), requires-python >=3.12, and Docker Scout
 # base-image recommendations (fewer base CVEs vs. 3.12-slim at last scan).
-FROM python:3.13-slim AS builder
+# Digest pin (ADR-0074 / #988): tag-only FROM is tag-moving risk; Dependabot docker ecosystem
+# proposes digest bumps. Human tag comment for review.
+FROM python:3.13-slim@sha256:3a2c25932e66f706172de831a1b283d491c53ef876cd7fc55a62bcf9a6dd2c61 AS builder # python:3.13-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential gcc g++ pkg-config \
@@ -35,7 +37,7 @@ RUN pip uninstall -y wheel || true && \
 # -----------------------------------------------------------------------------
 # Stage 2: minimal runtime (no build tools, only runtime libs + app)
 # -----------------------------------------------------------------------------
-FROM python:3.13-slim
+FROM python:3.13-slim@sha256:3a2c25932e66f706172de831a1b283d491c53ef876cd7fc55a62bcf9a6dd2c61 # python:3.13-slim
 
 LABEL org.opencontainers.image.description="LGPD/GDPR/CCPA audit. Default: web API and frontend on port 8088. Override command for CLI one-shot."
 

--- a/rust/boar_fast_filter/Cargo.toml
+++ b/rust/boar_fast_filter/Cargo.toml
@@ -2,6 +2,7 @@
 name = "boar_fast_filter"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 
 [lib]
 name = "boar_fast_filter"

--- a/rust/boar_fast_filter/deny.toml
+++ b/rust/boar_fast_filter/deny.toml
@@ -1,6 +1,6 @@
 # cargo-deny policy for boar_fast_filter (ADR-0074 Layer 1 / GitHub #988).
 # Run: cargo deny check advisories bans licenses sources
-# Schema: advisories/licenses version 2 (cargo-deny 0.17+; deprecated keys removed).
+# Schema: advisories/licenses version 2 (cargo-deny 0.18.6+ for CVSS 4.0 advisory DB).
 
 [advisories]
 version = 2

--- a/rust/boar_fast_filter/deny.toml
+++ b/rust/boar_fast_filter/deny.toml
@@ -1,14 +1,13 @@
 # cargo-deny policy for boar_fast_filter (ADR-0074 Layer 1 / GitHub #988).
 # Run: cargo deny check advisories bans licenses sources
+# Schema: advisories/licenses version 2 (cargo-deny 0.17+; deprecated keys removed).
 
 [advisories]
-vulnerability = "deny"
-unmaintained = "warn"
+version = 2
 yanked = "warn"
-notice = "warn"
 
 [licenses]
-unlicensed = "deny"
+version = 2
 allow = [
     "MIT",
     "Apache-2.0",

--- a/rust/boar_fast_filter/deny.toml
+++ b/rust/boar_fast_filter/deny.toml
@@ -1,0 +1,27 @@
+# cargo-deny policy for boar_fast_filter (ADR-0074 Layer 1 / GitHub #988).
+# Run: cargo deny check advisories bans licenses sources
+
+[advisories]
+vulnerability = "deny"
+unmaintained = "warn"
+yanked = "warn"
+notice = "warn"
+
+[licenses]
+unlicensed = "deny"
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "Unicode-3.0",
+]
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+unknown-registry = "warn"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/rust/boar_fast_filter/deny.toml
+++ b/rust/boar_fast_filter/deny.toml
@@ -11,6 +11,7 @@ version = 2
 allow = [
     "MIT",
     "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
     "BSD-3-Clause",
     "Unicode-3.0",
 ]

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -56,7 +56,11 @@ def test_slack_ci_failure_notify_workflow_present_and_valid() -> None:
 def test_upstream_workflows_invoke_slack_ci_failure_notify_on_failure() -> None:
     """Failure Slack ping is workflow_call from upstream CI workflows (not workflow_run)."""
     callers = (
-        ("ci.yml", "CI", ("test", "lint", "bandit", "audit", "sonar")),
+        (
+            "ci.yml",
+            "CI",
+            ("test", "lint", "bandit", "audit", "dependency-review", "sonar"),
+        ),
         ("semgrep.yml", "Semgrep", ("semgrep",)),
         ("gitleaks.yml", "Gitleaks", ("scan",)),
         ("sbom.yml", "SBOM", ("generate",)),
@@ -332,6 +336,41 @@ def test_ci_yml_pins_actions_and_uv_cli() -> None:
         assert sha_40.search(code), (
             f"expected full commit SHA in uses line: {line.strip()!r}"
         )
+
+
+def test_ci_yml_has_dependency_review_job_on_pull_request() -> None:
+    """ADR-0074 Layer 1 / #988: PR-time dependency diff before merge."""
+    data = _load_workflow("ci.yml")
+    jobs = data.get("jobs") or {}
+    dep = jobs.get("dependency-review")
+    assert isinstance(dep, dict), "ci.yml must define dependency-review job"
+    assert "pull_request" in str(dep.get("if") or "")
+    perms = dep.get("permissions") or {}
+    assert perms.get("pull-requests") == "read"
+    steps = dep.get("steps") or []
+    uses = [str(s.get("uses")) for s in steps if isinstance(s, dict) and s.get("uses")]
+    assert any("actions/dependency-review-action@" in u for u in uses)
+
+
+def test_rust_ci_runs_cargo_audit_and_deny() -> None:
+    """ADR-0074 Layer 1 / #988: Rust SCA in rust-ci.yml."""
+    text = (WORKFLOWS / "rust-ci.yml").read_text(encoding="utf-8")
+    assert "cargo audit" in text
+    assert "cargo deny check" in text
+
+
+def test_dockerfile_pins_python_base_image_by_digest() -> None:
+    """ADR-0074 Layer 1 / #988: base image digest pin, not tag-only FROM."""
+    dockerfile = REPO_ROOT / "Dockerfile"
+    text = dockerfile.read_text(encoding="utf-8")
+    from_lines = [
+        line.strip()
+        for line in text.splitlines()
+        if line.strip().upper().startswith("FROM ")
+    ]
+    assert len(from_lines) >= 2
+    for line in from_lines:
+        assert "@sha256:" in line, f"expected digest pin in FROM line: {line!r}"
 
 
 def test_dependabot_sync_workflow_present_and_valid() -> None:


### PR DESCRIPTION
## Summary

Implements **ADR-0074 Layer 1** CI gates (GitHub #988):

| Gap | Change |
|-----|--------|
| Rust SCA | `cargo-audit` + `cargo deny check` in `rust-ci.yml`; `rust/boar_fast_filter/deny.toml` |
| PR dep diff | `dependency-review` job in `ci.yml` (`actions/dependency-review-action@…` v4.8.0, SHA-pinned) |
| Base image | `Dockerfile` `FROM python:3.13-slim@sha256:3a2c…` (both stages) |
| Digest maintenance | Dependabot `docker` ecosystem on `/` |

## Related

- ADR-0074 (Proposed, PR #997) — posture; **#989** will amend Layers 3+4 (forward-ref pushed to #997)
- #984 Pester — orthogonal

## Test plan

- [x] `./scripts/lint-only.sh`
- [x] `pytest tests/test_github_workflows.py` (incl. new regression guards)
- [ ] CI (first run will compile/install cargo-audit/deny on rust path)

Closes #988 when merged. Does **not** close #406.

Made with [Cursor](https://cursor.com)