### PR TITLE
fix(maestro): #969 alpine sync scp+tar fallback + status reset

### DIFF
--- a/scripts/maestro/Get-LabStatus.ps1
+++ b/scripts/maestro/Get-LabStatus.ps1
@@ -3,7 +3,8 @@
 
 param(
     [Parameter(Mandatory=$true)][string]$TargetHost,
-    [Parameter(Mandatory=$true)][string]$TargetUser
+    [Parameter(Mandatory=$true)][string]$TargetUser,
+    [string]$RunMarker = ""
 )
 
 $expectedSession = "completao"
@@ -50,11 +51,15 @@ if ($LASTEXITCODE -eq 0 -and $null -ne $rawOutput) {
         $tmux = "COLD (No Session)"
     }
 
-    # 4. Le telemetria (sem criar novas variaveis desnecessarias ou abrir novas sessoes ssh)
-    if ($statusRaw) {
+    # 4. Le telemetria (#969: NOT_RUN apos reset; STALE se marker de outro turno)
+    if ($statusRaw -match '^\s*NOT_RUN\b') {
+        $lastResult = "NOT_RUN"
+    } elseif ($RunMarker -and $statusRaw -and $statusRaw -notmatch [regex]::Escape($RunMarker)) {
+        $lastResult = "STALE ($statusRaw)"
+    } elseif ($statusRaw) {
         $lastResult = $statusRaw
     } else {
-        $lastResult = "PENDING"
+        $lastResult = "NOT_RUN"
     }
 }
 

--- a/scripts/maestro/Lab-MaestroCommon.ps1
+++ b/scripts/maestro/Lab-MaestroCommon.ps1
@@ -85,3 +85,18 @@ function Clear-RemoteSentinel {
     $cmd = "rm -f $SentinelFile"
     ssh -q -o BatchMode=yes -o ConnectTimeout=15 "$($Node.user)@$($Node.hostname)" "$cmd" > $null 2>&1
 }
+
+function Reset-LabOpStatus {
+    <#
+    #969: clear stale ~/.labop-status at the start of each Maestro turn so yesterday's
+    DONE_FAILED does not masquerade as the current run outcome.
+    #>
+    param(
+        [Parameter(Mandatory = $true)]$Node,
+        [Parameter(Mandatory = $true)][string]$RunMarker
+    )
+    $safeMarker = $RunMarker -replace "'", ""
+    $cmd = "echo 'NOT_RUN maestro=$safeMarker at '`$(date -Iseconds 2>/dev/null || date +%Y-%m-%dT%H:%M:%S)' > ~/.labop-status"
+    ssh -q -o BatchMode=yes -o ConnectTimeout=8 "$($Node.user)@$($Node.hostname)" "$cmd" > $null 2>&1
+    return ($LASTEXITCODE -eq 0)
+}

--- a/scripts/maestro/Maestro.ps1
+++ b/scripts/maestro/Maestro.ps1
@@ -36,7 +36,9 @@ if (-not (Test-Path $inventoryPath)) {
 
 # 2. Carregamento dos dados do Lab-Op [cite: 8, 16]
 $inventory = Get-Content $inventoryPath | ConvertFrom-Json
-Write-Host "--- [Maestro] Iniciando Turno no Lab-Op (Ref: $Ref) ---" -ForegroundColor Cyan
+. "$PSScriptRoot/Lab-MaestroCommon.ps1"
+$script:MaestroRunMarker = Get-Date -Format "yyyyMMdd_HHmmss"
+Write-Host "--- [Maestro] Iniciando Turno no Lab-Op (Ref: $Ref, run=$($script:MaestroRunMarker)) ---" -ForegroundColor Cyan
 $warningCount = 0
 $realFailCount = 0
 # Personas that write /tmp/databoar_handler/<persona>_sentinel.txt (#831); web is inline health only.
@@ -70,8 +72,11 @@ elseif (-not $Collect) {
 # 3. Processamento dos Membros do Laboratório
 $globalReport = foreach ($node in $inventory.lab_members) {
 
+    # #969: reset per-host status before probe so stale ~/.labop-status never reads as current.
+    [void](Reset-LabOpStatus -Node $node -RunMarker $script:MaestroRunMarker)
+
     # Pre-flight Check: Injetando PII via argumentos (Agnosticismo)[cite: 14, 16]
-    $status = & "$PSScriptRoot/Get-LabStatus.ps1" -TargetHost $node.hostname -TargetUser $node.user
+    $status = & "$PSScriptRoot/Get-LabStatus.ps1" -TargetHost $node.hostname -TargetUser $node.user -RunMarker $script:MaestroRunMarker
 
     # SRE FIX: Se estivermos apenas coletando (-Collect), NÃO dispare a orquestração de novo!
     if ($status.SSH -eq "UP" -and -not $Collect) {
@@ -134,6 +139,9 @@ $globalReport = foreach ($node in $inventory.lab_members) {
                 Write-Warning "      [WARNING] Handler ausente para persona '$persona' em $($node.hostname): $handler"
             }
         }
+
+        # Refresh status for final report after handlers may have updated ~/.labop-status (#969).
+        $status = & "$PSScriptRoot/Get-LabStatus.ps1" -TargetHost $node.hostname -TargetUser $node.user -RunMarker $script:MaestroRunMarker
     }
 
     $status # Acumula para o relatório final [cite: 10]

--- a/scripts/maestro/Sync-WorkingTree.ps1
+++ b/scripts/maestro/Sync-WorkingTree.ps1
@@ -7,8 +7,8 @@
  Author: Fábio Leitão com apoio da Gemini e Cursosr IDE
  Missão principal: Sub-Orquestrador de sincronismo em pré-flight para o teste Completão funcionar no Lab-Op a partir do repo no gh ou da working tree no ambiente canônico de Dev principal no PC de desenvolvimento.
 
- #969: rsync e pre-req; se falhar (ex. exit 12 / rsync ausente no remoto), fallback tar|ssh com mesmas exclusoes.
- Narrow doas+apk rsync install fica para #958.
+ #969: rsync e pre-req; se falhar (ex. exit 12 / rsync ausente no remoto), fallback scp+tar
+ #969b: depois tar|ssh stream. Narrow doas+apk rsync install fica para #958.
 #>
 
 param(
@@ -65,6 +65,52 @@ function Test-SyncHashVerify {
     }
 
     Write-Host "      [Sync-Verify] Hash check OK (pyproject + Maestro)." -ForegroundColor DarkGray
+    return $true
+}
+
+function Invoke-SyncScpTarFallback {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepoRoot,
+        [Parameter(Mandatory = $true)][string]$RemoteUser,
+        [Parameter(Mandatory = $true)][string]$RemoteHost,
+        [Parameter(Mandatory = $true)][string]$RemotePath,
+        [int]$RsyncExitCode
+    )
+
+    Write-Warning "      [Sync-Fallback #969] rsync exit $RsyncExitCode em $RemoteHost; tentando scp+tar (remoto nao precisa de rsync — Consigliere #F4)."
+    $localTar = Join-Path ([System.IO.Path]::GetTempPath()) ("databoar-sync-" + [guid]::NewGuid().ToString("n") + ".tar.gz")
+    $remoteTar = "/tmp/databoar-sync-upload.tar.gz"
+    $escapedRoot = $RepoRoot -replace "'", "'\\''"
+    $tarLocalCmd = "tar -czf '$localTar' --exclude='.git' --exclude='.venv' --exclude='__pycache__' --exclude='.pytest_cache' --exclude='*.bundle' --exclude='docs/private' --exclude='*.log' --exclude='*.xlsx' --exclude='*.db' --exclude='data-boar-blackbox-audit.txt' --exclude='data-boar-*.tar' --exclude='.env' --exclude='.env.*' -C '$escapedRoot' ."
+
+    if ($IsWindows) {
+        wsl.exe -e bash -c $tarLocalCmd
+    } else {
+        bash -c $tarLocalCmd
+    }
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $localTar)) {
+        Write-Warning "      [Sync-Fallback] scp: falha ao criar tarball local (exit $LASTEXITCODE)."
+        if (Test-Path -LiteralPath $localTar) { Remove-Item -LiteralPath $localTar -Force -ErrorAction SilentlyContinue }
+        return $false
+    }
+
+    scp -q -o BatchMode=yes -o ConnectTimeout=15 "$localTar" "${RemoteUser}@${RemoteHost}:${remoteTar}"
+    $scpExit = $LASTEXITCODE
+    Remove-Item -LiteralPath $localTar -Force -ErrorAction SilentlyContinue
+    if ($scpExit -ne 0) {
+        Write-Warning "      [Sync-Fallback] scp falhou em $RemoteHost (exit $scpExit)."
+        ssh -q -o BatchMode=yes -o ConnectTimeout=15 "${RemoteUser}@${RemoteHost}" "rm -f $remoteTar" > $null 2>&1
+        return $false
+    }
+
+    $extractCmd = "mkdir -p $RemotePath && tar -xzf $remoteTar -C $RemotePath && rm -f $remoteTar"
+    ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "${RemoteUser}@${RemoteHost}" "$extractCmd"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "      [Sync-Fallback] scp: extract remoto falhou em $RemoteHost (exit $LASTEXITCODE)."
+        return $false
+    }
+
+    Write-Host "      [Sync-Fallback] scp+tar OK em $RemoteHost." -ForegroundColor DarkGray
     return $true
 }
 
@@ -125,7 +171,9 @@ if ($Ref -eq "WorkingTree") {
         $syncOk = Test-SyncHashVerify -RepoRoot $repoRoot -RemoteUser $targetUser -RemoteHost $targetHost -RemotePath $finalPath
     } else {
         Write-Warning "      [WARNING] rsync falhou no no $targetHost (exit $exitCode)."
-        if (Invoke-SyncTarSshFallback -RepoRoot $repoRoot -RemoteUser $targetUser -RemoteHost $targetHost -RemotePath $finalPath -RsyncExitCode $exitCode) {
+        if (Invoke-SyncScpTarFallback -RepoRoot $repoRoot -RemoteUser $targetUser -RemoteHost $targetHost -RemotePath $finalPath -RsyncExitCode $exitCode) {
+            $syncOk = Test-SyncHashVerify -RepoRoot $repoRoot -RemoteUser $targetUser -RemoteHost $targetHost -RemotePath $finalPath
+        } elseif (Invoke-SyncTarSshFallback -RepoRoot $repoRoot -RemoteUser $targetUser -RemoteHost $targetHost -RemotePath $finalPath -RsyncExitCode $exitCode) {
             $syncOk = Test-SyncHashVerify -RepoRoot $repoRoot -RemoteUser $targetUser -RemoteHost $targetHost -RemotePath $finalPath
         }
     }

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -903,16 +903,39 @@ def test_collect_artifacts_uses_repo_log_path() -> None:
 
 
 def test_sync_working_tree_tar_fallback_on_rsync_failure() -> None:
-    """#969: rsync failure triggers tar|ssh fallback with same exclude set."""
+    """#969: rsync failure triggers scp+tar then tar|ssh fallback with same exclude set."""
     root = _project_root()
     text = (root / "scripts" / "maestro" / "Sync-WorkingTree.ps1").read_text(
         encoding="utf-8", errors="replace"
     )
-    assert "Invoke-SyncTarSshFallback" in text
+    assert "Invoke-SyncScpTarFallback" in text
     assert "Sync-Fallback #969" in text
+    assert "Consigliere #F4" in text
+    assert "Invoke-SyncTarSshFallback" in text
     assert "tar -czf -" in text
     assert "tar -xzf -" in text
     assert "--exclude='docs/private'" in text
+
+
+def test_maestro_resets_labop_status_each_turn() -> None:
+    """#969: per-host ~/.labop-status reset at turn start; refresh after handlers."""
+    root = _project_root()
+    maestro = (root / "scripts" / "maestro" / "Maestro.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    common = (root / "scripts" / "maestro" / "Lab-MaestroCommon.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    status = (root / "scripts" / "maestro" / "Get-LabStatus.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "Reset-LabOpStatus" in common
+    assert "NOT_RUN maestro=" in common
+    assert "MaestroRunMarker" in maestro
+    assert "Reset-LabOpStatus -Node" in maestro
+    assert "-RunMarker $script:MaestroRunMarker" in maestro
+    assert "STALE (" in status
+    assert '"NOT_RUN"' in status
 
 
 def test_maestro_calls_wait_handler_sentinel_for_real_results() -> None:


### PR DESCRIPTION
## Description

FASE 1 (Sync) — **#969**: alpine caiu do run (rsync exit 12) + status STALE.

- **rsync → scp+tar → tar|ssh**: fallback scp+tar quando rsync falha (Consigliere #F4; remoto não precisa rsync); mantém tar|ssh stream como último recurso.
- **Reset per-host**: `Reset-LabOpStatus` no início de cada turno Maestro; `Get-LabStatus` expõe `NOT_RUN` / `STALE (...)` em vez de telemetria de ontem.
- Refresh de status após handlers para o relatório final.

## Type of change
- [x] Bug fix

## Checklist
- [x] `check-all.sh` — 1528 passed
- **NÃO** bump · **NÃO** fechar #406

Closes #969

Made with [Cursor](https://cursor.com)