### PR TITLE
fix(maestro): gate wiring + narrow privilege probe (#1021)

### DIFF
--- a/docs/private.example/homelab/labop-maestro-target-sudoers.example
+++ b/docs/private.example/homelab/labop-maestro-target-sudoers.example
@@ -1,6 +1,12 @@
 # Example: narrow sudoers for Maestro Handle-target_nfs / Handle-target_cifs
-# Copy fragments into /etc/sudoers.d/z-labop-host-report (or merge with existing LAB-OP drop-in).
-# Replace REPO_PATH and USER with operator values. Validate: sudo visudo -cf /etc/sudoers.d/z-labop-host-report
+# Copy fragments into /etc/sudoers.d/z-labop-maestro (or merge with existing LAB-OP drop-in).
+# Replace REPO_PATH and USER with operator values. Validate: sudo visudo -cf /etc/sudoers.d/z-labop-maestro
+#
+# Load order (#1021): files in /etc/sudoers.d/ are read lexically; the LAST matching rule wins.
+# If another drop-in (e.g. wheel) defines %wheel ALL=(ALL:ALL) ALL with password, LAB-OP files
+# MUST load AFTER it (prefix z- or zz-) or NOPASSWD narrow grants are silently overridden.
+# Verify with the real run (not only sudo -l):
+#   sudo -n /usr/bin/bash REPO_PATH/scripts/labop-fw-guard-ensure.sh --check
 #
 # Handlers invoke exactly:
 #   sudo -n bash REPO_PATH/scripts/labop-nfs-server-ensure.sh --check|--apply

--- a/docs/private.example/homelab/labop-maestro-target-sudoers.example
+++ b/docs/private.example/homelab/labop-maestro-target-sudoers.example
@@ -8,10 +8,11 @@
 # Verify with the real run (not only sudo -l):
 #   sudo -n /usr/bin/bash REPO_PATH/scripts/labop-fw-guard-ensure.sh --check
 #
-# Handlers invoke exactly:
-#   sudo -n bash REPO_PATH/scripts/labop-nfs-server-ensure.sh --check|--apply
-#   sudo -n bash REPO_PATH/scripts/labop-smb-server-ensure.sh --check|--apply
-# List BOTH /bin/bash and /usr/bin/bash (Void Linux may resolve bash to /usr/bin/bash).
+# Handlers invoke exactly (#1021 R8 — grant-match argv, env via .labop-gate/):
+#   Maestro writes REPO_PATH/.labop-gate/LAB_OP_SUBNET (and optional LAB_NFS_SVC) as the operator user.
+#   sudo -n /usr/bin/bash REPO_PATH/scripts/labop-nfs-server-ensure.sh --check|--apply
+#   sudo -n /usr/bin/bash REPO_PATH/scripts/labop-smb-server-ensure.sh --check|--apply
+#   (never: env LAB_OP_SUBNET=... bash — breaks narrow sudoers/doas literal match)
 
 Cmnd_Alias LABOP_NFS_SERVER = /bin/bash REPO_PATH/scripts/labop-nfs-server-ensure.sh --check, \
                               /usr/bin/bash REPO_PATH/scripts/labop-nfs-server-ensure.sh --check, \

--- a/scripts/labop-dep-doctor.sh
+++ b/scripts/labop-dep-doctor.sh
@@ -69,12 +69,19 @@ _detect_pm() {
 _pkg_logical_to_pm() {
   local logical="$1" pm="$2"
   case "$logical" in
-    procps) echo "procps" ;;
+    procps)
+      case "$pm" in
+        xbps) echo "procps-ng" ;;
+        apk) echo "procps" ;;
+        *) echo "procps" ;;
+      esac
+      ;;
     iproute2) echo "iproute2" ;;
     samba) echo "samba" ;;
     nfs-utils)
       case "$pm" in
         apt) echo "nfs-kernel-server" ;;
+        apk) echo "nfs-utils" ;;
         *) echo "nfs-utils" ;;
       esac
       ;;

--- a/scripts/labop-dep-doctor.sh
+++ b/scripts/labop-dep-doctor.sh
@@ -222,17 +222,64 @@ if [[ -z "$UV_BIN" ]]; then
 fi
 _log "uv: $UV_BIN ($("$UV_BIN" --version 2>/dev/null | head -1))"
 
+# uv/python probes must run as the operator, not root (#1021 R6 false-positive when root).
+_uv_run_as_operator() {
+  if [[ "$(id -un)" == "root" && -n "$_DD_OPERATOR" && "$_DD_OPERATOR" != "root" ]]; then
+    sudo -u "$_DD_OPERATOR" -H env PATH="$PATH" "$UV_BIN" run --project "$REPO_ROOT" "$@"
+  else
+    "$UV_BIN" run --project "$REPO_ROOT" "$@"
+  fi
+}
+
+_emit_optional_module_hints() {
+  _warn "HINT: optional 7z/compressed support: uv sync --extra compressed"
+  _warn "HINT: may need OS lzma headers (liblzma-dev / xz-dev / xz-devel)"
+  _warn "Host feature: 7z_UNSUPPORTED reason=optional_modules_degraded"
+}
+
+_optional_modules_only_gap() {
+  [[ $NEED_FIX -eq 1 && $PERSONA_OS_OK -eq 1 ]]
+}
+
+_uv_pip_install_py7zr() {
+  if [[ "$(id -un)" == "root" && -n "$_DD_OPERATOR" && "$_DD_OPERATOR" != "root" ]]; then
+    sudo -u "$_DD_OPERATOR" -H env PATH="$PATH" bash -c "cd '$REPO_ROOT' && '$UV_BIN' pip install 'py7zr>=0.20.0'"
+  else
+    (cd "$REPO_ROOT" && "$UV_BIN" pip install 'py7zr>=0.20.0')
+  fi
+}
+
+_uv_sync_compressed_graceful() {
+  local out ec=0
+  if [[ "$(id -un)" == "root" && -n "$_DD_OPERATOR" && "$_DD_OPERATOR" != "root" ]]; then
+    out="$(sudo -u "$_DD_OPERATOR" -H env PATH="$PATH" bash -c "cd '$REPO_ROOT' && '$UV_BIN' sync --extra compressed" 2>&1)" || ec=$?
+  else
+    out="$(cd "$REPO_ROOT" && "$UV_BIN" sync --extra compressed 2>&1)" || ec=$?
+  fi
+  printf '%s\n' "$out"
+  if [[ $ec -eq 0 ]]; then
+    return 0
+  fi
+  if grep -qiE 'scikit-learn|Failed to build|failed-wheel|error: failed' <<<"$out"; then
+    _warn "uv sync failed on ML/core build (min-spec); trying py7zr-only pip install"
+    if _uv_pip_install_py7zr 2>&1; then
+      return 0
+    fi
+  fi
+  return "$ec"
+}
+
 # ---------------------------------------------------------------------------
 # Phase 2: probe for known optional modules
 # ---------------------------------------------------------------------------
 probe_module() {
   local mod="$1"
-  "$UV_BIN" run --project "$REPO_ROOT" python3 -c "import $mod" >/dev/null 2>&1
+  _uv_run_as_operator python3 -c "import $mod" >/dev/null 2>&1
   return $?
 }
 
 probe_lzma() {
-  "$UV_BIN" run --project "$REPO_ROOT" python3 -c "import lzma" >/dev/null 2>&1
+  _uv_run_as_operator python3 -c "import lzma" >/dev/null 2>&1
   return $?
 }
 
@@ -261,6 +308,11 @@ if [[ $NEED_FIX -eq 0 ]]; then
 fi
 
 if [[ $CHECK_ONLY -eq 1 ]]; then
+  if _optional_modules_only_gap; then
+    _emit_optional_module_hints
+    _ok "optional_modules_degraded (graceful; gate may proceed)"
+    exit 0
+  fi
   _warn "Check-only mode: fixes needed but not applied."
   exit 1
 fi
@@ -269,7 +321,7 @@ fi
 # Phase 3: try uv sync --extra compressed (safe, no root needed)
 # ---------------------------------------------------------------------------
 _log "Step 1: uv sync --extra compressed"
-if (cd "$REPO_ROOT" && "$UV_BIN" sync --extra compressed 2>&1); then
+if _uv_sync_compressed_graceful; then
   _log "uv sync succeeded. Re-probing py7zr..."
   if probe_module "py7zr"; then
     _ok "py7zr now importable after uv sync."
@@ -338,7 +390,7 @@ fi
 # Phase 6: re-sync and final probe
 # ---------------------------------------------------------------------------
 _log "Step 4: uv sync --extra compressed (post-install)"
-(cd "$REPO_ROOT" && "$UV_BIN" sync --extra compressed 2>&1) || _warn "Post-install sync failed."
+_uv_sync_compressed_graceful || _warn "Post-install sync failed."
 
 _log "Final probe..."
 if probe_lzma && probe_module "py7zr"; then
@@ -349,6 +401,11 @@ if probe_lzma && probe_module "py7zr"; then
   _ok "All optional modules healthy after full remediation."
   exit 0
 else
+  if _optional_modules_only_gap; then
+    _emit_optional_module_hints
+    _ok "optional_modules_degraded after remediation (graceful)"
+    exit 0
+  fi
   _fail "Modules still unavailable after all remediation steps."
   _warn "Host feature: 7z_UNSUPPORTED reason=lzma_unavailable_after_all_steps"
   exit 1

--- a/scripts/labop-dep-doctor.sh
+++ b/scripts/labop-dep-doctor.sh
@@ -56,9 +56,6 @@ _ok()  { echo "[DepDoctor] OK: $*"; }
 _warn(){ echo "[DepDoctor] WARN: $*" >&2; }
 _fail(){ echo "[DepDoctor] FAIL: $*" >&2; }
 
-HOST=$(hostname -f 2>/dev/null || hostname)
-_log "Starting on $HOST (check_only=$CHECK_ONLY privileged=$PRIVILEGED apply_only=$APPLY_ONLY personas=${PERSONAS_RAW:-<none>})"
-
 _detect_pm() {
   if command -v apt-get >/dev/null 2>&1; then echo "apt"; return 0; fi
   if command -v xbps-install >/dev/null 2>&1; then echo "xbps"; return 0; fi
@@ -180,10 +177,13 @@ _run_persona_os_phase() {
   return 0
 }
 
+HOST=$(hostname -f 2>/dev/null || hostname)
+_load_personas_from_gate_context
+_log "Starting on $HOST (check_only=$CHECK_ONLY privileged=$PRIVILEGED apply_only=$APPLY_ONLY personas=${PERSONAS_RAW:-<none>})"
+
 # ---------------------------------------------------------------------------
 # Phase 0: persona OS packages (#958) before Python probes
 # ---------------------------------------------------------------------------
-_load_personas_from_gate_context
 PERSONA_OS_OK=1
 if [[ -n "$PERSONAS_RAW" ]]; then
   if ! _run_persona_os_phase; then

--- a/scripts/labop-gate-readiness.sh
+++ b/scripts/labop-gate-readiness.sh
@@ -155,18 +155,98 @@ _any_persona() {
   return 1
 }
 
-# --- Privilege probe (#954 / #959) ---
+_FW_GUARD_SCRIPT="$SCRIPT_DIR/labop-fw-guard-ensure.sh"
+_FW_GUARD_PROBE_DONE=0
+_FW_GUARD_PROBE_EC=0
+_FW_GUARD_PROBE_OUT=""
+_PRIV_DETAIL=""
+
+_sudo_l_has_labop_grant() {
+  local listing
+  listing="$(sudo -n -l 2>/dev/null)" || return 1
+  grep -qE 'LABOP_(FW_GUARD|DEP_DOCTOR|NFS_SERVER|SMB_SERVER)|labop-(fw-guard|dep-doctor|nfs-server|smb-server)-ensure\.sh' <<<"$listing"
+}
+
+_doas_c_has_labop_grant() {
+  local conf
+  for conf in /etc/doas.conf /etc/doas.d/*.conf; do
+    [[ -f "$conf" ]] || continue
+    if doas -C "$conf" bash "$_FW_GUARD_SCRIPT" --check 2>/dev/null; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+_probe_fw_guard_priv() {
+  local priv="$1"
+  local out ec=0
+  if [[ ! -f "$_FW_GUARD_SCRIPT" ]]; then
+    return 1
+  fi
+  if ! _write_gate_context; then
+    return 1
+  fi
+  out="$($priv bash "$_FW_GUARD_SCRIPT" --check 2>&1)" || ec=$?
+  _FW_GUARD_PROBE_OUT="$out"
+  _FW_GUARD_PROBE_EC=$ec
+  _FW_GUARD_PROBE_DONE=1
+  if [[ $ec -eq 126 ]] || _priv_denied_output "$out"; then
+    return 1
+  fi
+  return 0
+}
+
+_detect_sudo_narrow() {
+  if ! command -v sudo >/dev/null 2>&1; then
+    return 1
+  fi
+  if sudo -n true 2>/dev/null; then
+    _PRIV_DETAIL="blanket"
+    return 0
+  fi
+  if _sudo_l_has_labop_grant; then
+    _PRIV_DETAIL="sudo_l"
+    return 0
+  fi
+  if _probe_fw_guard_priv "sudo -n"; then
+    _PRIV_DETAIL="probe_fw_guard"
+    return 0
+  fi
+  return 1
+}
+
+_detect_doas_narrow() {
+  if ! command -v doas >/dev/null 2>&1; then
+    return 1
+  fi
+  if doas -n true 2>/dev/null; then
+    _PRIV_DETAIL="blanket"
+    return 0
+  fi
+  if [[ -f "$_FW_GUARD_SCRIPT" ]] && _doas_c_has_labop_grant; then
+    _PRIV_DETAIL="doas_c"
+    return 0
+  fi
+  if _probe_fw_guard_priv "doas -n"; then
+    _PRIV_DETAIL="probe_fw_guard"
+    return 0
+  fi
+  return 1
+}
+
+# --- Privilege probe (#954 / #959 / #1022: narrow grant != sudo -n true) ---
 PRIV="NO_PRIV"
-if command -v doas >/dev/null 2>&1 && doas -n true 2>/dev/null; then
+if _detect_doas_narrow; then
   PRIV="doas-narrow"
-elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+elif _detect_sudo_narrow; then
   PRIV="sudo-narrow"
 fi
 if [[ "$PRIV" == "NO_PRIV" ]]; then
-  _gr privilege ALARM "no doas/sudo -n"
+  _gr privilege ALARM "no_narrow_grant"
   FAIL=1
 else
-  _gr privilege OK "$PRIV"
+  _gr privilege OK "$PRIV" "${_PRIV_DETAIL:-}"
 fi
 
 # --- Per-persona binaries ---
@@ -231,7 +311,10 @@ if [[ -f "$FW_SCRIPT" ]]; then
     FAIL=1
   elif [[ "$PRIV" != "NO_PRIV" ]]; then
     FW_EC=0
-    if ! _invoke_priv_script "$FW_SCRIPT" "$FW_MODE"; then
+    if [[ "${_FW_GUARD_PROBE_DONE:-0}" -eq 1 && "$FW_MODE" == "--check" ]]; then
+      printf '%s\n' "$_FW_GUARD_PROBE_OUT" >&2
+      FW_EC="$_FW_GUARD_PROBE_EC"
+    elif ! _invoke_priv_script "$FW_SCRIPT" "$FW_MODE"; then
       FW_EC=$?
     fi
     if [[ $FW_EC -eq 0 ]]; then

--- a/scripts/labop-gate-readiness.sh
+++ b/scripts/labop-gate-readiness.sh
@@ -109,14 +109,15 @@ _priv_denied_output() {
 }
 
 _invoke_priv_script() {
-  local script="$1" mode="$2"
+  local script="$1"
+  shift
   local priv out ec=0
   priv="$(_priv_cmd)"
   [[ -z "$priv" ]] && return 127
   if ! _write_gate_context; then
     return 125
   fi
-  out="$($priv bash "$script" "$mode" 2>&1)" || ec=$?
+  out="$($priv bash "$script" "$@" 2>&1)" || ec=$?
   printf '%s\n' "$out" >&2
   if [[ $ec -ne 0 ]] && _priv_denied_output "$out"; then
     return 126
@@ -280,15 +281,17 @@ if _any_persona cifs; then
 fi
 
 if _any_persona baremetal; then
+  UV_BIN="$(command -v uv 2>/dev/null || true)"
   for bin in uv cargo maturin; do
     if command -v "$bin" >/dev/null 2>&1; then
       _gr "login-env:$bin" OK "on_path"
+    elif [[ "$bin" == "maturin" && -n "$UV_BIN" ]] && "$UV_BIN" run maturin --version >/dev/null 2>&1; then
+      _gr "login-env:maturin" OK "uv_run"
     else
       _gr "login-env:$bin" ALARM "missing_from_path"
       FAIL=1
     fi
   done
-  UV_BIN="$(command -v uv 2>/dev/null || true)"
   if [[ -n "$UV_BIN" ]]; then
     if "$UV_BIN" run --project "$REPO_ROOT" python3 -c "import boar_fast_filter" >/dev/null 2>&1; then
       _gr rust-wheel OK "boar_fast_filter_importable"
@@ -345,24 +348,52 @@ if [[ -f "$DEP_SCRIPT" ]]; then
   DEP_EC=0
   DEP_OUT="$(bash "$DEP_SCRIPT" --check --personas "$PERSONAS_RAW" 2>&1)" || DEP_EC=$?
   printf '%s\n' "$DEP_OUT" >&2
-  if [[ $DEP_EC -eq 0 ]]; then
+  DEP_ALARM=0
+  if [[ $DEP_EC -ne 0 ]]; then
+    DEP_ALARM=1
+  fi
+  if [[ $APPLY -eq 1 && "$PRIV" != "NO_PRIV" && $DEP_ALARM -eq 1 ]]; then
+    PRIV_EC=0
+    if ! _invoke_priv_script "$DEP_SCRIPT" --privileged --personas "$PERSONAS_RAW"; then
+      PRIV_EC=$?
+    fi
+    DEP_RECHECK_EC=0
+    if [[ $PRIV_EC -eq 0 ]]; then
+      DEP_RECHECK_OUT="$(bash "$DEP_SCRIPT" --check --personas "$PERSONAS_RAW" 2>&1)" || DEP_RECHECK_EC=$?
+      printf '%s\n' "$DEP_RECHECK_OUT" >&2
+    fi
+    if [[ $PRIV_EC -eq 0 && $DEP_RECHECK_EC -eq 0 ]]; then
+      _gr dep-doctor REMEDIATE "privileged_heal_ok"
+      DEP_ALARM=0
+    elif [[ $PRIV_EC -eq 126 ]]; then
+      _gr dep-doctor ALARM "privilege_denied"
+    elif [[ $PRIV_EC -ne 0 ]]; then
+      _gr dep-doctor ALARM "remediation_failed"
+    else
+      _gr dep-doctor ALARM "packages_still_missing_after_remediate"
+    fi
+  fi
+  if [[ $DEP_ALARM -eq 0 ]]; then
     _gr dep-doctor OK "modules_and_persona_os"
   else
     _gr dep-doctor ALARM "packages_or_modules_missing"
     FAIL=1
   fi
-  if [[ $APPLY -eq 1 && "$PRIV" != "NO_PRIV" ]]; then
-    PRIV_EC=0
-    if ! _invoke_priv_script "$DEP_SCRIPT" --privileged; then
-      PRIV_EC=$?
-    fi
-    if [[ $PRIV_EC -eq 0 ]]; then
-      _gr dep-doctor REMEDIATE "privileged_heal_ok"
-    elif [[ $PRIV_EC -eq 126 ]]; then
-      _gr dep-doctor ALARM "privilege_denied"
-      FAIL=1
+fi
+
+# --- rust wheel (#1021): maturin develop on --apply when baremetal persona needs FFI ---
+if [[ $APPLY -eq 1 ]] && _any_persona baremetal; then
+  UV_BIN="$(command -v uv 2>/dev/null || true)"
+  if [[ -n "$UV_BIN" ]] && ! "$UV_BIN" run --project "$REPO_ROOT" python3 -c "import boar_fast_filter" >/dev/null 2>&1; then
+    if (cd "$REPO_ROOT" && "$UV_BIN" run maturin develop --release >/dev/null 2>&1); then
+      if "$UV_BIN" run --project "$REPO_ROOT" python3 -c "import boar_fast_filter" >/dev/null 2>&1; then
+        _gr rust-wheel REMEDIATE "maturin_develop_ok"
+      else
+        _gr rust-wheel ALARM "import_still_missing_after_maturin"
+        FAIL=1
+      fi
     else
-      _gr dep-doctor ALARM "remediation_failed"
+      _gr rust-wheel ALARM "maturin_develop_failed"
       FAIL=1
     fi
   fi

--- a/scripts/labop-gate-readiness.sh
+++ b/scripts/labop-gate-readiness.sh
@@ -330,24 +330,70 @@ if _any_persona cifs; then
   fi
 fi
 
+# --- baremetal Rust accelerator (#1021 R7): optional FFI; pure-Python fallback is OK ---
+_rust_toolchain_runnable() {
+  local uv_bin mat_ok=0
+  if command -v maturin >/dev/null 2>&1; then
+    mat_ok=1
+  else
+    uv_bin="$(command -v uv 2>/dev/null || true)"
+    if [[ -n "$uv_bin" ]] && "$uv_bin" run maturin --version >/dev/null 2>&1; then
+      mat_ok=1
+    fi
+  fi
+  [[ $mat_ok -eq 1 ]] && command -v rustc >/dev/null 2>&1
+}
+
+_boar_fast_filter_importable() {
+  local uv_bin="$1"
+  [[ -n "$uv_bin" ]] && "$uv_bin" run --project "$REPO_ROOT" python3 -c "import boar_fast_filter" >/dev/null 2>&1
+}
+
+_emit_rust_accel_hints() {
+  local reason="${1:-optional_degraded}"
+  echo "[GateReadiness] WARN: HINT: boar_fast_filter (Rust) is optional; scanner uses pure-Python fallback" >&2
+  echo "[GateReadiness] WARN: HINT: install rustc + maturin, then: uv run maturin develop --release (repo root)" >&2
+  echo "[GateReadiness] WARN: Host feature: RUST_ACCEL_UNSUPPORTED reason=$reason" >&2
+}
+
 if _any_persona baremetal; then
   UV_BIN="$(command -v uv 2>/dev/null || true)"
-  for bin in uv cargo maturin; do
+  if [[ -z "$UV_BIN" ]]; then
+    _gr "login-env:uv" ALARM "missing_from_path"
+    FAIL=1
+  else
+    _gr "login-env:uv" OK "on_path"
+  fi
+  for bin in cargo maturin; do
     if command -v "$bin" >/dev/null 2>&1; then
       _gr "login-env:$bin" OK "on_path"
     elif [[ "$bin" == "maturin" && -n "$UV_BIN" ]] && "$UV_BIN" run maturin --version >/dev/null 2>&1; then
       _gr "login-env:maturin" OK "uv_run"
     else
-      _gr "login-env:$bin" ALARM "missing_from_path"
-      FAIL=1
+      _gr "login-env:$bin" ALARM "optional_accelerator_missing"
     fi
   done
-  if [[ -n "$UV_BIN" ]]; then
-    if "$UV_BIN" run --project "$REPO_ROOT" python3 -c "import boar_fast_filter" >/dev/null 2>&1; then
-      _gr rust-wheel OK "boar_fast_filter_importable"
-    else
-      _gr rust-wheel ALARM "boar_fast_filter_missing_in_venv"
-      FAIL=1
+  if _boar_fast_filter_importable "$UV_BIN"; then
+    _gr rust-wheel OK "boar_fast_filter_importable"
+  else
+    _emit_rust_accel_hints "boar_fast_filter_missing_in_venv"
+    _gr rust-wheel ALARM "pure_python_fallback hint=maturin_develop_release"
+    if [[ $APPLY -eq 1 && -n "$UV_BIN" ]]; then
+      if _rust_toolchain_runnable; then
+        if (cd "$REPO_ROOT" && "$UV_BIN" run maturin develop --release >/dev/null 2>&1); then
+          if _boar_fast_filter_importable "$UV_BIN"; then
+            _gr rust-wheel REMEDIATE "maturin_develop_ok"
+          else
+            _emit_rust_accel_hints "import_still_missing_after_maturin"
+            _gr rust-wheel ALARM "maturin_develop_no_import hint=pure_python_fallback"
+          fi
+        else
+          _emit_rust_accel_hints "maturin_develop_failed"
+          _gr rust-wheel ALARM "maturin_develop_failed hint=pure_python_fallback"
+        fi
+      else
+        _gr rust-wheel ALARM "rust_toolchain_unavailable hint=install_rust_maturin"
+      fi
     fi
   fi
 fi
@@ -444,40 +490,6 @@ if [[ -f "$DEP_SCRIPT" ]]; then
   else
     _gr dep-doctor ALARM "packages_or_modules_missing"
     FAIL=1
-  fi
-fi
-
-# --- rust wheel (#1021): maturin develop on --apply when baremetal persona needs FFI ---
-_rust_toolchain_runnable() {
-  local uv_bin mat_ok=0
-  if command -v maturin >/dev/null 2>&1; then
-    mat_ok=1
-  else
-    uv_bin="$(command -v uv 2>/dev/null || true)"
-    if [[ -n "$uv_bin" ]] && "$uv_bin" run maturin --version >/dev/null 2>&1; then
-      mat_ok=1
-    fi
-  fi
-  [[ $mat_ok -eq 1 ]] && command -v rustc >/dev/null 2>&1
-}
-
-if [[ $APPLY -eq 1 ]] && _any_persona baremetal; then
-  UV_BIN="$(command -v uv 2>/dev/null || true)"
-  if [[ -n "$UV_BIN" ]] && ! "$UV_BIN" run --project "$REPO_ROOT" python3 -c "import boar_fast_filter" >/dev/null 2>&1; then
-    if ! _rust_toolchain_runnable; then
-      _gr rust-wheel ALARM "rust_toolchain_unavailable"
-      FAIL=1
-    elif (cd "$REPO_ROOT" && "$UV_BIN" run maturin develop --release >/dev/null 2>&1); then
-      if "$UV_BIN" run --project "$REPO_ROOT" python3 -c "import boar_fast_filter" >/dev/null 2>&1; then
-        _gr rust-wheel REMEDIATE "maturin_develop_ok"
-      else
-        _gr rust-wheel ALARM "import_still_missing_after_maturin"
-        FAIL=1
-      fi
-    else
-      _gr rust-wheel ALARM "maturin_develop_failed"
-      FAIL=1
-    fi
   fi
 fi
 

--- a/scripts/labop-gate-readiness.sh
+++ b/scripts/labop-gate-readiness.sh
@@ -108,6 +108,12 @@ _log "mode=$MODE_WORD personas=$PERSONAS_RAW repo=$REPO_ROOT bash=$LABOP_BASH_BI
 
 GATE_CTX_DIR="$REPO_ROOT/.labop-gate"
 
+# Plano B (#1021 R8): Maestro/handlers write subnet to .labop-gate before gate runs.
+if [[ -z "${LAB_OP_SUBNET:-}" && -f "$GATE_CTX_DIR/LAB_OP_SUBNET" ]]; then
+  LAB_OP_SUBNET="$(tr -d '[:space:]' <"$GATE_CTX_DIR/LAB_OP_SUBNET")"
+  export LAB_OP_SUBNET
+fi
+
 # shellcheck source=labop-rfc1918-cidr-lib.sh
 . "$SCRIPT_DIR/labop-rfc1918-cidr-lib.sh"
 

--- a/scripts/labop-gate-readiness.sh
+++ b/scripts/labop-gate-readiness.sh
@@ -71,6 +71,29 @@ _ensure_login_path() {
 
 _ensure_login_path
 
+# Narrow sudoers/doas grants match a literal bash path (#1021 ROUND 5) - never bare `bash`.
+_resolve_bash_bin() {
+  local candidate
+  candidate="$(command -v bash 2>/dev/null || true)"
+  if [[ -n "$candidate" && -x "$candidate" ]]; then
+    printf '%s' "$candidate"
+    return 0
+  fi
+  for candidate in /usr/bin/bash /bin/bash; do
+    if [[ -x "$candidate" ]]; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+LABOP_BASH_BIN=""
+if ! LABOP_BASH_BIN="$(_resolve_bash_bin)"; then
+  _gr privilege ALARM "bash_bin_unresolved"
+  FAIL=1
+fi
+
 GATE_CTX_DIR="$REPO_ROOT/.labop-gate"
 
 # shellcheck source=labop-rfc1918-cidr-lib.sh
@@ -114,15 +137,28 @@ _invoke_priv_script() {
   local priv out ec=0
   priv="$(_priv_cmd)"
   [[ -z "$priv" ]] && return 127
+  if [[ -z "$LABOP_BASH_BIN" ]]; then
+    return 127
+  fi
   if ! _write_gate_context; then
     return 125
   fi
-  out="$($priv bash "$script" "$@" 2>&1)" || ec=$?
+  out="$($priv "$LABOP_BASH_BIN" "$script" "$@" 2>&1)" || ec=$?
   printf '%s\n' "$out" >&2
   if [[ $ec -ne 0 ]] && _priv_denied_output "$out"; then
     return 126
   fi
   return $ec
+}
+
+_has_persona() {
+  local want="$1" p
+  IFS=',' read -ra _PL <<<"$PERSONAS_RAW"
+  for p in "${_PL[@]}"; do
+    p="${p// /}"
+    [[ "$p" == "$want" ]] && return 0
+  done
+  return 1
 }
 
 _persona_needs() {
@@ -172,7 +208,7 @@ _doas_c_has_labop_grant() {
   local conf
   for conf in /etc/doas.conf /etc/doas.d/*.conf; do
     [[ -f "$conf" ]] || continue
-    if doas -C "$conf" bash "$_FW_GUARD_SCRIPT" --check 2>/dev/null; then
+    if doas -C "$conf" "${LABOP_BASH_BIN:-/bin/bash}" "$_FW_GUARD_SCRIPT" --check 2>/dev/null; then
       return 0
     fi
   done
@@ -188,7 +224,7 @@ _probe_fw_guard_priv() {
   if ! _write_gate_context; then
     return 1
   fi
-  out="$($priv bash "$_FW_GUARD_SCRIPT" --check 2>&1)" || ec=$?
+  out="$($priv "${LABOP_BASH_BIN:-/bin/bash}" "$_FW_GUARD_SCRIPT" --check 2>&1)" || ec=$?
   _FW_GUARD_PROBE_OUT="$out"
   _FW_GUARD_PROBE_EC=$ec
   _FW_GUARD_PROBE_DONE=1
@@ -238,16 +274,18 @@ _detect_doas_narrow() {
 
 # --- Privilege probe (#954 / #959 / #1022: narrow grant != sudo -n true) ---
 PRIV="NO_PRIV"
-if _detect_doas_narrow; then
-  PRIV="doas-narrow"
-elif _detect_sudo_narrow; then
-  PRIV="sudo-narrow"
-fi
-if [[ "$PRIV" == "NO_PRIV" ]]; then
-  _gr privilege ALARM "no_narrow_grant"
-  FAIL=1
-else
-  _gr privilege OK "$PRIV" "${_PRIV_DETAIL:-}"
+if [[ -n "$LABOP_BASH_BIN" ]]; then
+  if _detect_doas_narrow; then
+    PRIV="doas-narrow"
+  elif _detect_sudo_narrow; then
+    PRIV="sudo-narrow"
+  fi
+  if [[ "$PRIV" == "NO_PRIV" ]]; then
+    _gr privilege ALARM "no_narrow_grant"
+    FAIL=1
+  else
+    _gr privilege OK "$PRIV" "${_PRIV_DETAIL:-}"
+  fi
 fi
 
 # --- Per-persona binaries ---
@@ -305,14 +343,16 @@ fi
 # --- fail2ban / sshguard (#957) ---
 FW_SCRIPT="$SCRIPT_DIR/labop-fw-guard-ensure.sh"
 if [[ -f "$FW_SCRIPT" ]]; then
-  FW_MODE=$([[ $APPLY -eq 1 ]] && echo --apply || echo --check)
-  if [[ -z "${LAB_OP_SUBNET:-}" ]]; then
+  if _has_persona maestro; then
+    _gr fail2ban OK "maestro_orchestrator_skip"
+  elif [[ -z "${LAB_OP_SUBNET:-}" ]]; then
     _gr fail2ban ALARM "LAB_OP_SUBNET_unset"
     FAIL=1
   elif ! _is_rfc1918_lab_subnet "${LAB_OP_SUBNET}"; then
     _gr fail2ban ALARM "LAB_OP_SUBNET_not_rfc1918"
     FAIL=1
   elif [[ "$PRIV" != "NO_PRIV" ]]; then
+    FW_MODE=$([[ $APPLY -eq 1 ]] && echo --apply || echo --check)
     FW_EC=0
     if [[ "${_FW_GUARD_PROBE_DONE:-0}" -eq 1 && "$FW_MODE" == "--check" ]]; then
       printf '%s\n' "$_FW_GUARD_PROBE_OUT" >&2

--- a/scripts/labop-gate-readiness.sh
+++ b/scripts/labop-gate-readiness.sh
@@ -71,20 +71,29 @@ _ensure_login_path() {
 
 _ensure_login_path
 
-# Narrow sudoers/doas grants match a literal bash path (#1021 ROUND 5) - never bare `bash`.
+# Narrow sudoers/doas grants match a literal bash path (#1021 ROUND 5/6).
+# Prefer /usr/bin/bash and /bin/bash (grant-canonical) before command -v bash,
+# which may resolve to /usr/sbin/bash via secure_path and miss the grant (#1021 R6 RCA).
 _resolve_bash_bin() {
-  local candidate
-  candidate="$(command -v bash 2>/dev/null || true)"
-  if [[ -n "$candidate" && -x "$candidate" ]]; then
-    printf '%s' "$candidate"
-    return 0
-  fi
+  local candidate resolved
   for candidate in /usr/bin/bash /bin/bash; do
     if [[ -x "$candidate" ]]; then
       printf '%s' "$candidate"
       return 0
     fi
   done
+  candidate="$(command -v bash 2>/dev/null || true)"
+  if [[ -n "$candidate" && -x "$candidate" ]]; then
+    resolved="$(readlink -f "$candidate" 2>/dev/null || printf '%s' "$candidate")"
+    case "$resolved" in
+      /usr/bin/bash|/bin/bash)
+        printf '%s' "$resolved"
+        return 0
+        ;;
+    esac
+    printf '%s' "$candidate"
+    return 0
+  fi
   return 1
 }
 
@@ -92,7 +101,10 @@ LABOP_BASH_BIN=""
 if ! LABOP_BASH_BIN="$(_resolve_bash_bin)"; then
   _gr privilege ALARM "bash_bin_unresolved"
   FAIL=1
+else
+  _gr bootstrap OK "bash_bin=$LABOP_BASH_BIN"
 fi
+_log "mode=$MODE_WORD personas=$PERSONAS_RAW repo=$REPO_ROOT bash=$LABOP_BASH_BIN"
 
 GATE_CTX_DIR="$REPO_ROOT/.labop-gate"
 
@@ -361,26 +373,8 @@ if [[ -f "$FW_SCRIPT" ]]; then
       _invoke_priv_script "$FW_SCRIPT" "$FW_MODE"
       FW_EC=$?
     fi
-    # #1021 R6: --apply grant missing (126) but --check works (narrow sudoers on some hosts).
-    FW_APPLY_FALLBACK=0
-    if [[ $FW_EC -eq 126 && "$FW_MODE" == "--apply" ]]; then
-      if [[ "${_FW_GUARD_PROBE_DONE:-0}" -eq 1 && "$_FW_GUARD_PROBE_EC" -eq 0 ]]; then
-        FW_EC=0
-        FW_APPLY_FALLBACK=1
-      else
-        _invoke_priv_script "$FW_SCRIPT" --check
-        FW_EC=$?
-        if [[ $FW_EC -eq 0 ]]; then
-          FW_APPLY_FALLBACK=1
-        fi
-      fi
-    fi
     if [[ $FW_EC -eq 0 ]]; then
-      if [[ "${FW_APPLY_FALLBACK:-0}" -eq 1 ]]; then
-        _gr fail2ban OK "check_only_apply_grant_missing"
-      else
-        _gr fail2ban OK "subnet_whitelisted"
-      fi
+      _gr fail2ban OK "subnet_whitelisted"
     elif [[ $FW_EC -eq 125 ]]; then
       _gr fail2ban ALARM "LAB_OP_SUBNET_not_rfc1918"
       FAIL=1

--- a/scripts/labop-gate-readiness.sh
+++ b/scripts/labop-gate-readiness.sh
@@ -317,7 +317,8 @@ if [[ -f "$FW_SCRIPT" ]]; then
     if [[ "${_FW_GUARD_PROBE_DONE:-0}" -eq 1 && "$FW_MODE" == "--check" ]]; then
       printf '%s\n' "$_FW_GUARD_PROBE_OUT" >&2
       FW_EC="$_FW_GUARD_PROBE_EC"
-    elif ! _invoke_priv_script "$FW_SCRIPT" "$FW_MODE"; then
+    else
+      _invoke_priv_script "$FW_SCRIPT" "$FW_MODE"
       FW_EC=$?
     fi
     if [[ $FW_EC -eq 0 ]]; then
@@ -353,12 +354,9 @@ if [[ -f "$DEP_SCRIPT" ]]; then
     DEP_ALARM=1
   fi
   if [[ $APPLY -eq 1 && "$PRIV" != "NO_PRIV" && $DEP_ALARM -eq 1 ]]; then
-    PRIV_EC=0
-    # Plano B (#1021): narrow LABOP_DEP_DOCTOR grant matches --privileged only; personas from
-    # .labop-gate/PERSONAS via dep-doctor _load_personas_from_gate_context (written above).
-    if ! _invoke_priv_script "$DEP_SCRIPT" --privileged; then
-      PRIV_EC=$?
-    fi
+    # Capture exit directly - `if ! cmd; then EC=$?` records 0 (negation success), not 126 (#1021).
+    _invoke_priv_script "$DEP_SCRIPT" --privileged
+    PRIV_EC=$?
     DEP_RECHECK_EC=0
     if [[ $PRIV_EC -eq 0 ]]; then
       DEP_RECHECK_OUT="$(bash "$DEP_SCRIPT" --check --personas "$PERSONAS_RAW" 2>&1)" || DEP_RECHECK_EC=$?
@@ -385,12 +383,16 @@ fi
 
 # --- rust wheel (#1021): maturin develop on --apply when baremetal persona needs FFI ---
 _rust_toolchain_runnable() {
-  if command -v rustc >/dev/null 2>&1; then
-    return 0
+  local uv_bin mat_ok=0
+  if command -v maturin >/dev/null 2>&1; then
+    mat_ok=1
+  else
+    uv_bin="$(command -v uv 2>/dev/null || true)"
+    if [[ -n "$uv_bin" ]] && "$uv_bin" run maturin --version >/dev/null 2>&1; then
+      mat_ok=1
+    fi
   fi
-  local uv_bin
-  uv_bin="$(command -v uv 2>/dev/null || true)"
-  [[ -n "$uv_bin" ]] && "$uv_bin" run maturin --version >/dev/null 2>&1
+  [[ $mat_ok -eq 1 ]] && command -v rustc >/dev/null 2>&1
 }
 
 if [[ $APPLY -eq 1 ]] && _any_persona baremetal; then

--- a/scripts/labop-gate-readiness.sh
+++ b/scripts/labop-gate-readiness.sh
@@ -361,8 +361,26 @@ if [[ -f "$FW_SCRIPT" ]]; then
       _invoke_priv_script "$FW_SCRIPT" "$FW_MODE"
       FW_EC=$?
     fi
+    # #1021 R6: --apply grant missing (126) but --check works (narrow sudoers on some hosts).
+    FW_APPLY_FALLBACK=0
+    if [[ $FW_EC -eq 126 && "$FW_MODE" == "--apply" ]]; then
+      if [[ "${_FW_GUARD_PROBE_DONE:-0}" -eq 1 && "$_FW_GUARD_PROBE_EC" -eq 0 ]]; then
+        FW_EC=0
+        FW_APPLY_FALLBACK=1
+      else
+        _invoke_priv_script "$FW_SCRIPT" --check
+        FW_EC=$?
+        if [[ $FW_EC -eq 0 ]]; then
+          FW_APPLY_FALLBACK=1
+        fi
+      fi
+    fi
     if [[ $FW_EC -eq 0 ]]; then
-      _gr fail2ban OK "subnet_whitelisted"
+      if [[ "${FW_APPLY_FALLBACK:-0}" -eq 1 ]]; then
+        _gr fail2ban OK "check_only_apply_grant_missing"
+      else
+        _gr fail2ban OK "subnet_whitelisted"
+      fi
     elif [[ $FW_EC -eq 125 ]]; then
       _gr fail2ban ALARM "LAB_OP_SUBNET_not_rfc1918"
       FAIL=1
@@ -383,6 +401,10 @@ if [[ -f "$FW_SCRIPT" ]]; then
 fi
 
 # --- dep-doctor (#958): always --check as operator; --privileged via narrow grant only ---
+_dep_optional_degraded() {
+  grep -qE 'optional_modules_degraded|7z_UNSUPPORTED' <<<"$1"
+}
+
 DEP_SCRIPT="$SCRIPT_DIR/labop-dep-doctor.sh"
 if [[ -f "$DEP_SCRIPT" ]]; then
   DEP_OUT=""
@@ -390,8 +412,11 @@ if [[ -f "$DEP_SCRIPT" ]]; then
   DEP_OUT="$(bash "$DEP_SCRIPT" --check --personas "$PERSONAS_RAW" 2>&1)" || DEP_EC=$?
   printf '%s\n' "$DEP_OUT" >&2
   DEP_ALARM=0
+  DEP_OPTIONAL_DEGRADED=0
   if [[ $DEP_EC -ne 0 ]]; then
     DEP_ALARM=1
+  elif _dep_optional_degraded "$DEP_OUT"; then
+    DEP_OPTIONAL_DEGRADED=1
   fi
   if [[ $APPLY -eq 1 && "$PRIV" != "NO_PRIV" && $DEP_ALARM -eq 1 ]]; then
     # Capture exit directly - `if ! cmd; then EC=$?` records 0 (negation success), not 126 (#1021).
@@ -405,6 +430,9 @@ if [[ -f "$DEP_SCRIPT" ]]; then
     if [[ $PRIV_EC -eq 0 && $DEP_RECHECK_EC -eq 0 ]]; then
       _gr dep-doctor REMEDIATE "privileged_heal_ok"
       DEP_ALARM=0
+      if _dep_optional_degraded "${DEP_RECHECK_OUT:-}"; then
+        DEP_OPTIONAL_DEGRADED=1
+      fi
     elif [[ $PRIV_EC -eq 126 ]]; then
       _gr dep-doctor ALARM "privilege_denied"
     elif [[ $PRIV_EC -ne 0 ]]; then
@@ -414,7 +442,11 @@ if [[ -f "$DEP_SCRIPT" ]]; then
     fi
   fi
   if [[ $DEP_ALARM -eq 0 ]]; then
-    _gr dep-doctor OK "modules_and_persona_os"
+    if [[ $DEP_OPTIONAL_DEGRADED -eq 1 ]]; then
+      _gr dep-doctor ALARM "optional_modules_degraded hint=uv_sync_extra_compressed"
+    else
+      _gr dep-doctor OK "modules_and_persona_os"
+    fi
   else
     _gr dep-doctor ALARM "packages_or_modules_missing"
     FAIL=1

--- a/scripts/labop-gate-readiness.sh
+++ b/scripts/labop-gate-readiness.sh
@@ -105,7 +105,7 @@ _priv_cmd() {
 
 _priv_denied_output() {
   local out="$1"
-  grep -qiE 'not allowed|a password is required|doas \(.*\) failed|sorry, user|authentication failures' <<<"$out"
+  grep -qiE 'not allowed|a password is required|authentication required|doas \(.*\) failed|sorry, user|authentication failures' <<<"$out"
 }
 
 _invoke_priv_script() {
@@ -354,7 +354,9 @@ if [[ -f "$DEP_SCRIPT" ]]; then
   fi
   if [[ $APPLY -eq 1 && "$PRIV" != "NO_PRIV" && $DEP_ALARM -eq 1 ]]; then
     PRIV_EC=0
-    if ! _invoke_priv_script "$DEP_SCRIPT" --privileged --personas "$PERSONAS_RAW"; then
+    # Plano B (#1021): narrow LABOP_DEP_DOCTOR grant matches --privileged only; personas from
+    # .labop-gate/PERSONAS via dep-doctor _load_personas_from_gate_context (written above).
+    if ! _invoke_priv_script "$DEP_SCRIPT" --privileged; then
       PRIV_EC=$?
     fi
     DEP_RECHECK_EC=0
@@ -382,10 +384,22 @@ if [[ -f "$DEP_SCRIPT" ]]; then
 fi
 
 # --- rust wheel (#1021): maturin develop on --apply when baremetal persona needs FFI ---
+_rust_toolchain_runnable() {
+  if command -v rustc >/dev/null 2>&1; then
+    return 0
+  fi
+  local uv_bin
+  uv_bin="$(command -v uv 2>/dev/null || true)"
+  [[ -n "$uv_bin" ]] && "$uv_bin" run maturin --version >/dev/null 2>&1
+}
+
 if [[ $APPLY -eq 1 ]] && _any_persona baremetal; then
   UV_BIN="$(command -v uv 2>/dev/null || true)"
   if [[ -n "$UV_BIN" ]] && ! "$UV_BIN" run --project "$REPO_ROOT" python3 -c "import boar_fast_filter" >/dev/null 2>&1; then
-    if (cd "$REPO_ROOT" && "$UV_BIN" run maturin develop --release >/dev/null 2>&1); then
+    if ! _rust_toolchain_runnable; then
+      _gr rust-wheel ALARM "rust_toolchain_unavailable"
+      FAIL=1
+    elif (cd "$REPO_ROOT" && "$UV_BIN" run maturin develop --release >/dev/null 2>&1); then
       if "$UV_BIN" run --project "$REPO_ROOT" python3 -c "import boar_fast_filter" >/dev/null 2>&1; then
         _gr rust-wheel REMEDIATE "maturin_develop_ok"
       else

--- a/scripts/labop-nfs-server-ensure.sh
+++ b/scripts/labop-nfs-server-ensure.sh
@@ -3,7 +3,9 @@
 # Validates and optionally ensures NFS server-side prerequisites on a target node.
 # Run via narrow sudoers (LABOP_NFS_SERVER) from Maestro Handle-target_nfs.ps1.
 #
-# Usage: sudo -n bash /path/to/labop-nfs-server-ensure.sh [--check | --apply] [--export-path PATH]
+# Usage: sudo -n /usr/bin/bash /path/to/labop-nfs-server-ensure.sh [--check | --apply] [--export-path PATH]
+#   Subnet and persona hints: REPO_ROOT/.labop-gate/LAB_OP_SUBNET (and optional LAB_NFS_SVC,
+#   LAB_PKG_MGR) written by Maestro Build-EnsureRemoteCommand before narrow-grant invoke.
 #   (no args / --check)  probe only; exit 0 if healthy, 1 if fix needed
 #   --apply              start services + configure export (additive only)
 #   --export-path PATH   path to validate/export (default: $HOME/Documents/LGPD)
@@ -48,6 +50,20 @@ done
 
 # Source firewall library
 _SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+_REPO_ROOT="$(cd "$_SCRIPT_DIR/.." && pwd)"
+_GATE_DIR="$_REPO_ROOT/.labop-gate"
+if [[ -f "$_GATE_DIR/LAB_OP_SUBNET" ]]; then
+  LAB_OP_SUBNET="$(tr -d '[:space:]' <"$_GATE_DIR/LAB_OP_SUBNET")"
+  export LAB_OP_SUBNET
+fi
+if [[ -f "$_GATE_DIR/LAB_NFS_SVC" ]]; then
+  LAB_NFS_SVC="$(tr -d '[:space:]' <"$_GATE_DIR/LAB_NFS_SVC")"
+  export LAB_NFS_SVC
+fi
+if [[ -f "$_GATE_DIR/LAB_PKG_MGR" ]]; then
+  LAB_PKG_MGR="$(tr -d '[:space:]' <"$_GATE_DIR/LAB_PKG_MGR")"
+  export LAB_PKG_MGR
+fi
 # shellcheck source=labop-firewall-lib.sh
 source "$_SCRIPT_DIR/labop-firewall-lib.sh" 2>/dev/null || {
   echo "[NFS-Ensure] WARN: labop-firewall-lib.sh not found - firewall checks skipped." >&2

--- a/scripts/labop-nfs-server-ensure.sh
+++ b/scripts/labop-nfs-server-ensure.sh
@@ -10,7 +10,7 @@
 #   --apply              start services + configure export (additive only)
 #   --export-path PATH   path to validate/export (default: $HOME/Documents/LGPD)
 #
-# Exit codes: 0=healthy, 1=needs fix, 2=invocation error
+# Exit codes: 0=healthy, 1=needs fix (hard), 2=invocation error, 3=graceful ALARM (#1021 R9)
 #
 # Distro support: Debian/Ubuntu (nfs-kernel-server), Fedora/RHEL (nfs-server),
 #                 openSUSE (nfsserver), Alpine (nfs), Void (nfs-utils)
@@ -164,7 +164,8 @@ fi
 if [[ -z "$NFS_SVC" ]]; then
   _fail "No NFS server service found (tried: nfs-kernel-server nfs-server nfsserver nfs)."
   echo "NFS_SERVER_UNAVAILABLE at $(date +'%H:%M:%S')" > "$STATUS_FILE" 2>/dev/null || true
-  exit 1
+  echo "[NFS-Ensure] ALARM=nfs_server_unavailable hint=t14_primary_nfs_coverage" >&2
+  exit 3
 fi
 _log "NFS service: $NFS_SVC"
 
@@ -246,7 +247,11 @@ if command -v exportfs >/dev/null 2>&1; then
     if [[ $APPLY -eq 1 ]]; then
       _log "Adding export: $EXPORT_PATH *(ro,sync,no_subtree_check)"
       echo "$EXPORT_PATH *(ro,sync,no_subtree_check)" >> /etc/exports
-      exportfs -ra 2>&1 && _ok "exportfs -ra OK." || _fail "exportfs -ra failed."
+      exportfs -ra 2>&1 && _ok "exportfs -ra OK." || {
+        _fail "exportfs -ra failed."
+        echo "[NFS-Ensure] ALARM=nfs_export_unavailable hint=t14_primary_nfs_coverage" >&2
+        exit 3
+      }
     fi
   fi
 fi

--- a/scripts/labop-smb-server-ensure.sh
+++ b/scripts/labop-smb-server-ensure.sh
@@ -3,7 +3,8 @@
 # Validates and optionally ensures SMB/Samba server-side prerequisites on a target node.
 # Run via narrow sudoers (LABOP_SMB_SERVER) from Maestro Handle-target_cifs.ps1.
 #
-# Usage: sudo -n bash /path/to/labop-smb-server-ensure.sh [--check | --apply] [--share-path PATH] [--share-name NAME]
+# Usage: sudo -n /usr/bin/bash /path/to/labop-smb-server-ensure.sh [--check | --apply] [--share-path PATH] [--share-name NAME]
+#   Subnet: REPO_ROOT/.labop-gate/LAB_OP_SUBNET (Maestro context file; env is fallback only).
 #   (no args / --check)  probe only; exit 0 if healthy, 1 if fix needed
 #   --apply              start services (additive; does NOT write smb.conf automatically)
 #   --share-path PATH    path to validate (default: $HOME/Documents/LGPD)
@@ -54,6 +55,12 @@ done
 
 # Source firewall library
 _SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+_REPO_ROOT="$(cd "$_SCRIPT_DIR/.." && pwd)"
+_GATE_DIR="$_REPO_ROOT/.labop-gate"
+if [[ -f "$_GATE_DIR/LAB_OP_SUBNET" ]]; then
+  LAB_OP_SUBNET="$(tr -d '[:space:]' <"$_GATE_DIR/LAB_OP_SUBNET")"
+  export LAB_OP_SUBNET
+fi
 # shellcheck source=labop-firewall-lib.sh
 source "$_SCRIPT_DIR/labop-firewall-lib.sh" 2>/dev/null || {
   echo "[SMB-Ensure] WARN: labop-firewall-lib.sh not found - firewall checks skipped." >&2

--- a/scripts/labop-smb-server-ensure.sh
+++ b/scripts/labop-smb-server-ensure.sh
@@ -13,7 +13,7 @@
 # NOTE: smb.conf is NOT auto-written -- operator must configure shares manually.
 #       This script only ensures services are running and validates existing config.
 #
-# Exit codes: 0=healthy, 1=needs fix, 2=invocation error
+# Exit codes: 0=healthy, 1=needs fix (hard), 2=invocation error, 3=graceful ALARM (#1021 R9)
 
 set -u
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin${PATH+:$PATH}"
@@ -82,6 +82,12 @@ fi
 
 NEED_FIX=0
 
+if ! command -v systemctl >/dev/null 2>&1; then
+  _warn "No systemd; SMB server ensure needs systemctl (graceful ALARM)."
+  echo "[SMB-Ensure] ALARM=smbd_start_failed hint=t14_primary_cifs_coverage" >&2
+  exit 3
+fi
+
 # ---------------------------------------------------------------------------
 # Phase 1: Check smbd
 # ---------------------------------------------------------------------------
@@ -90,7 +96,13 @@ if ! systemctl is-active --quiet smbd 2>/dev/null; then
   NEED_FIX=1
   if [[ $APPLY -eq 1 ]]; then
     _log "Starting smbd..."
-    systemctl start smbd 2>&1 && _ok "smbd started." || _fail "smbd start failed."
+    if systemctl start smbd 2>&1; then
+      _ok "smbd started."
+    else
+      _fail "smbd start failed."
+      echo "[SMB-Ensure] ALARM=smbd_start_failed hint=t14_primary_cifs_coverage" >&2
+      exit 3
+    fi
   fi
 else
   _ok "smbd: active."

--- a/scripts/maestro/Build-ContainerArtefact.ps1
+++ b/scripts/maestro/Build-ContainerArtefact.ps1
@@ -28,7 +28,12 @@ function Test-ContainerEngineReady {
         if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) {
             continue
         }
-        $null = & $cmd info --format '{{.ServerVersion}}' 2>$null
+        # Podman info lacks Docker's .ServerVersion template (#1021 -Deep preflight on Linux primary).
+        if ($cmd -eq "podman") {
+            $null = & podman info --format '{{.Host.OS}}' 2>$null
+        } else {
+            $null = & docker info --format '{{.ServerVersion}}' 2>$null
+        }
         if ($LASTEXITCODE -eq 0) {
             $isPodman = ($cmd -eq "podman")
             return [PSCustomObject]@{ Cmd = $cmd; Ready = $true; IsPodman = $isPodman }
@@ -45,17 +50,17 @@ function Invoke-ContainerImageBuild {
         [string]$Context
     )
     if ($IsPodman -or $EngineCmd -eq "podman") {
-        & podman build -q -t $FullImage $Context
+        $null = & podman build -q -t $FullImage $Context
         return $LASTEXITCODE
     }
     if ($env:DOCKER_HOST -match "podman" -and (Get-Command podman -ErrorAction SilentlyContinue)) {
-        & podman build -q -t $FullImage $Context
+        $null = & podman build -q -t $FullImage $Context
         return $LASTEXITCODE
     }
     $prevBuildKit = $env:DOCKER_BUILDKIT
     $env:DOCKER_BUILDKIT = "0"
     try {
-        & docker build -q -t $FullImage $Context
+        $null = & docker build -q -t $FullImage $Context
         return $LASTEXITCODE
     } finally {
         if ($null -eq $prevBuildKit) {

--- a/scripts/maestro/Lab-MaestroCommon.ps1
+++ b/scripts/maestro/Lab-MaestroCommon.ps1
@@ -19,6 +19,25 @@ function Get-HandlerTmuxSessionName {
     return "completao_$Persona"
 }
 
+function Get-EnsureAlarmFromOutput {
+    <#
+    Parses ALARM= lines from labop-*-ensure.sh (exit 3 graceful, #1021 R9).
+    #>
+    param(
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]]$Lines,
+        [Parameter(Mandatory = $true)][string]$LogTag
+    )
+    foreach ($line in @($Lines)) {
+        if ($line -match "\[$LogTag\] ALARM=([a-z_]+)(?: hint=([^\s]+))?") {
+            return [pscustomobject]@{
+                Alarm = $Matches[1]
+                Hint  = $Matches[2]
+            }
+        }
+    }
+    return $null
+}
+
 function Get-LabPrivilegeInvoker {
     <#
     Returns the non-interactive privilege prefix for remote ensure scripts (#954).

--- a/scripts/maestro/Lab-MaestroCommon.ps1
+++ b/scripts/maestro/Lab-MaestroCommon.ps1
@@ -69,6 +69,121 @@ function Format-MaestroHandlersSummary {
     return 'OK'
 }
 
+function Confirm-TargetDbSyntheticData {
+    <#
+    #1021 R9c: after container READY, prove init seed rows exist (not just port open).
+    Uses podman/docker exec against lab-* containers; retries while entrypoint init runs.
+    #>
+    param(
+        [Parameter(Mandatory = $true)]$Node,
+        [Parameter(Mandatory = $true)][ValidateSet('postgres', 'mariadb', 'mongodb')]
+        [string]$Engine,
+        [int]$Port = 0,
+        [int]$MaxAttempts = 15,
+        [int]$WaitSeconds = 2
+    )
+
+    $repoPath = Get-MaestroRemoteRepoPath -RepoPath ([string]$Node.path)
+    $stackDir = "$repoPath/deploy/lab-smoke-stack"
+
+    $engineBody = switch ($Engine) {
+        'postgres' {
+            @'
+cd __STACK_DIR__
+_count_pg() {
+  if command -v podman >/dev/null 2>&1 && podman ps --format '{{.Names}}' 2>/dev/null | grep -qx 'lab-postgres'; then
+    podman exec lab-postgres psql -U "${LAB_PG_USER:-lab_smoke}" -d "${LAB_PG_DATABASE:-lab_smoke_pg}" -tAc "SELECT count(*) FROM lab_customers;"
+  elif command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+    docker compose exec -T lab-postgres psql -U "${LAB_PG_USER:-lab_smoke}" -d "${LAB_PG_DATABASE:-lab_smoke_pg}" -tAc "SELECT count(*) FROM lab_customers;"
+  else
+    return 2
+  fi
+}
+attempt=0
+while [ "$attempt" -lt __MAX_ATTEMPTS__ ]; do
+  cnt=$(_count_pg 2>/dev/null) || cnt=""
+  cnt=$(printf '%s' "$cnt" | tr -d '[:space:]')
+  if printf '%s' "$cnt" | grep -Eq '^[0-9]+$' && [ "$cnt" -gt 0 ]; then
+    echo "SYNTHETIC_DATA_OK engine=postgres table=lab_customers count=$cnt"
+    exit 0
+  fi
+  attempt=$((attempt + 1))
+  sleep __WAIT_SECONDS__
+done
+echo "SYNTHETIC_DATA_FAIL engine=postgres reason=zero_or_unreachable"
+exit 1
+'@
+        }
+        'mariadb' {
+            @'
+cd __STACK_DIR__
+_count_my() {
+  if command -v podman >/dev/null 2>&1 && podman ps --format '{{.Names}}' 2>/dev/null | grep -qx 'lab-mariadb'; then
+    podman exec lab-mariadb mariadb -u"${LAB_MY_USER:-lab_smoke}" -p"${LAB_MY_PASSWORD:-lab_smoke_change_me}" -N -e "SELECT count(*) FROM lab_customers;" "${LAB_MY_DATABASE:-lab_smoke_my}"
+  elif command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+    docker compose exec -T lab-mariadb mariadb -u"${LAB_MY_USER:-lab_smoke}" -p"${LAB_MY_PASSWORD:-lab_smoke_change_me}" -N -e "SELECT count(*) FROM lab_customers;" "${LAB_MY_DATABASE:-lab_smoke_my}"
+  else
+    return 2
+  fi
+}
+attempt=0
+while [ "$attempt" -lt __MAX_ATTEMPTS__ ]; do
+  cnt=$(_count_my 2>/dev/null) || cnt=""
+  cnt=$(printf '%s' "$cnt" | tr -d '[:space:]')
+  if printf '%s' "$cnt" | grep -Eq '^[0-9]+$' && [ "$cnt" -gt 0 ]; then
+    echo "SYNTHETIC_DATA_OK engine=mariadb table=lab_customers count=$cnt"
+    exit 0
+  fi
+  attempt=$((attempt + 1))
+  sleep __WAIT_SECONDS__
+done
+echo "SYNTHETIC_DATA_FAIL engine=mariadb reason=zero_or_unreachable"
+exit 1
+'@
+        }
+        'mongodb' {
+            @'
+cd __STACK_DIR__
+_count_mongo() {
+  if command -v podman >/dev/null 2>&1 && podman ps --format '{{.Names}}' 2>/dev/null | grep -qx 'lab-mongodb'; then
+    podman exec lab-mongodb mongosh --quiet --eval 'db.getSiblingDB("lab_smoke_mongo").lab_people.countDocuments()'
+  elif command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+    docker compose -f docker-compose.mongo.yml exec -T lab-mongodb mongosh --quiet --eval 'db.getSiblingDB("lab_smoke_mongo").lab_people.countDocuments()'
+  else
+    return 2
+  fi
+}
+attempt=0
+while [ "$attempt" -lt __MAX_ATTEMPTS__ ]; do
+  cnt=$(_count_mongo 2>/dev/null) || cnt=""
+  cnt=$(printf '%s' "$cnt" | tr -d '[:space:]')
+  if printf '%s' "$cnt" | grep -Eq '^[0-9]+$' && [ "$cnt" -gt 0 ]; then
+    echo "SYNTHETIC_DATA_OK engine=mongodb collection=lab_people count=$cnt"
+    exit 0
+  fi
+  attempt=$((attempt + 1))
+  sleep __WAIT_SECONDS__
+done
+echo "SYNTHETIC_DATA_FAIL engine=mongodb reason=zero_or_unreachable"
+exit 1
+'@
+        }
+    }
+
+    $remoteCmd = $engineBody.Replace('__STACK_DIR__', $stackDir).Replace('__MAX_ATTEMPTS__', [string]$MaxAttempts).Replace('__WAIT_SECONDS__', [string]$WaitSeconds)
+
+    $out = ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 `
+        "$($Node.user)@$($Node.hostname)" $remoteCmd 2>&1
+    $text = ($out | Out-String).Trim()
+    if ($LASTEXITCODE -eq 0 -and $text -match 'SYNTHETIC_DATA_OK') {
+        $countMatch = [regex]::Match($text, 'count=(\d+)')
+        $count = if ($countMatch.Success) { [int]$countMatch.Groups[1].Value } else { 0 }
+        return [pscustomobject]@{ Ok = $true; Count = $count; Detail = $text }
+    }
+    $failDetail = if ($text) { $text } else { "ssh_exit=$LASTEXITCODE engine=$Engine port=$Port" }
+    return [pscustomobject]@{ Ok = $false; Count = 0; Detail = $failDetail }
+}
+
 function Get-LabPrivilegeInvoker {
     <#
     Returns the non-interactive privilege prefix for remote ensure scripts (#954).

--- a/scripts/maestro/Lab-MaestroCommon.ps1
+++ b/scripts/maestro/Lab-MaestroCommon.ps1
@@ -22,10 +22,20 @@ function Get-HandlerTmuxSessionName {
 function Get-LabPrivilegeInvoker {
     <#
     Returns the non-interactive privilege prefix for remote ensure scripts (#954).
-    doas strips caller env by default; callers must use: $priv env VAR=val bash script.sh
+    #1021 R8: env vars go to .labop-gate/ context files (Plano B); privileged argv is
+    canonical bash + script only so narrow sudoers/doas grants match literally.
     #>
     return @'
 if command -v doas >/dev/null 2>&1; then echo "doas -n"; elif command -v sudo >/dev/null 2>&1; then echo "sudo -n"; else echo "NO_PRIV"; fi
+'@.Trim()
+}
+
+function Get-LabCanonicalBashProbe {
+    <#
+    #1021 R8: prefer /usr/bin/bash and /bin/bash before command -v (usrmerge secure_path).
+    #>
+    return @'
+BASH_BIN=""; for _b in /usr/bin/bash /bin/bash; do if [ -x "$_b" ]; then BASH_BIN="$_b"; break; fi; done; if [ -z "$BASH_BIN" ]; then echo "[Ensure] bash_bin_unresolved" >&2; exit 2; fi
 '@.Trim()
 }
 
@@ -36,16 +46,30 @@ function Build-EnsureRemoteCommand {
         [hashtable]$EnvVars = @{}
     )
     $privProbe = Get-LabPrivilegeInvoker
-    $envPairs = @()
+    $bashProbe = Get-LabCanonicalBashProbe
+    $ctxFileByKey = @{
+        LAB_OP_SUBNET = 'LAB_OP_SUBNET'
+        LAB_NFS_SVC   = 'LAB_NFS_SVC'
+        LAB_PKG_MGR   = 'LAB_PKG_MGR'
+    }
+    $ctxWrites = @()
     foreach ($k in $EnvVars.Keys) {
         $v = [string]$EnvVars[$k]
         if ($v -match "[\s'`"$\\]") {
             throw "Build-EnsureRemoteCommand: unsafe env value for $k"
         }
-        $envPairs += "${k}=${v}"
+        if (-not $ctxFileByKey.ContainsKey($k)) {
+            throw "Build-EnsureRemoteCommand: unsupported context key $k (use .labop-gate files)"
+        }
+        $fname = $ctxFileByKey[$k]
+        $ctxWrites += "printf '%s\n' '$v' >`"`$GATE_DIR/$fname`""
     }
-    $envPrefix = if ($envPairs.Count -gt 0) { "env $($envPairs -join ' ') " } else { "" }
-    return "PRIV=`$($privProbe)` ; if [ `"`$PRIV`" = NO_PRIV ]; then echo '[Ensure] NO doas/sudo on host' >&2; exit 2; fi; `$PRIV $envPrefix bash $EnsureScript $EnsureMode 2>&1"
+    $ctxBlock = if ($ctxWrites.Count -gt 0) {
+        "ENSURE_SCRIPT=$EnsureScript; GATE_DIR=`"`$(cd `"`$(dirname `"`$ENSURE_SCRIPT`")/..`" && pwd)/.labop-gate`"; mkdir -p `"`$GATE_DIR`"; $($ctxWrites -join '; '); "
+    } else {
+        "ENSURE_SCRIPT=$EnsureScript; "
+    }
+    return "${ctxBlock}PRIV=`$($privProbe)` ; if [ `"`$PRIV`" = NO_PRIV ]; then echo '[Ensure] NO doas/sudo on host' >&2; exit 2; fi; $bashProbe; `$PRIV `"`$BASH_BIN`" `"`$ENSURE_SCRIPT`" '$EnsureMode' 2>&1"
 }
 
 function Invoke-HandlerTmuxPayload {
@@ -131,16 +155,17 @@ function Invoke-LabopGateReadiness {
     $personaCsv = ($personaList -join ',')
     $repoPath = Get-MaestroRemoteRepoPath -RepoPath ([string]$Node.path)
     $mode = if ($Deep) { '--apply' } else { '--check' }
-    $envPrefix = ""
+    $ctxSetup = ""
     if ($Node.PSObject.Properties.Name -contains 'lab_op_subnet' -and $Node.lab_op_subnet) {
         $subnet = [string]$Node.lab_op_subnet
         if ($subnet -match "[\s'`"$\\]") {
             throw "Invoke-LabopGateReadiness: unsafe lab_op_subnet on $($Node.hostname)"
         }
-        $envPrefix = "env LAB_OP_SUBNET=$subnet "
+        $ctxSetup = "mkdir -p .labop-gate && printf '%s\n' '$subnet' > .labop-gate/LAB_OP_SUBNET && "
     }
+    $bashProbe = Get-LabCanonicalBashProbe
     $gateScript = "$repoPath/scripts/labop-gate-readiness.sh"
-    $remoteCmd = "cd $repoPath && ${envPrefix}bash $gateScript $mode --personas '$personaCsv' 2>&1"
+    $remoteCmd = "cd $repoPath && ${ctxSetup}${bashProbe}; `"`$BASH_BIN`" $gateScript $mode --personas '$personaCsv' 2>&1"
     Write-Host "      [GateReadiness] $mode on $($Node.hostname) personas=$personaCsv" -ForegroundColor DarkCyan
     $output = ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 `
         "$($Node.user)@$($Node.hostname)" $remoteCmd 2>&1

--- a/scripts/maestro/Lab-MaestroCommon.ps1
+++ b/scripts/maestro/Lab-MaestroCommon.ps1
@@ -107,6 +107,15 @@ function Get-MaestroCanonicalRepoPath {
     return ($RepoPath -replace "-v[0-9]+\.[0-9]+\.[0-9]+[^/\\]*$", "")
 }
 
+function Get-MaestroRemoteRepoPath {
+    param([Parameter(Mandatory = $true)][string]$RepoPath)
+    $canonical = Get-MaestroCanonicalRepoPath -RepoPath $RepoPath
+    if ($canonical -match '^~(/.*)$') {
+        return "`$HOME$($Matches[1])"
+    }
+    return $canonical
+}
+
 function Invoke-LabopGateReadiness {
     <#
     #960: ALARM (--check) skips handlers; REMEDIATE (-Deep / --apply) uses narrow grants.
@@ -120,7 +129,7 @@ function Invoke-LabopGateReadiness {
         return $true
     }
     $personaCsv = ($personaList -join ',')
-    $repoPath = Get-MaestroCanonicalRepoPath -RepoPath ([string]$Node.path)
+    $repoPath = Get-MaestroRemoteRepoPath -RepoPath ([string]$Node.path)
     $mode = if ($Deep) { '--apply' } else { '--check' }
     $envPrefix = ""
     if ($Node.PSObject.Properties.Name -contains 'lab_op_subnet' -and $Node.lab_op_subnet) {
@@ -131,7 +140,7 @@ function Invoke-LabopGateReadiness {
         $envPrefix = "env LAB_OP_SUBNET=$subnet "
     }
     $gateScript = "$repoPath/scripts/labop-gate-readiness.sh"
-    $remoteCmd = "cd '$repoPath' && ${envPrefix}bash '$gateScript' $mode --personas '$personaCsv' 2>&1"
+    $remoteCmd = "cd $repoPath && ${envPrefix}bash $gateScript $mode --personas '$personaCsv' 2>&1"
     Write-Host "      [GateReadiness] $mode on $($Node.hostname) personas=$personaCsv" -ForegroundColor DarkCyan
     $output = ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 `
         "$($Node.user)@$($Node.hostname)" $remoteCmd 2>&1

--- a/scripts/maestro/Lab-MaestroCommon.ps1
+++ b/scripts/maestro/Lab-MaestroCommon.ps1
@@ -69,6 +69,33 @@ function Format-MaestroHandlersSummary {
     return 'OK'
 }
 
+function Get-LabDbInitStageBash {
+    <#
+    #1021 R11: SCP/rsync often leaves init SQL at 660; rootless podman cannot read bind mount.
+    Stage to /tmp with a+rX before podman run (see LAB_SMOKE_MULTI_HOST.md / ADR-0029).
+    #>
+    return @'
+stage_lab_db_init() {
+  local src="$1"
+  local label="$2"
+  local dest="/tmp/databoar-lab-init/${label}"
+  rm -rf "$dest"
+  mkdir -p "$dest"
+  cp -a "${src}/." "$dest/"
+  chmod -R a+rX "$dest"
+  printf '%s' "$dest"
+}
+ensure_lab_smoke_init_readable() {
+  local dir
+  for dir in "$@"; do
+    if [ -d "$dir" ]; then
+      chmod -R a+rX "$dir" 2>/dev/null || true
+    fi
+  done
+}
+'@.Trim()
+}
+
 function Confirm-TargetDbSyntheticData {
     <#
     #1021 R9c: after container READY, prove init seed rows exist (not just port open).
@@ -90,6 +117,21 @@ function Confirm-TargetDbSyntheticData {
         'postgres' {
             @'
 cd __STACK_DIR__
+_pg_container_state() {
+  if command -v podman >/dev/null 2>&1 && podman ps -a --format '{{.Names}}' 2>/dev/null | grep -qx 'lab-postgres'; then
+    podman inspect -f '{{.State.Status}}' lab-postgres 2>/dev/null || echo missing
+    return
+  fi
+  if command -v docker >/dev/null 2>&1 && docker compose ps lab-postgres 2>/dev/null | grep -q 'Up'; then
+    echo running
+    return
+  fi
+  if command -v docker >/dev/null 2>&1 && docker compose ps -a lab-postgres 2>/dev/null | grep -q lab-postgres; then
+    echo exited
+    return
+  fi
+  echo missing
+}
 _count_pg() {
   if command -v podman >/dev/null 2>&1 && podman ps --format '{{.Names}}' 2>/dev/null | grep -qx 'lab-postgres'; then
     podman exec lab-postgres psql -U "${LAB_PG_USER:-lab_smoke}" -d "${LAB_PG_DATABASE:-lab_smoke_pg}" -tAc "SELECT count(*) FROM lab_customers;"
@@ -99,9 +141,17 @@ _count_pg() {
     return 2
   fi
 }
+st=$(_pg_container_state)
+if [ "$st" != "running" ]; then
+  echo "SYNTHETIC_DATA_FAIL engine=postgres reason=confirm_unreachable container=$st"
+  command -v podman >/dev/null 2>&1 && podman logs --tail 5 lab-postgres 2>&1 || true
+  exit 1
+fi
 attempt=0
+last_err=""
 while [ "$attempt" -lt __MAX_ATTEMPTS__ ]; do
-  cnt=$(_count_pg 2>/dev/null) || cnt=""
+  cnt=$(_count_pg 2>"/tmp/databoar-pg-count.err") || cnt=""
+  last_err=$(tail -1 /tmp/databoar-pg-count.err 2>/dev/null || true)
   cnt=$(printf '%s' "$cnt" | tr -d '[:space:]')
   if printf '%s' "$cnt" | grep -Eq '^[0-9]+$' && [ "$cnt" -gt 0 ]; then
     echo "SYNTHETIC_DATA_OK engine=postgres table=lab_customers count=$cnt"
@@ -110,13 +160,32 @@ while [ "$attempt" -lt __MAX_ATTEMPTS__ ]; do
   attempt=$((attempt + 1))
   sleep __WAIT_SECONDS__
 done
-echo "SYNTHETIC_DATA_FAIL engine=postgres reason=zero_or_unreachable"
+if [ -n "$last_err" ]; then
+  echo "SYNTHETIC_DATA_FAIL engine=postgres reason=confirm_exec_failed detail=${last_err}"
+else
+  echo "SYNTHETIC_DATA_FAIL engine=postgres reason=seed_empty container=running"
+fi
 exit 1
 '@
         }
         'mariadb' {
             @'
 cd __STACK_DIR__
+_my_container_state() {
+  if command -v podman >/dev/null 2>&1 && podman ps -a --format '{{.Names}}' 2>/dev/null | grep -qx 'lab-mariadb'; then
+    podman inspect -f '{{.State.Status}}' lab-mariadb 2>/dev/null || echo missing
+    return
+  fi
+  if command -v docker >/dev/null 2>&1 && docker compose ps lab-mariadb 2>/dev/null | grep -q 'Up'; then
+    echo running
+    return
+  fi
+  if command -v docker >/dev/null 2>&1 && docker compose ps -a lab-mariadb 2>/dev/null | grep -q lab-mariadb; then
+    echo exited
+    return
+  fi
+  echo missing
+}
 _count_my() {
   if command -v podman >/dev/null 2>&1 && podman ps --format '{{.Names}}' 2>/dev/null | grep -qx 'lab-mariadb'; then
     podman exec lab-mariadb mariadb -u"${LAB_MY_USER:-lab_smoke}" -p"${LAB_MY_PASSWORD:-lab_smoke_change_me}" -N -e "SELECT count(*) FROM lab_customers;" "${LAB_MY_DATABASE:-lab_smoke_my}"
@@ -126,9 +195,17 @@ _count_my() {
     return 2
   fi
 }
+st=$(_my_container_state)
+if [ "$st" != "running" ]; then
+  echo "SYNTHETIC_DATA_FAIL engine=mariadb reason=confirm_unreachable container=$st"
+  command -v podman >/dev/null 2>&1 && podman logs --tail 5 lab-mariadb 2>&1 || true
+  exit 1
+fi
 attempt=0
+last_err=""
 while [ "$attempt" -lt __MAX_ATTEMPTS__ ]; do
-  cnt=$(_count_my 2>/dev/null) || cnt=""
+  cnt=$(_count_my 2>"/tmp/databoar-my-count.err") || cnt=""
+  last_err=$(tail -1 /tmp/databoar-my-count.err 2>/dev/null || true)
   cnt=$(printf '%s' "$cnt" | tr -d '[:space:]')
   if printf '%s' "$cnt" | grep -Eq '^[0-9]+$' && [ "$cnt" -gt 0 ]; then
     echo "SYNTHETIC_DATA_OK engine=mariadb table=lab_customers count=$cnt"
@@ -137,13 +214,32 @@ while [ "$attempt" -lt __MAX_ATTEMPTS__ ]; do
   attempt=$((attempt + 1))
   sleep __WAIT_SECONDS__
 done
-echo "SYNTHETIC_DATA_FAIL engine=mariadb reason=zero_or_unreachable"
+if [ -n "$last_err" ]; then
+  echo "SYNTHETIC_DATA_FAIL engine=mariadb reason=confirm_exec_failed detail=${last_err}"
+else
+  echo "SYNTHETIC_DATA_FAIL engine=mariadb reason=seed_empty container=running"
+fi
 exit 1
 '@
         }
         'mongodb' {
             @'
 cd __STACK_DIR__
+_mongo_container_state() {
+  if command -v podman >/dev/null 2>&1 && podman ps -a --format '{{.Names}}' 2>/dev/null | grep -qx 'lab-mongodb'; then
+    podman inspect -f '{{.State.Status}}' lab-mongodb 2>/dev/null || echo missing
+    return
+  fi
+  if command -v docker >/dev/null 2>&1 && docker compose -f docker-compose.mongo.yml ps lab-mongodb 2>/dev/null | grep -q 'Up'; then
+    echo running
+    return
+  fi
+  if command -v docker >/dev/null 2>&1 && docker compose -f docker-compose.mongo.yml ps -a lab-mongodb 2>/dev/null | grep -q lab-mongodb; then
+    echo exited
+    return
+  fi
+  echo missing
+}
 _count_mongo() {
   if command -v podman >/dev/null 2>&1 && podman ps --format '{{.Names}}' 2>/dev/null | grep -qx 'lab-mongodb'; then
     podman exec lab-mongodb mongosh --quiet --eval 'db.getSiblingDB("lab_smoke_mongo").lab_people.countDocuments()'
@@ -153,9 +249,17 @@ _count_mongo() {
     return 2
   fi
 }
+st=$(_mongo_container_state)
+if [ "$st" != "running" ]; then
+  echo "SYNTHETIC_DATA_FAIL engine=mongodb reason=confirm_unreachable container=$st"
+  command -v podman >/dev/null 2>&1 && podman logs --tail 5 lab-mongodb 2>&1 || true
+  exit 1
+fi
 attempt=0
+last_err=""
 while [ "$attempt" -lt __MAX_ATTEMPTS__ ]; do
-  cnt=$(_count_mongo 2>/dev/null) || cnt=""
+  cnt=$(_count_mongo 2>"/tmp/databoar-mongo-count.err") || cnt=""
+  last_err=$(tail -1 /tmp/databoar-mongo-count.err 2>/dev/null || true)
   cnt=$(printf '%s' "$cnt" | tr -d '[:space:]')
   if printf '%s' "$cnt" | grep -Eq '^[0-9]+$' && [ "$cnt" -gt 0 ]; then
     echo "SYNTHETIC_DATA_OK engine=mongodb collection=lab_people count=$cnt"
@@ -164,7 +268,11 @@ while [ "$attempt" -lt __MAX_ATTEMPTS__ ]; do
   attempt=$((attempt + 1))
   sleep __WAIT_SECONDS__
 done
-echo "SYNTHETIC_DATA_FAIL engine=mongodb reason=zero_or_unreachable"
+if [ -n "$last_err" ]; then
+  echo "SYNTHETIC_DATA_FAIL engine=mongodb reason=confirm_exec_failed detail=${last_err}"
+else
+  echo "SYNTHETIC_DATA_FAIL engine=mongodb reason=seed_empty container=running"
+fi
 exit 1
 '@
         }

--- a/scripts/maestro/Lab-MaestroCommon.ps1
+++ b/scripts/maestro/Lab-MaestroCommon.ps1
@@ -20,9 +20,6 @@ function Get-HandlerTmuxSessionName {
 }
 
 function Get-EnsureAlarmFromOutput {
-    <#
-    Parses ALARM= lines from labop-*-ensure.sh (exit 3 graceful, #1021 R9).
-    #>
     param(
         [Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]]$Lines,
         [Parameter(Mandatory = $true)][string]$LogTag
@@ -36,6 +33,40 @@ function Get-EnsureAlarmFromOutput {
         }
     }
     return $null
+}
+
+function Add-MaestroHandlerExitTally {
+    <#
+    #1021 R9b: passou (0) vs degradou (3) vs falhou (other). Exit 3 is ALARM, not REAL FAIL.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][int]$ExitCode,
+        [ref]$FailCount,
+        [ref]$AlarmCount
+    )
+    if ($ExitCode -eq 0) { return }
+    if ($ExitCode -eq 3) {
+        $AlarmCount.Value++
+        return
+    }
+    $FailCount.Value++
+}
+
+function Format-MaestroHandlersSummary {
+    <#
+    Per-host handler rollup for Deep smoke / gate reports (#1021 R9b).
+    #>
+    param(
+        [bool]$GateOk,
+        [int]$HandlerRan = 0,
+        [int]$HandlerFails = 0,
+        [int]$HandlerAlarms = 0
+    )
+    if (-not $GateOk) { return 'SKIP' }
+    if ($HandlerRan -eq 0) { return 'NONE' }
+    if ($HandlerFails -gt 0) { return "FAIL:$HandlerFails" }
+    if ($HandlerAlarms -gt 0) { return "ALARM:$HandlerAlarms" }
+    return 'OK'
 }
 
 function Get-LabPrivilegeInvoker {

--- a/scripts/maestro/Lab-MaestroCommon.ps1
+++ b/scripts/maestro/Lab-MaestroCommon.ps1
@@ -170,10 +170,10 @@ exit 1
         }
     }
 
-    $remoteCmd = $engineBody.Replace('__STACK_DIR__', $stackDir).Replace('__MAX_ATTEMPTS__', [string]$MaxAttempts).Replace('__WAIT_SECONDS__', [string]$WaitSeconds)
+    $remoteCmd = $engineBody.Replace('__STACK_DIR__', $stackDir).Replace('__MAX_ATTEMPTS__', [string]$MaxAttempts).Replace('__WAIT_SECONDS__', [string]$WaitSeconds) -replace "`r", ""
 
     $out = ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 `
-        "$($Node.user)@$($Node.hostname)" $remoteCmd 2>&1
+        "$($Node.user)@$($Node.hostname)" "$remoteCmd" 2>&1
     $text = ($out | Out-String).Trim()
     if ($LASTEXITCODE -eq 0 -and $text -match 'SYNTHETIC_DATA_OK') {
         $countMatch = [regex]::Match($text, 'count=(\d+)')

--- a/scripts/maestro/Maestro-Deep-5Host-Gate.ps1
+++ b/scripts/maestro/Maestro-Deep-5Host-Gate.ps1
@@ -6,12 +6,31 @@
 .DESCRIPTION
   Sync WorkingTree, gate --apply, handlers -Deep per persona; prints summary with
   Handlers column OK | ALARM:N | FAIL:N (#1021 R9b).
+  #1021 R11: -Detach runs under tmux+setsid (avoid nohup orphan); -IdempotentTwice runs two passes.
 #>
+param(
+    [switch]$Detach,
+    [switch]$IdempotentTwice
+)
+
 $ErrorActionPreference = "Continue"
 $repo = (Resolve-Path "$PSScriptRoot/../..").Path
 $maestro = "$PSScriptRoot"
 Set-Location $repo
 . "$maestro/Lab-MaestroCommon.ps1"
+
+$log = if ($env:MAESTRO_DEEP_LOG) { $env:MAESTRO_DEEP_LOG } else { "/tmp/maestro-deep-5host-gate.log" }
+
+if ($Detach) {
+    $session = "maestro-deep-gate"
+    $argTail = if ($IdempotentTwice) { "-IdempotentTwice" } else { "" }
+    $inner = "cd '$repo' && setsid pwsh -NoProfile -File '$PSCommandPath' $argTail 2>&1 | tee '$log'"
+    tmux kill-session -t $session 2>$null
+    tmux new-session -d -s $session $inner
+    Write-Host "re-Deep detached: tmux attach -t $session" -ForegroundColor Green
+    Write-Host "Log: $log"
+    exit 0
+}
 
 $invPath = "$repo/docs/private/homelab/data/inventory.json"
 if (-not (Test-Path -LiteralPath $invPath)) {
@@ -23,90 +42,125 @@ $inv = Get-Content $invPath -Raw | ConvertFrom-Json
 $targets = @($inv.lab_members | Where-Object {
         $_.hostname -and ($_.ip -match '^\d+\.\d+\.\d+\.\d+$')
     })
-$log = if ($env:MAESTRO_DEEP_LOG) { $env:MAESTRO_DEEP_LOG } else { "/tmp/maestro-deep-5host-gate.log" }
-Remove-Item $log -ErrorAction SilentlyContinue
-$summary = @()
 
-"=== Pre-flight Build-ContainerArtefact $(Get-Date -Format o) ===" | Tee-Object -FilePath $log -Append
-& "$maestro/Build-ContainerArtefact.ps1" 2>&1 | Tee-Object -FilePath $log -Append
-
-foreach ($node in $targets) {
-    $name = $node.hostname
-    "`n########## DEEP: $name $(Get-Date -Format o) ##########" | Tee-Object -FilePath $log -Append | Out-Null
-    if (-not $node) { "SKIP missing node" | Add-Content $log; continue }
-    if ($node.ip -match '[^0-9.]') { "SKIP bad IP" | Add-Content $log; continue }
-    $octets = ($node.ip -split "\.")[0..2] -join "."
-    $node | Add-Member -NotePropertyName lab_op_subnet -NotePropertyValue "$octets.0/24" -Force
-
-    $status = & "$maestro/Get-LabStatus.ps1" -TargetHost $node.hostname -TargetUser $node.user 2>&1
-    $status | Tee-Object -FilePath $log -Append
-    if ($status.SSH -ne "UP") {
-        $summary += [pscustomobject]@{ Host = $name; Sync = "-"; Gate = "SSH_DOWN"; Handlers = "-" }
-        continue
+function Invoke-MaestroDeepGatePass {
+    param(
+        [string]$PassLabel,
+        [object[]]$TargetNodes,
+        [switch]$SkipPreflight
+    )
+    $passSummary = @()
+    if (-not $SkipPreflight) {
+        "=== Pre-flight Build-ContainerArtefact $PassLabel $(Get-Date -Format o) ===" | Tee-Object -FilePath $log -Append
+        & "$maestro/Build-ContainerArtefact.ps1" 2>&1 | Tee-Object -FilePath $log -Append
     }
 
-    Write-Host ">>> Sync $name" -ForegroundColor Cyan
-    $syncOk = [bool](& "$maestro/Sync-WorkingTree.ps1" -Node $node -Ref WorkingTree)
-    "Sync result: $syncOk" | Tee-Object -FilePath $log -Append
-    if (-not $syncOk) {
-        $summary += [pscustomobject]@{ Host = $name; Sync = "FAIL"; Gate = "-"; Handlers = "SKIP" }
-        continue
-    }
+    foreach ($node in $TargetNodes) {
+        $name = $node.hostname
+        "`n########## DEEP $PassLabel : $name $(Get-Date -Format o) ##########" | Tee-Object -FilePath $log -Append | Out-Null
+        if (-not $node) { "SKIP missing node" | Add-Content $log; continue }
+        if ($node.ip -match '[^0-9.]') { "SKIP bad IP" | Add-Content $log; continue }
+        $octets = ($node.ip -split "\.")[0..2] -join "."
+        $node | Add-Member -NotePropertyName lab_op_subnet -NotePropertyValue "$octets.0/24" -Force
 
-    $isContainer = ($node.personas -contains "docker") -or ($node.personas -contains "podman") -or ($node.personas -contains "dockerswarm")
-    if ($isContainer) {
-        & "$maestro/Sync-ContainerArtefact.ps1" -Node $node 2>&1 | Tee-Object -FilePath $log -Append
-    }
-
-    Write-Host ">>> Gate -Deep $name" -ForegroundColor Cyan
-    $gateOk = Invoke-LabopGateReadiness -Node $node -Deep
-    "Gate result: $gateOk" | Tee-Object -FilePath $log -Append
-
-    $handlerFails = 0
-    $handlerAlarms = 0
-    $handlerRan = 0
-    if ($gateOk) {
-        $ordered = $node.personas | Sort-Object {
-            switch ($_) {
-                "docker" { 0; break }
-                "podman" { 0; break }
-                "dockerswarm" { 0; break }
-                "web" { 2; break }
-                default { 1; break }
-            }
+        $status = & "$maestro/Get-LabStatus.ps1" -TargetHost $node.hostname -TargetUser $node.user 2>&1
+        $status | Tee-Object -FilePath $log -Append
+        if ($status.SSH -ne "UP") {
+            $passSummary += [pscustomobject]@{ Host = $name; Sync = "-"; Gate = "SSH_DOWN"; Handlers = "-" }
+            continue
         }
-        foreach ($persona in $ordered) {
-            $handler = "$maestro/handlers/Handle-$persona.ps1"
-            if (-not (Test-Path -LiteralPath $handler)) {
-                "HANDLER_MISSING: $persona" | Add-Content $log
-                continue
-            }
-            Write-Host "   Handler $persona on $name" -ForegroundColor DarkCyan
-            & $handler -Node $node -Ref WorkingTree -Deep 2>&1 | Tee-Object -FilePath $log -Append
-            $handlerRan++
-            Add-MaestroHandlerExitTally -ExitCode $LASTEXITCODE -FailCount ([ref]$handlerFails) -AlarmCount ([ref]$handlerAlarms)
+
+        Write-Host ">>> Sync $name ($PassLabel)" -ForegroundColor Cyan
+        $syncOk = [bool](& "$maestro/Sync-WorkingTree.ps1" -Node $node -Ref WorkingTree)
+        "Sync result: $syncOk" | Tee-Object -FilePath $log -Append
+        if (-not $syncOk) {
+            $passSummary += [pscustomobject]@{ Host = $name; Sync = "FAIL"; Gate = "-"; Handlers = "SKIP" }
+            continue
         }
-    } else {
-        "HANDLERS_SKIPPED gate failed (Maestro contract)" | Add-Content $log
+
+        $isContainer = ($node.personas -contains "docker") -or ($node.personas -contains "podman") -or ($node.personas -contains "dockerswarm")
+        if ($isContainer) {
+            & "$maestro/Sync-ContainerArtefact.ps1" -Node $node 2>&1 | Tee-Object -FilePath $log -Append
+        }
+
+        Write-Host ">>> Gate -Deep $name ($PassLabel)" -ForegroundColor Cyan
+        $gateOk = Invoke-LabopGateReadiness -Node $node -Deep
+        "Gate result: $gateOk" | Tee-Object -FilePath $log -Append
+
+        $handlerFails = 0
+        $handlerAlarms = 0
+        $handlerRan = 0
+        if ($gateOk) {
+            $ordered = $node.personas | Sort-Object {
+                switch ($_) {
+                    "docker" { 0; break }
+                    "podman" { 0; break }
+                    "dockerswarm" { 0; break }
+                    "web" { 2; break }
+                    default { 1; break }
+                }
+            }
+            foreach ($persona in $ordered) {
+                $handler = "$maestro/handlers/Handle-$persona.ps1"
+                if (-not (Test-Path -LiteralPath $handler)) {
+                    "HANDLER_MISSING: $persona" | Add-Content $log
+                    continue
+                }
+                Write-Host "   Handler $persona on $name" -ForegroundColor DarkCyan
+                & $handler -Node $node -Ref WorkingTree -Deep 2>&1 | Tee-Object -FilePath $log -Append
+                $handlerRan++
+                Add-MaestroHandlerExitTally -ExitCode $LASTEXITCODE -FailCount ([ref]$handlerFails) -AlarmCount ([ref]$handlerAlarms)
+            }
+        } else {
+            "HANDLERS_SKIPPED gate failed (Maestro contract)" | Add-Content $log
+        }
+
+        $handlersLabel = Format-MaestroHandlersSummary -GateOk $gateOk -HandlerRan $handlerRan `
+            -HandlerFails $handlerFails -HandlerAlarms $handlerAlarms
+        $passSummary += [pscustomobject]@{
+            Host     = $name
+            Sync     = "OK"
+            Gate     = if ($gateOk) { "OK" } else { "ALARM" }
+            Handlers = $handlersLabel
+        }
     }
 
-    $handlersLabel = Format-MaestroHandlersSummary -GateOk $gateOk -HandlerRan $handlerRan `
-        -HandlerFails $handlerFails -HandlerAlarms $handlerAlarms
-    $summary += [pscustomobject]@{
-        Host     = $name
-        Sync     = "OK"
-        Gate     = if ($gateOk) { "OK" } else { "ALARM" }
-        Handlers = $handlersLabel
-    }
+    "`n=== SUMMARY $PassLabel $(Get-Date -Format o) ===" | Add-Content $log
+    $passSummary | Format-Table | Out-String | Tee-Object -FilePath $log -Append
+    $passSummary | Format-Table
+    return ,$passSummary
 }
 
-"`n=== SUMMARY $(Get-Date -Format o) ===" | Add-Content $log
-$summary | Format-Table | Out-String | Tee-Object -FilePath $log -Append
-$summary | Format-Table
+Remove-Item $log -ErrorAction SilentlyContinue
+$summary = Invoke-MaestroDeepGatePass -PassLabel "pass1" -TargetNodes $targets
+
+if ($IdempotentTwice) {
+    "`n=== IDEMPOTENCY pass2 $(Get-Date -Format o) ===" | Add-Content $log
+    $summary2 = Invoke-MaestroDeepGatePass -PassLabel "pass2" -TargetNodes $targets -SkipPreflight
+    $mismatch = @()
+    foreach ($row in $summary) {
+        $other = $summary2 | Where-Object { $_.Host -eq $row.Host } | Select-Object -First 1
+        if (-not $other) { $mismatch += "$($row.Host): missing in pass2"; continue }
+        $line = "$($row.Host)|$($row.Sync)|$($row.Gate)|$($row.Handlers)"
+        $line2 = "$($other.Host)|$($other.Sync)|$($other.Gate)|$($other.Handlers)"
+        if ($line -ne $line2) { $mismatch += "pass1=$line pass2=$line2" }
+    }
+    if ($mismatch.Count -eq 0) {
+        "IDEMPOTENCY: pass1 and pass2 SUMMARY match" | Tee-Object -FilePath $log -Append
+        Write-Host "IDEMPOTENCY: pass1 and pass2 SUMMARY match" -ForegroundColor Green
+    } else {
+        "IDEMPOTENCY: MISMATCH" | Tee-Object -FilePath $log -Append
+        $mismatch | Tee-Object -FilePath $log -Append
+        Write-Warning "IDEMPOTENCY: pass1 vs pass2 mismatch — see log"
+    }
+}
 
 "`n=== GR LINES ===" | Add-Content $log
 Get-Content $log | Select-String -Pattern 'GR host=' | ForEach-Object { $_.Line.Trim() } | Tee-Object -FilePath $log -Append
 
 $totalFails = ($summary | Where-Object { $_.Handlers -like 'FAIL:*' }).Count
+if ($IdempotentTwice) {
+    $totalFails += ($summary2 | Where-Object { $_.Handlers -like 'FAIL:*' }).Count
+}
 if ($totalFails -gt 0) { exit 1 }
 exit 0

--- a/scripts/maestro/Maestro-Deep-5Host-Gate.ps1
+++ b/scripts/maestro/Maestro-Deep-5Host-Gate.ps1
@@ -1,0 +1,112 @@
+#Requires -Version 7
+<#
+.SYNOPSIS
+  Deep gate + handlers smoke on five lab-op hosts (#1021 re-Deep harness).
+
+.DESCRIPTION
+  Sync WorkingTree, gate --apply, handlers -Deep per persona; prints summary with
+  Handlers column OK | ALARM:N | FAIL:N (#1021 R9b).
+#>
+$ErrorActionPreference = "Continue"
+$repo = (Resolve-Path "$PSScriptRoot/../..").Path
+$maestro = "$PSScriptRoot"
+Set-Location $repo
+. "$maestro/Lab-MaestroCommon.ps1"
+
+$invPath = "$repo/docs/private/homelab/data/inventory.json"
+if (-not (Test-Path -LiteralPath $invPath)) {
+    Write-Error "Missing inventory: $invPath"
+    exit 2
+}
+$inv = Get-Content $invPath -Raw | ConvertFrom-Json
+# Host list from private inventory only (no hardcoded hostnames in tracked tree — PII gate).
+$targets = @($inv.lab_members | Where-Object {
+        $_.hostname -and ($_.ip -match '^\d+\.\d+\.\d+\.\d+$')
+    })
+$log = if ($env:MAESTRO_DEEP_LOG) { $env:MAESTRO_DEEP_LOG } else { "/tmp/maestro-deep-5host-gate.log" }
+Remove-Item $log -ErrorAction SilentlyContinue
+$summary = @()
+
+"=== Pre-flight Build-ContainerArtefact $(Get-Date -Format o) ===" | Tee-Object -FilePath $log -Append
+& "$maestro/Build-ContainerArtefact.ps1" 2>&1 | Tee-Object -FilePath $log -Append
+
+foreach ($node in $targets) {
+    $name = $node.hostname
+    "`n########## DEEP: $name $(Get-Date -Format o) ##########" | Tee-Object -FilePath $log -Append | Out-Null
+    if (-not $node) { "SKIP missing node" | Add-Content $log; continue }
+    if ($node.ip -match '[^0-9.]') { "SKIP bad IP" | Add-Content $log; continue }
+    $octets = ($node.ip -split "\.")[0..2] -join "."
+    $node | Add-Member -NotePropertyName lab_op_subnet -NotePropertyValue "$octets.0/24" -Force
+
+    $status = & "$maestro/Get-LabStatus.ps1" -TargetHost $node.hostname -TargetUser $node.user 2>&1
+    $status | Tee-Object -FilePath $log -Append
+    if ($status.SSH -ne "UP") {
+        $summary += [pscustomobject]@{ Host = $name; Sync = "-"; Gate = "SSH_DOWN"; Handlers = "-" }
+        continue
+    }
+
+    Write-Host ">>> Sync $name" -ForegroundColor Cyan
+    $syncOk = [bool](& "$maestro/Sync-WorkingTree.ps1" -Node $node -Ref WorkingTree)
+    "Sync result: $syncOk" | Tee-Object -FilePath $log -Append
+    if (-not $syncOk) {
+        $summary += [pscustomobject]@{ Host = $name; Sync = "FAIL"; Gate = "-"; Handlers = "SKIP" }
+        continue
+    }
+
+    $isContainer = ($node.personas -contains "docker") -or ($node.personas -contains "podman") -or ($node.personas -contains "dockerswarm")
+    if ($isContainer) {
+        & "$maestro/Sync-ContainerArtefact.ps1" -Node $node 2>&1 | Tee-Object -FilePath $log -Append
+    }
+
+    Write-Host ">>> Gate -Deep $name" -ForegroundColor Cyan
+    $gateOk = Invoke-LabopGateReadiness -Node $node -Deep
+    "Gate result: $gateOk" | Tee-Object -FilePath $log -Append
+
+    $handlerFails = 0
+    $handlerAlarms = 0
+    $handlerRan = 0
+    if ($gateOk) {
+        $ordered = $node.personas | Sort-Object {
+            switch ($_) {
+                "docker" { 0; break }
+                "podman" { 0; break }
+                "dockerswarm" { 0; break }
+                "web" { 2; break }
+                default { 1; break }
+            }
+        }
+        foreach ($persona in $ordered) {
+            $handler = "$maestro/handlers/Handle-$persona.ps1"
+            if (-not (Test-Path -LiteralPath $handler)) {
+                "HANDLER_MISSING: $persona" | Add-Content $log
+                continue
+            }
+            Write-Host "   Handler $persona on $name" -ForegroundColor DarkCyan
+            & $handler -Node $node -Ref WorkingTree -Deep 2>&1 | Tee-Object -FilePath $log -Append
+            $handlerRan++
+            Add-MaestroHandlerExitTally -ExitCode $LASTEXITCODE -FailCount ([ref]$handlerFails) -AlarmCount ([ref]$handlerAlarms)
+        }
+    } else {
+        "HANDLERS_SKIPPED gate failed (Maestro contract)" | Add-Content $log
+    }
+
+    $handlersLabel = Format-MaestroHandlersSummary -GateOk $gateOk -HandlerRan $handlerRan `
+        -HandlerFails $handlerFails -HandlerAlarms $handlerAlarms
+    $summary += [pscustomobject]@{
+        Host     = $name
+        Sync     = "OK"
+        Gate     = if ($gateOk) { "OK" } else { "ALARM" }
+        Handlers = $handlersLabel
+    }
+}
+
+"`n=== SUMMARY $(Get-Date -Format o) ===" | Add-Content $log
+$summary | Format-Table | Out-String | Tee-Object -FilePath $log -Append
+$summary | Format-Table
+
+"`n=== GR LINES ===" | Add-Content $log
+Get-Content $log | Select-String -Pattern 'GR host=' | ForEach-Object { $_.Line.Trim() } | Tee-Object -FilePath $log -Append
+
+$totalFails = ($summary | Where-Object { $_.Handlers -like 'FAIL:*' }).Count
+if ($totalFails -gt 0) { exit 1 }
+exit 0

--- a/scripts/maestro/Maestro-Deep-5Host-Gate.ps1
+++ b/scripts/maestro/Maestro-Deep-5Host-Gate.ps1
@@ -128,18 +128,19 @@ function Invoke-MaestroDeepGatePass {
     "`n=== SUMMARY $PassLabel $(Get-Date -Format o) ===" | Add-Content $log
     $passSummary | Format-Table | Out-String | Tee-Object -FilePath $log -Append
     $passSummary | Format-Table
-    return ,$passSummary
+    return $passSummary
 }
 
 Remove-Item $log -ErrorAction SilentlyContinue
-$summary = Invoke-MaestroDeepGatePass -PassLabel "pass1" -TargetNodes $targets
+$summary = @(Invoke-MaestroDeepGatePass -PassLabel "pass1" -TargetNodes $targets)
 
 if ($IdempotentTwice) {
     "`n=== IDEMPOTENCY pass2 $(Get-Date -Format o) ===" | Add-Content $log
-    $summary2 = Invoke-MaestroDeepGatePass -PassLabel "pass2" -TargetNodes $targets -SkipPreflight
+    $summary2 = @(Invoke-MaestroDeepGatePass -PassLabel "pass2" -TargetNodes $targets -SkipPreflight)
     $mismatch = @()
-    foreach ($row in $summary) {
-        $other = $summary2 | Where-Object { $_.Host -eq $row.Host } | Select-Object -First 1
+    foreach ($row in @($summary)) {
+        if (-not $row.Host) { continue }
+        $other = @($summary2) | Where-Object { $_.Host -eq $row.Host } | Select-Object -First 1
         if (-not $other) { $mismatch += "$($row.Host): missing in pass2"; continue }
         $line = "$($row.Host)|$($row.Sync)|$($row.Gate)|$($row.Handlers)"
         $line2 = "$($other.Host)|$($other.Sync)|$($other.Gate)|$($other.Handlers)"
@@ -158,9 +159,9 @@ if ($IdempotentTwice) {
 "`n=== GR LINES ===" | Add-Content $log
 Get-Content $log | Select-String -Pattern 'GR host=' | ForEach-Object { $_.Line.Trim() } | Tee-Object -FilePath $log -Append
 
-$totalFails = ($summary | Where-Object { $_.Handlers -like 'FAIL:*' }).Count
+$totalFails = (@($summary) | Where-Object { $_.Handlers -like 'FAIL:*' }).Count
 if ($IdempotentTwice) {
-    $totalFails += ($summary2 | Where-Object { $_.Handlers -like 'FAIL:*' }).Count
+    $totalFails += (@($summary2) | Where-Object { $_.Handlers -like 'FAIL:*' }).Count
 }
 if ($totalFails -gt 0) { exit 1 }
 exit 0

--- a/scripts/maestro/Maestro-Deep-5Host-Gate.ps1
+++ b/scripts/maestro/Maestro-Deep-5Host-Gate.ps1
@@ -8,6 +8,7 @@
   Handlers column OK | ALARM:N | FAIL:N (#1021 R9b).
   #1021 R11: -Detach runs under tmux+setsid (avoid nohup orphan); -IdempotentTwice runs two passes.
   #1021 R12: idempotency compare uses Compare-MaestroDeepGateSummaries (no Format-Table pipeline pollution).
+  #1021 R12.1: Get-MaestroDeepSummaryRows flattens pass return; row-count guard must match gate host list.
 #>
 param(
     [switch]$Detach,
@@ -44,16 +45,43 @@ $targets = @($inv.lab_members | Where-Object {
         $_.hostname -and ($_.ip -match '^\d+\.\d+\.\d+\.\d+$')
     })
 
+function Get-MaestroDeepSummaryRows {
+    <#
+    #1021 R12.1: flatten Invoke-MaestroDeepGatePass return (never trust nested single-element arrays).
+    #>
+    param([object]$RawResult)
+    if ($null -eq $RawResult) { return @() }
+    $flat = [System.Collections.Generic.List[object]]::new()
+    foreach ($item in @($RawResult)) {
+        if ($null -eq $item) { continue }
+        $hasHost = $item.PSObject.Properties.Match("Host").Count -gt 0
+        if ($hasHost) {
+            [void]$flat.Add($item)
+            continue
+        }
+        if ($item -is [System.Collections.IEnumerable] -and $item -isnot [string]) {
+            foreach ($inner in @($item)) {
+                if ($null -eq $inner) { continue }
+                if ($inner.PSObject.Properties.Match("Host").Count -gt 0) {
+                    [void]$flat.Add($inner)
+                }
+            }
+        }
+    }
+    return @($flat)
+}
+
 function Compare-MaestroDeepGateSummaries {
     <#
     #1021 R12: compare pass1 vs pass2 rows by Host key (no pipeline/Format-Table pollution).
+    #1021 R12.1: inputs flattened via Get-MaestroDeepSummaryRows.
     #>
     param(
         [object[]]$Pass1,
         [object[]]$Pass2
     )
-    $rows1 = @($Pass1 | Where-Object { $null -ne $_ -and $null -ne $_.Host })
-    $rows2 = @($Pass2 | Where-Object { $null -ne $_ -and $null -ne $_.Host })
+    $rows1 = Get-MaestroDeepSummaryRows -RawResult $Pass1
+    $rows2 = Get-MaestroDeepSummaryRows -RawResult $Pass2
     $mismatch = [System.Collections.Generic.List[string]]::new()
     foreach ($row in $rows1) {
         $key = [string]$row.Host
@@ -170,20 +198,27 @@ function Invoke-MaestroDeepGatePass {
     $tableOut = $passSummary | Format-Table | Out-String
     $tableOut | Tee-Object -FilePath $log -Append | Out-Null
     Write-Host $tableOut
-    # Return only data rows — never emit Format-Table to the success pipeline (R12).
-    return ,@($passSummary)
+    # Return flat PSCustomObject rows only — no comma-nested array (R12.1).
+    return @($passSummary)
 }
 
+$expectedGateHosts = @($targets).Count
+
 Remove-Item $log -ErrorAction SilentlyContinue
-$summaryRaw = Invoke-MaestroDeepGatePass -PassLabel "pass1" -TargetNodes $targets
-$summary = @($summaryRaw | Where-Object { $null -ne $_ -and $null -ne $_.Host })
+$summary = Get-MaestroDeepSummaryRows -RawResult (Invoke-MaestroDeepGatePass -PassLabel "pass1" -TargetNodes $targets)
 
 if ($IdempotentTwice) {
     "`n=== IDEMPOTENCY pass2 $(Get-Date -Format o) ===" | Add-Content $log
-    $summary2Raw = Invoke-MaestroDeepGatePass -PassLabel "pass2" -TargetNodes $targets -SkipPreflight
-    $summary2 = @($summary2Raw | Where-Object { $null -ne $_ -and $null -ne $_.Host })
+    $summary2 = Get-MaestroDeepSummaryRows -RawResult (
+        Invoke-MaestroDeepGatePass -PassLabel "pass2" -TargetNodes $targets -SkipPreflight
+    )
     $idem = Compare-MaestroDeepGateSummaries -Pass1 $summary -Pass2 $summary2
-    "IDEMPOTENCY compare: pass1_rows=$($idem.Pass1Count) pass2_rows=$($idem.Pass2Count)" | Tee-Object -FilePath $log -Append
+    "IDEMPOTENCY compare: pass1_rows=$($idem.Pass1Count) pass2_rows=$($idem.Pass2Count) expected=$expectedGateHosts" | Tee-Object -FilePath $log -Append
+    if ($idem.Pass1Count -ne $expectedGateHosts -or $idem.Pass2Count -ne $expectedGateHosts) {
+        "IDEMPOTENCY: ROW_COUNT_FAIL expected=$expectedGateHosts pass1=$($idem.Pass1Count) pass2=$($idem.Pass2Count)" | Tee-Object -FilePath $log -Append
+        Write-Warning "IDEMPOTENCY: row count guard failed — verifier cannot trust match"
+        exit 1
+    }
     if ($idem.Ok) {
         "IDEMPOTENCY: pass1 and pass2 SUMMARY match" | Tee-Object -FilePath $log -Append
         Write-Host "IDEMPOTENCY: pass1 and pass2 SUMMARY match" -ForegroundColor Green

--- a/scripts/maestro/Maestro-Deep-5Host-Gate.ps1
+++ b/scripts/maestro/Maestro-Deep-5Host-Gate.ps1
@@ -7,6 +7,7 @@
   Sync WorkingTree, gate --apply, handlers -Deep per persona; prints summary with
   Handlers column OK | ALARM:N | FAIL:N (#1021 R9b).
   #1021 R11: -Detach runs under tmux+setsid (avoid nohup orphan); -IdempotentTwice runs two passes.
+  #1021 R12: idempotency compare uses Compare-MaestroDeepGateSummaries (no Format-Table pipeline pollution).
 #>
 param(
     [switch]$Detach,
@@ -42,6 +43,46 @@ $inv = Get-Content $invPath -Raw | ConvertFrom-Json
 $targets = @($inv.lab_members | Where-Object {
         $_.hostname -and ($_.ip -match '^\d+\.\d+\.\d+\.\d+$')
     })
+
+function Compare-MaestroDeepGateSummaries {
+    <#
+    #1021 R12: compare pass1 vs pass2 rows by Host key (no pipeline/Format-Table pollution).
+    #>
+    param(
+        [object[]]$Pass1,
+        [object[]]$Pass2
+    )
+    $rows1 = @($Pass1 | Where-Object { $null -ne $_ -and $null -ne $_.Host })
+    $rows2 = @($Pass2 | Where-Object { $null -ne $_ -and $null -ne $_.Host })
+    $mismatch = [System.Collections.Generic.List[string]]::new()
+    foreach ($row in $rows1) {
+        $key = [string]$row.Host
+        $other = @($rows2 | Where-Object { [string]$_.Host -eq $key } | Select-Object -First 1)
+        if ($other.Count -eq 0) {
+            $mismatch.Add("${key}: missing in pass2")
+            continue
+        }
+        $o = $other[0]
+        $line1 = "$key|$($row.Sync)|$($row.Gate)|$($row.Handlers)"
+        $line2 = "$key|$($o.Sync)|$($o.Gate)|$($o.Handlers)"
+        if ($line1 -ne $line2) {
+            $mismatch.Add("pass1=$line1 pass2=$line2")
+        }
+    }
+    foreach ($row in $rows2) {
+        $key = [string]$row.Host
+        $found = @($rows1 | Where-Object { [string]$_.Host -eq $key })
+        if ($found.Count -eq 0) {
+            $mismatch.Add("${key}: missing in pass1")
+        }
+    }
+    return [pscustomobject]@{
+        Ok       = ($mismatch.Count -eq 0)
+        Mismatch = @($mismatch)
+        Pass1Count = $rows1.Count
+        Pass2Count = $rows2.Count
+    }
+}
 
 function Invoke-MaestroDeepGatePass {
     param(
@@ -126,33 +167,31 @@ function Invoke-MaestroDeepGatePass {
     }
 
     "`n=== SUMMARY $PassLabel $(Get-Date -Format o) ===" | Add-Content $log
-    $passSummary | Format-Table | Out-String | Tee-Object -FilePath $log -Append
-    $passSummary | Format-Table
-    return $passSummary
+    $tableOut = $passSummary | Format-Table | Out-String
+    $tableOut | Tee-Object -FilePath $log -Append | Out-Null
+    Write-Host $tableOut
+    # Return only data rows — never emit Format-Table to the success pipeline (R12).
+    return ,@($passSummary)
 }
 
 Remove-Item $log -ErrorAction SilentlyContinue
-$summary = @(Invoke-MaestroDeepGatePass -PassLabel "pass1" -TargetNodes $targets)
+$summaryRaw = Invoke-MaestroDeepGatePass -PassLabel "pass1" -TargetNodes $targets
+$summary = @($summaryRaw | Where-Object { $null -ne $_ -and $null -ne $_.Host })
 
 if ($IdempotentTwice) {
     "`n=== IDEMPOTENCY pass2 $(Get-Date -Format o) ===" | Add-Content $log
-    $summary2 = @(Invoke-MaestroDeepGatePass -PassLabel "pass2" -TargetNodes $targets -SkipPreflight)
-    $mismatch = @()
-    foreach ($row in @($summary)) {
-        if (-not $row.Host) { continue }
-        $other = @($summary2) | Where-Object { $_.Host -eq $row.Host } | Select-Object -First 1
-        if (-not $other) { $mismatch += "$($row.Host): missing in pass2"; continue }
-        $line = "$($row.Host)|$($row.Sync)|$($row.Gate)|$($row.Handlers)"
-        $line2 = "$($other.Host)|$($other.Sync)|$($other.Gate)|$($other.Handlers)"
-        if ($line -ne $line2) { $mismatch += "pass1=$line pass2=$line2" }
-    }
-    if ($mismatch.Count -eq 0) {
+    $summary2Raw = Invoke-MaestroDeepGatePass -PassLabel "pass2" -TargetNodes $targets -SkipPreflight
+    $summary2 = @($summary2Raw | Where-Object { $null -ne $_ -and $null -ne $_.Host })
+    $idem = Compare-MaestroDeepGateSummaries -Pass1 $summary -Pass2 $summary2
+    "IDEMPOTENCY compare: pass1_rows=$($idem.Pass1Count) pass2_rows=$($idem.Pass2Count)" | Tee-Object -FilePath $log -Append
+    if ($idem.Ok) {
         "IDEMPOTENCY: pass1 and pass2 SUMMARY match" | Tee-Object -FilePath $log -Append
         Write-Host "IDEMPOTENCY: pass1 and pass2 SUMMARY match" -ForegroundColor Green
     } else {
         "IDEMPOTENCY: MISMATCH" | Tee-Object -FilePath $log -Append
-        $mismatch | Tee-Object -FilePath $log -Append
+        $idem.Mismatch | Tee-Object -FilePath $log -Append
         Write-Warning "IDEMPOTENCY: pass1 vs pass2 mismatch — see log"
+        exit 1
     }
 }
 

--- a/scripts/maestro/Maestro.ps1
+++ b/scripts/maestro/Maestro.ps1
@@ -41,6 +41,7 @@ $script:MaestroRunMarker = Get-Date -Format "yyyyMMdd_HHmmss"
 Write-Host "--- [Maestro] Iniciando Turno no Lab-Op (Ref: $Ref, run=$($script:MaestroRunMarker)) ---" -ForegroundColor Cyan
 $warningCount = 0
 $realFailCount = 0
+$handlerAlarmCount = 0
 # Personas that write /tmp/databoar_handler/<persona>_sentinel.txt (#831); web is inline health only.
 $script:SentinelPersonas = @(
     "baremetal", "docker", "podman", "dockerswarm", "lxd", "microk8s",
@@ -132,9 +133,11 @@ $globalReport = foreach ($node in $inventory.lab_members) {
                     BenchHealthUrl = $BenchHealthUrl
                 }
                 & $handler @handlerArgs
-                # Capture real handler failures (#825): offline-skip already gated above;
-                # exit != 0 here means allowlist rejection, SSH send-keys failure, etc.
-                if ($LASTEXITCODE -ne 0) {
+                # #1021 R9b: exit 3 = graceful ALARM; exit != 0 && != 3 = REAL FAIL (#825).
+                if ($LASTEXITCODE -eq 3) {
+                    $handlerAlarmCount++
+                    Write-Warning "      [ALARM] Handler '$persona' em $($node.hostname) exit 3 (graceful degradation)."
+                } elseif ($LASTEXITCODE -ne 0) {
                     $realFailCount++
                     Write-Warning "      [REAL FAIL] Handler '$persona' em $($node.hostname) saiu com exit $LASTEXITCODE"
                 } elseif ($script:SentinelPersonas -contains $persona) {
@@ -215,7 +218,10 @@ if ($Collect -and $warningCount -gt 0) {
 }
 
 # Aggregate REAL handler failures into exit code (#825).
-# Offline-skip and Safe-Hold do NOT increment $realFailCount — only genuine handler errors do.
+# Exit 3 (graceful ALARM) does not increment $realFailCount (#1021 R9b).
+if ($handlerAlarmCount -gt 0) {
+    Write-Warning "[Maestro] $handlerAlarmCount handler(s) ALARM (exit 3, graceful — nao contam como REAL FAIL)."
+}
 if ($realFailCount -gt 0) {
     Write-Error "[Maestro] $realFailCount handler(s) retornaram exit != 0 (falhas reais, nao offline-skip)."
     exit 1

--- a/scripts/maestro/Sync-WorkingTree.ps1
+++ b/scripts/maestro/Sync-WorkingTree.ps1
@@ -19,7 +19,7 @@ param(
 # O StrictMode entra LOGO APÓS os parâmetros
 Set-StrictMode -Version 2
 
-. "$PSScriptRoot/maestro/Maestro-CanonicalGuard.ps1"
+. "$PSScriptRoot/Maestro-CanonicalGuard.ps1"
 $script:MaestroOrchestratorHost = Get-MaestroOrchestratorHostname
 
 # Mapeamento alinhado com o objeto JSON recebido do Maestro

--- a/scripts/maestro/handlers/Handle-target_cifs.ps1
+++ b/scripts/maestro/handlers/Handle-target_cifs.ps1
@@ -43,28 +43,35 @@ $sentinelDir  = "/tmp/databoar_handler"
 $sentinelFile = "$sentinelDir/target_cifs_sentinel.txt"
 
 # --- Phase 1: SMB server-side ensure (service + port + firewall) ---
-$ensureMode = if ($Deep) { "--apply" } else { "--check" }
-$ensureEnv = @{}
-if ($Node.PSObject.Properties["lab_op_subnet"] -and $Node.lab_op_subnet) {
-    $ensureEnv["LAB_OP_SUBNET"] = [string]$Node.lab_op_subnet
-}
-$ensureCmd = Build-EnsureRemoteCommand -EnsureScript $ensureScript -EnsureMode $ensureMode -EnvVars $ensureEnv
-
-Write-Host "      [CIFS-Ensure] Running: $ensureMode on $($Node.hostname)" -ForegroundColor DarkGray
-$ensureOut = ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 `
-    "$($Node.user)@$($Node.hostname)" "$ensureCmd"
-$ensureExit = $LASTEXITCODE
-
-if ($ensureOut) { $ensureOut | ForEach-Object { Write-Host "        $_" -ForegroundColor DarkGray } }
-
-if ($ensureExit -eq 0) {
-    Write-Host "      [SUCCESS] CIFS server-side validated: $($Node.hostname):$($Node.path)" -ForegroundColor Green
-} elseif ($Deep) {
-    Write-Warning "      [REAL FAIL] CIFS ensure --apply returned exit $ensureExit on $($Node.hostname)."
-    Write-RemoteSentinel -Node $Node -SentinelFile $sentinelFile -ExitCode 1
-    exit 1
+# Maestro/orchestrator nodes scan remote CIFS targets; they are not SMB servers (#1021).
+$personaList = @($Node.personas)
+$skipServerEnsure = ($personaList -contains "maestro")
+if ($skipServerEnsure) {
+    Write-Host "      [CIFS-Ensure] Skip server ensure on maestro orchestrator (client-only persona mix)." -ForegroundColor DarkGray
 } else {
-    Write-Warning "      [WARNING] CIFS ensure --check returned exit $ensureExit on $($Node.hostname). Run with -Deep to attempt remediation."
+    $ensureMode = if ($Deep) { "--apply" } else { "--check" }
+    $ensureEnv = @{}
+    if ($Node.PSObject.Properties["lab_op_subnet"] -and $Node.lab_op_subnet) {
+        $ensureEnv["LAB_OP_SUBNET"] = [string]$Node.lab_op_subnet
+    }
+    $ensureCmd = Build-EnsureRemoteCommand -EnsureScript $ensureScript -EnsureMode $ensureMode -EnvVars $ensureEnv
+
+    Write-Host "      [CIFS-Ensure] Running: $ensureMode on $($Node.hostname)" -ForegroundColor DarkGray
+    $ensureOut = ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 `
+        "$($Node.user)@$($Node.hostname)" "$ensureCmd"
+    $ensureExit = $LASTEXITCODE
+
+    if ($ensureOut) { $ensureOut | ForEach-Object { Write-Host "        $_" -ForegroundColor DarkGray } }
+
+    if ($ensureExit -eq 0) {
+        Write-Host "      [SUCCESS] CIFS server-side validated: $($Node.hostname):$($Node.path)" -ForegroundColor Green
+    } elseif ($Deep) {
+        Write-Warning "      [REAL FAIL] CIFS ensure --apply returned exit $ensureExit on $($Node.hostname)."
+        Write-RemoteSentinel -Node $Node -SentinelFile $sentinelFile -ExitCode 1
+        exit 1
+    } else {
+        Write-Warning "      [WARNING] CIFS ensure --check returned exit $ensureExit on $($Node.hostname). Run with -Deep to attempt remediation."
+    }
 }
 
 # --- Phase 2: IO monitoring in tmux ---

--- a/scripts/maestro/handlers/Handle-target_cifs.ps1
+++ b/scripts/maestro/handlers/Handle-target_cifs.ps1
@@ -71,6 +71,7 @@ if ($skipServerEnsure) {
         $alarm = if ($grace) { $grace.Alarm } else { 'cifs_degraded' }
         $hint = if ($grace -and $grace.Hint) { $grace.Hint } else { 'see_ensure_log' }
         Write-Warning "      [ALARM] CIFS ensure graceful on $($Node.hostname): $alarm hint=$hint"
+        exit 3
     } elseif ($Deep) {
         Write-Warning "      [REAL FAIL] CIFS ensure --apply returned exit $ensureExit on $($Node.hostname)."
         Write-RemoteSentinel -Node $Node -SentinelFile $sentinelFile -ExitCode 1

--- a/scripts/maestro/handlers/Handle-target_cifs.ps1
+++ b/scripts/maestro/handlers/Handle-target_cifs.ps1
@@ -18,6 +18,7 @@
  the IO monitor result so Maestro can verify CIFS target readiness.
 
  Privilege (#954/#1021 R8): .labop-gate context + canonical bash for grant-match.
+ Deep apply-fail: exit 3 = graceful ALARM (#1021 R9); exit 1 = REAL FAIL.
 #>
 
 param(
@@ -65,6 +66,11 @@ if ($skipServerEnsure) {
 
     if ($ensureExit -eq 0) {
         Write-Host "      [SUCCESS] CIFS server-side validated: $($Node.hostname):$($Node.path)" -ForegroundColor Green
+    } elseif ($ensureExit -eq 3) {
+        $grace = Get-EnsureAlarmFromOutput -Lines @($ensureOut) -LogTag 'SMB-Ensure'
+        $alarm = if ($grace) { $grace.Alarm } else { 'cifs_degraded' }
+        $hint = if ($grace -and $grace.Hint) { $grace.Hint } else { 'see_ensure_log' }
+        Write-Warning "      [ALARM] CIFS ensure graceful on $($Node.hostname): $alarm hint=$hint"
     } elseif ($Deep) {
         Write-Warning "      [REAL FAIL] CIFS ensure --apply returned exit $ensureExit on $($Node.hostname)."
         Write-RemoteSentinel -Node $Node -SentinelFile $sentinelFile -ExitCode 1

--- a/scripts/maestro/handlers/Handle-target_cifs.ps1
+++ b/scripts/maestro/handlers/Handle-target_cifs.ps1
@@ -17,7 +17,7 @@
  Sentinel (#831): payload writes /tmp/databoar_handler/target_cifs_sentinel.txt with
  the IO monitor result so Maestro can verify CIFS target readiness.
 
- Privilege (#954): doas vs sudo; env VAR=val bash. Deep apply-fail must not mask ready=0.
+ Privilege (#954/#1021 R8): .labop-gate context + canonical bash for grant-match.
 #>
 
 param(

--- a/scripts/maestro/handlers/Handle-target_mariadb.ps1
+++ b/scripts/maestro/handlers/Handle-target_mariadb.ps1
@@ -36,6 +36,9 @@ mkdir -p "$(dirname "$SENTINEL")"
 _rc=0
 trap '_rc=$?; echo $_rc > "$SENTINEL"; exit $_rc' EXIT
 cd __NODE_PATH__/deploy/lab-smoke-stack
+__DB_INIT_STAGE__
+ensure_lab_smoke_init_readable "$PWD/init/mariadb"
+MY_INIT="$(stage_lab_db_init "$PWD/init/mariadb" mariadb)"
 pick_port() {
   local default_port="$1"
   local candidates="$2"
@@ -63,11 +66,23 @@ if command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then
     -e MARIADB_DATABASE="${LAB_MY_DATABASE:-lab_smoke_my}" \
     -e MARIADB_USER="${LAB_MY_USER:-lab_smoke}" \
     -e MARIADB_PASSWORD="${LAB_MY_PASSWORD:-lab_smoke_change_me}" \
-    -v "$PWD/init/mariadb:/docker-entrypoint-initdb.d:ro" \
+    -v "${MY_INIT}:/docker-entrypoint-initdb.d:ro" \
     docker.io/library/mariadb:11 >/dev/null
+  for _w in $(seq 1 90); do
+    if podman inspect -f '{{.State.Status}}' lab-mariadb 2>/dev/null | grep -qx running; then
+      break
+    fi
+    if podman inspect -f '{{.State.Status}}' lab-mariadb 2>/dev/null | grep -qx exited; then
+      echo "TARGET_MARIADB_INIT_FAIL"
+      podman logs --tail 8 lab-mariadb 2>&1 || true
+      exit 1
+    fi
+    sleep 1
+  done
   podman ps --filter name=lab-mariadb --format "{{.Names}} {{.Status}}" || true
 elif command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
   export LAB_MY_PORT="$CHOSEN_PORT"
+  ensure_lab_smoke_init_readable "$PWD/init/mariadb"
   docker compose up -d lab-mariadb >/dev/null
   docker compose ps lab-mariadb || true
 else
@@ -78,7 +93,9 @@ echo "TARGET_MARIADB_READY port=${CHOSEN_PORT} at $(date +'%H:%M:%S')" > ~/.labo
 echo "TARGET_MARIADB_READY port=${CHOSEN_PORT}"
 '@
 $remoteCmd = $remoteCmd.Replace("__SENTINEL__", $sentinelFile)
-$remoteCmd = $remoteCmd.Replace("__NODE_PATH__", [string]$Node.path) -replace "`r", ""
+$remoteCmd = $remoteCmd.Replace("__NODE_PATH__", [string]$Node.path)
+$remoteCmd = $remoteCmd.Replace("__DB_INIT_STAGE__", (Get-LabDbInitStageBash))
+$remoteCmd = $remoteCmd -replace "`r", ""
 
 $out = ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$($Node.user)@$($Node.hostname)" "$remoteCmd"
 if ($LASTEXITCODE -eq 0 -and $out -match "TARGET_MARIADB_READY") {

--- a/scripts/maestro/handlers/Handle-target_mariadb.ps1
+++ b/scripts/maestro/handlers/Handle-target_mariadb.ps1
@@ -83,11 +83,19 @@ $remoteCmd = $remoteCmd.Replace("__NODE_PATH__", [string]$Node.path) -replace "`
 $out = ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$($Node.user)@$($Node.hostname)" "$remoteCmd"
 if ($LASTEXITCODE -eq 0 -and $out -match "TARGET_MARIADB_READY") {
     $portMatch = [regex]::Match(($out -join "`n"), "port=(\d+)")
+    $portNum = if ($portMatch.Success) { [int]$portMatch.Groups[1].Value } else { 0 }
     if ($portMatch.Success) {
-        Write-Host "      [SUCCESS] MariaDB sintetico pronto em $($Node.hostname) (porta $($portMatch.Groups[1].Value))." -ForegroundColor Green
+        Write-Host "      [SUCCESS] MariaDB sintetico pronto em $($Node.hostname) (porta $portNum)." -ForegroundColor Green
     } else {
         Write-Host "      [SUCCESS] MariaDB sintetico pronto em $($Node.hostname)." -ForegroundColor Green
     }
+    $verify = Confirm-TargetDbSyntheticData -Node $Node -Engine mariadb -Port $portNum
+    if (-not $verify.Ok) {
+        Write-Warning "      [REAL FAIL] MariaDB up mas dados sinteticos ausentes: $($verify.Detail)"
+        Write-RemoteSentinel -Node $Node -SentinelFile $sentinelFile -ExitCode 1
+        exit 1
+    }
+    Write-Host "      [VERIFY] lab_customers count=$($verify.Count) (synthetic seed OK)" -ForegroundColor Green
 } else {
     Write-Warning "      [WARNING] Falha ao provisionar target_mariadb em $($Node.hostname)."
     Write-RemoteSentinel -Node $Node -SentinelFile $sentinelFile -ExitCode 1

--- a/scripts/maestro/handlers/Handle-target_mongodb.ps1
+++ b/scripts/maestro/handlers/Handle-target_mongodb.ps1
@@ -79,11 +79,19 @@ $remoteCmd = $remoteCmd.Replace("__NODE_PATH__", [string]$Node.path) -replace "`
 $out = ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$($Node.user)@$($Node.hostname)" "$remoteCmd"
 if ($LASTEXITCODE -eq 0 -and $out -match "TARGET_MONGODB_READY") {
     $portMatch = [regex]::Match(($out -join "`n"), "port=(\d+)")
+    $portNum = if ($portMatch.Success) { [int]$portMatch.Groups[1].Value } else { 0 }
     if ($portMatch.Success) {
-        Write-Host "      [SUCCESS] MongoDB sintetico pronto em $($Node.hostname) (porta $($portMatch.Groups[1].Value))." -ForegroundColor Green
+        Write-Host "      [SUCCESS] MongoDB sintetico pronto em $($Node.hostname) (porta $portNum)." -ForegroundColor Green
     } else {
         Write-Host "      [SUCCESS] MongoDB sintetico pronto em $($Node.hostname)." -ForegroundColor Green
     }
+    $verify = Confirm-TargetDbSyntheticData -Node $Node -Engine mongodb -Port $portNum
+    if (-not $verify.Ok) {
+        Write-Warning "      [REAL FAIL] MongoDB up mas dados sinteticos ausentes: $($verify.Detail)"
+        Write-RemoteSentinel -Node $Node -SentinelFile $sentinelFile -ExitCode 1
+        exit 1
+    }
+    Write-Host "      [VERIFY] lab_people count=$($verify.Count) (synthetic seed OK)" -ForegroundColor Green
 } else {
     Write-Warning "      [WARNING] Falha ao provisionar target_mongodb em $($Node.hostname)."
     Write-RemoteSentinel -Node $Node -SentinelFile $sentinelFile -ExitCode 1

--- a/scripts/maestro/handlers/Handle-target_mongodb.ps1
+++ b/scripts/maestro/handlers/Handle-target_mongodb.ps1
@@ -36,6 +36,9 @@ mkdir -p "$(dirname "$SENTINEL")"
 _rc=0
 trap '_rc=$?; echo $_rc > "$SENTINEL"; exit $_rc' EXIT
 cd __NODE_PATH__/deploy/lab-smoke-stack
+__DB_INIT_STAGE__
+ensure_lab_smoke_init_readable "$PWD/init/mongodb"
+MONGO_INIT="$(stage_lab_db_init "$PWD/init/mongodb" mongodb)"
 pick_port() {
   local default_port="$1"
   local candidates="$2"
@@ -59,11 +62,23 @@ if command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then
   podman rm -f lab-mongodb >/dev/null 2>&1 || true
   podman run -d --name lab-mongodb \
     -p "${CHOSEN_PORT}:27017" \
-    -v "$PWD/init/mongodb:/docker-entrypoint-initdb.d:ro" \
+    -v "${MONGO_INIT}:/docker-entrypoint-initdb.d:ro" \
     docker.io/library/mongo:7 >/dev/null
+  for _w in $(seq 1 90); do
+    if podman inspect -f '{{.State.Status}}' lab-mongodb 2>/dev/null | grep -qx running; then
+      break
+    fi
+    if podman inspect -f '{{.State.Status}}' lab-mongodb 2>/dev/null | grep -qx exited; then
+      echo "TARGET_MONGODB_INIT_FAIL"
+      podman logs --tail 8 lab-mongodb 2>&1 || true
+      exit 1
+    fi
+    sleep 1
+  done
   podman ps --filter name=lab-mongodb --format "{{.Names}} {{.Status}}" || true
 elif command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
   export LAB_MONGO_PORT="$CHOSEN_PORT"
+  ensure_lab_smoke_init_readable "$PWD/init/mongodb"
   docker compose -f docker-compose.mongo.yml up -d lab-mongodb >/dev/null
   docker compose -f docker-compose.mongo.yml ps lab-mongodb || true
 else
@@ -74,7 +89,9 @@ echo "TARGET_MONGODB_READY port=${CHOSEN_PORT} at $(date +'%H:%M:%S')" > ~/.labo
 echo "TARGET_MONGODB_READY port=${CHOSEN_PORT}"
 '@
 $remoteCmd = $remoteCmd.Replace("__SENTINEL__", $sentinelFile)
-$remoteCmd = $remoteCmd.Replace("__NODE_PATH__", [string]$Node.path) -replace "`r", ""
+$remoteCmd = $remoteCmd.Replace("__NODE_PATH__", [string]$Node.path)
+$remoteCmd = $remoteCmd.Replace("__DB_INIT_STAGE__", (Get-LabDbInitStageBash))
+$remoteCmd = $remoteCmd -replace "`r", ""
 
 $out = ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$($Node.user)@$($Node.hostname)" "$remoteCmd"
 if ($LASTEXITCODE -eq 0 -and $out -match "TARGET_MONGODB_READY") {

--- a/scripts/maestro/handlers/Handle-target_nfs.ps1
+++ b/scripts/maestro/handlers/Handle-target_nfs.ps1
@@ -71,6 +71,7 @@ if ($ensureExit -eq 0) {
     $alarm = if ($grace) { $grace.Alarm } else { 'nfs_degraded' }
     $hint = if ($grace -and $grace.Hint) { $grace.Hint } else { 'see_ensure_log' }
     Write-Warning "      [ALARM] NFS ensure graceful on $($Node.hostname): $alarm hint=$hint"
+    exit 3
 } elseif ($Deep) {
     Write-Warning "      [REAL FAIL] NFS ensure --apply returned exit $ensureExit on $($Node.hostname)."
     Write-RemoteSentinel -Node $Node -SentinelFile $sentinelFile -ExitCode 1

--- a/scripts/maestro/handlers/Handle-target_nfs.ps1
+++ b/scripts/maestro/handlers/Handle-target_nfs.ps1
@@ -20,8 +20,8 @@
  Quote/escape safety (#830): IO monitor payload is base64-encoded before tmux injection;
  ensure script path uses canonical repo path from Node.path.
 
- Privilege (#954): doas vs sudo via Build-EnsureRemoteCommand; env VAR=val bash so doas
- does not strip LAB_* (even though ensure auto-detects NFS svc today).
+ Privilege (#954/#1021 R8): Build-EnsureRemoteCommand writes .labop-gate context then
+ $PRIV <canonical-bash> script (no env-prefix on privileged argv).
  Deep (#949 bundle): ensure --apply failure must NOT mask as ready=0.
 #>
 

--- a/scripts/maestro/handlers/Handle-target_nfs.ps1
+++ b/scripts/maestro/handlers/Handle-target_nfs.ps1
@@ -22,7 +22,7 @@
 
  Privilege (#954/#1021 R8): Build-EnsureRemoteCommand writes .labop-gate context then
  $PRIV <canonical-bash> script (no env-prefix on privileged argv).
- Deep (#949 bundle): ensure --apply failure must NOT mask as ready=0.
+ Deep (#949 bundle): ensure --apply hard failure exits non-zero; exit 3 = graceful ALARM (#1021 R9).
 #>
 
 param(
@@ -66,6 +66,11 @@ if ($ensureOut) { $ensureOut | ForEach-Object { Write-Host "        $_" -Foregro
 
 if ($ensureExit -eq 0) {
     Write-Host "      [SUCCESS] NFS server-side validated: $($Node.hostname):$($Node.path)" -ForegroundColor Green
+} elseif ($ensureExit -eq 3) {
+    $grace = Get-EnsureAlarmFromOutput -Lines @($ensureOut) -LogTag 'NFS-Ensure'
+    $alarm = if ($grace) { $grace.Alarm } else { 'nfs_degraded' }
+    $hint = if ($grace -and $grace.Hint) { $grace.Hint } else { 'see_ensure_log' }
+    Write-Warning "      [ALARM] NFS ensure graceful on $($Node.hostname): $alarm hint=$hint"
 } elseif ($Deep) {
     Write-Warning "      [REAL FAIL] NFS ensure --apply returned exit $ensureExit on $($Node.hostname)."
     Write-RemoteSentinel -Node $Node -SentinelFile $sentinelFile -ExitCode 1

--- a/scripts/maestro/handlers/Handle-target_postgres.ps1
+++ b/scripts/maestro/handlers/Handle-target_postgres.ps1
@@ -82,11 +82,19 @@ $remoteCmd = $remoteCmd.Replace("__NODE_PATH__", [string]$Node.path) -replace "`
 $out = ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$($Node.user)@$($Node.hostname)" "$remoteCmd"
 if ($LASTEXITCODE -eq 0 -and $out -match "TARGET_POSTGRES_READY") {
     $portMatch = [regex]::Match(($out -join "`n"), "port=(\d+)")
+    $portNum = if ($portMatch.Success) { [int]$portMatch.Groups[1].Value } else { 0 }
     if ($portMatch.Success) {
-        Write-Host "      [SUCCESS] Postgres sintetico pronto em $($Node.hostname) (porta $($portMatch.Groups[1].Value))." -ForegroundColor Green
+        Write-Host "      [SUCCESS] Postgres sintetico pronto em $($Node.hostname) (porta $portNum)." -ForegroundColor Green
     } else {
         Write-Host "      [SUCCESS] Postgres sintetico pronto em $($Node.hostname)." -ForegroundColor Green
     }
+    $verify = Confirm-TargetDbSyntheticData -Node $Node -Engine postgres -Port $portNum
+    if (-not $verify.Ok) {
+        Write-Warning "      [REAL FAIL] Postgres up mas dados sinteticos ausentes: $($verify.Detail)"
+        Write-RemoteSentinel -Node $Node -SentinelFile $sentinelFile -ExitCode 1
+        exit 1
+    }
+    Write-Host "      [VERIFY] lab_customers count=$($verify.Count) (synthetic seed OK)" -ForegroundColor Green
 } else {
     Write-Warning "      [WARNING] Falha ao provisionar target_postgres em $($Node.hostname)."
     Write-RemoteSentinel -Node $Node -SentinelFile $sentinelFile -ExitCode 1

--- a/scripts/maestro/handlers/Handle-target_postgres.ps1
+++ b/scripts/maestro/handlers/Handle-target_postgres.ps1
@@ -36,6 +36,9 @@ mkdir -p "$(dirname "$SENTINEL")"
 _rc=0
 trap '_rc=$?; echo $_rc > "$SENTINEL"; exit $_rc' EXIT
 cd __NODE_PATH__/deploy/lab-smoke-stack
+__DB_INIT_STAGE__
+ensure_lab_smoke_init_readable "$PWD/init/postgres"
+PG_INIT="$(stage_lab_db_init "$PWD/init/postgres" postgres)"
 pick_port() {
   local default_port="$1"
   local candidates="$2"
@@ -62,11 +65,23 @@ if command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then
     -e POSTGRES_USER="${LAB_PG_USER:-lab_smoke}" \
     -e POSTGRES_PASSWORD="${LAB_PG_PASSWORD:-lab_smoke_change_me}" \
     -e POSTGRES_DB="${LAB_PG_DATABASE:-lab_smoke_pg}" \
-    -v "$PWD/init/postgres:/docker-entrypoint-initdb.d:ro" \
+    -v "${PG_INIT}:/docker-entrypoint-initdb.d:ro" \
     docker.io/library/postgres:16-alpine >/dev/null
+  for _w in $(seq 1 60); do
+    if podman inspect -f '{{.State.Status}}' lab-postgres 2>/dev/null | grep -qx running; then
+      break
+    fi
+    if podman inspect -f '{{.State.Status}}' lab-postgres 2>/dev/null | grep -qx exited; then
+      echo "TARGET_POSTGRES_INIT_FAIL"
+      podman logs --tail 8 lab-postgres 2>&1 || true
+      exit 1
+    fi
+    sleep 1
+  done
   podman ps --filter name=lab-postgres --format "{{.Names}} {{.Status}}" || true
 elif command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
   export LAB_PG_PORT="$CHOSEN_PORT"
+  ensure_lab_smoke_init_readable "$PWD/init/postgres"
   docker compose up -d lab-postgres >/dev/null
   docker compose ps lab-postgres || true
 else
@@ -77,7 +92,9 @@ echo "TARGET_POSTGRES_READY port=${CHOSEN_PORT} at $(date +'%H:%M:%S')" > ~/.lab
 echo "TARGET_POSTGRES_READY port=${CHOSEN_PORT}"
 '@
 $remoteCmd = $remoteCmd.Replace("__SENTINEL__", $sentinelFile)
-$remoteCmd = $remoteCmd.Replace("__NODE_PATH__", [string]$Node.path) -replace "`r", ""
+$remoteCmd = $remoteCmd.Replace("__NODE_PATH__", [string]$Node.path)
+$remoteCmd = $remoteCmd.Replace("__DB_INIT_STAGE__", (Get-LabDbInitStageBash))
+$remoteCmd = $remoteCmd -replace "`r", ""
 
 $out = ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$($Node.user)@$($Node.hostname)" "$remoteCmd"
 if ($LASTEXITCODE -eq 0 -and $out -match "TARGET_POSTGRES_READY") {

--- a/scripts/maestro/handlers/Handle-web.ps1
+++ b/scripts/maestro/handlers/Handle-web.ps1
@@ -52,6 +52,8 @@ if (-not $webHealthPath.StartsWith("/")) { $webHealthPath = "/$webHealthPath" }
 $allowInsecureTls = [bool](Get-NodePropOrDefault -Obj $Node -Name "web_allow_insecure_tls" -DefaultValue $false)
 $retries = [int](Get-NodePropOrDefault -Obj $Node -Name "web_check_retries" -DefaultValue 3)
 $waitSeconds = [int](Get-NodePropOrDefault -Obj $Node -Name "web_check_wait_seconds" -DefaultValue 2)
+$postFallbackRetries = [int](Get-NodePropOrDefault -Obj $Node -Name "web_check_post_fallback_retries" -DefaultValue 6)
+$postFallbackWaitSeconds = [int](Get-NodePropOrDefault -Obj $Node -Name "web_check_post_fallback_wait_seconds" -DefaultValue 3)
 $apiUrl = "${webScheme}://${targetIp}:${webPort}${webHealthPath}"
 $localHealthOk = $false
 $benchTrackNormalized = $BenchTrack.ToLowerInvariant()
@@ -161,9 +163,15 @@ else
   START_CMD="python3 main.py ${CFG_ARG} --web --host 0.0.0.0 --allow-insecure-http --port ${CHOSEN_PORT}"
 fi
 nohup bash -lc "$START_CMD" > ~/.labop-web.log 2>&1 < /dev/null &
-sleep 2
+for _w in 1 2 3 4 5; do
+  sleep 2
+  if curl -fsS --max-time 3 "http://127.0.0.1:${CHOSEN_PORT}__WEB_HEALTH_PATH__" >/dev/null 2>&1; then
+    break
+  fi
+done
 echo "$CHOSEN_PORT"
 '@
+$remoteStartCmd = $remoteStartCmd.Replace("__WEB_HEALTH_PATH__", [string]$webHealthPath)
 $remoteStartCmd = $remoteStartCmd.Replace("__NODE_PATH__", [string]$Node.path)
 $remoteStartCmd = $remoteStartCmd.Replace("__PORTS_JOINED__", [string]$portsJoined)
 $remoteStartCmd = $remoteStartCmd.Replace("__WEB_PORT__", [string]$webPort)
@@ -185,17 +193,27 @@ foreach ($line in $startOut) {
 }
 
 $remoteCurlCmd = "curl -fsS --max-time 5 http://127.0.0.1:$chosenPort$webHealthPath >/dev/null"
-ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$targetUser@$targetHost" "$remoteCurlCmd" > $null 2>&1
+$remoteCurlOk = $false
+for ($curlAttempt = 1; $curlAttempt -le $postFallbackRetries; $curlAttempt++) {
+    ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 "$targetUser@$targetHost" "$remoteCurlCmd" > $null 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        $remoteCurlOk = $true
+        break
+    }
+    if ($curlAttempt -lt $postFallbackRetries) {
+        Write-Warning "      [Web-Recovery] curl localhost ainda falhou (tentativa $curlAttempt/$postFallbackRetries); aguardando ${postFallbackWaitSeconds}s..."
+        Start-Sleep -Seconds $postFallbackWaitSeconds
+    }
+}
 # Ground-truth signal of the recovered process: did the service answer on the chosen
 # port from the host's own loopback? Kept to reconcile against the external HTTP probe.
-$remoteCurlOk = ($LASTEXITCODE -eq 0)
 if (-not $remoteCurlOk) {
-    Write-Warning "      [WARNING] Fallback web iniciou, mas curl remoto localhost falhou em ${targetHost}:$chosenPort$webHealthPath."
+    Write-Warning "      [WARNING] Fallback web iniciou, mas curl remoto localhost falhou em ${targetHost}:$chosenPort$webHealthPath após $postFallbackRetries tentativas."
 }
 
 $webScheme = "http"
 $apiUrl = "http://${targetIp}:${chosenPort}${webHealthPath}"
-for ($attempt = 1; $attempt -le $retries; $attempt++) {
+for ($attempt = 1; $attempt -le $postFallbackRetries; $attempt++) {
     if (Test-HealthUrl -Url $apiUrl -Scheme $webScheme -SkipTls $false) {
         # Reconciliation (#889): an external HTTP 200 is not enough. If the recovered
         # process never answered on the host's own loopback (remoteCurlOk = false), the
@@ -208,8 +226,8 @@ for ($attempt = 1; $attempt -le $retries; $attempt++) {
         Write-Host "      [SUCCESS] Persona Web recuperada! $($Node.hostname) responde HTTP 200 em $apiUrl." -ForegroundColor Green
         return
     }
-    if ($attempt -lt $retries) {
-        Start-Sleep -Seconds $waitSeconds
+    if ($attempt -lt $postFallbackRetries) {
+        Start-Sleep -Seconds $postFallbackWaitSeconds
     }
 }
 

--- a/tests/pester/Maestro-GateReadiness.Tests.ps1
+++ b/tests/pester/Maestro-GateReadiness.Tests.ps1
@@ -1,0 +1,33 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_RepoRoot.ps1')
+}
+
+Describe 'Sync-WorkingTree.ps1 wiring (#1022)' {
+    It 'dots Maestro-CanonicalGuard from PSScriptRoot' {
+        $raw = Get-ScriptRaw 'scripts/maestro/Sync-WorkingTree.ps1'
+        $raw | Should -Match '\$PSScriptRoot/Maestro-CanonicalGuard\.ps1'
+        $raw | Should -Not -Match 'maestro/maestro/Maestro-CanonicalGuard'
+    }
+}
+
+Describe 'Lab-MaestroCommon remote path (#1022)' {
+    It 'expands tilde for SSH gate cd' {
+        $raw = Get-ScriptRaw 'scripts/maestro/Lab-MaestroCommon.ps1'
+        $raw | Should -Match 'function Get-MaestroRemoteRepoPath'
+        $raw | Should -Match '\$HOME'
+        $raw | Should -Match 'cd \$repoPath'
+        $raw | Should -Not -Match "cd '\`$repoPath'"
+    }
+}
+
+Describe 'labop-gate-readiness privilege probe (#1022)' {
+    It 'detects narrow grant without blanket true only' {
+        $raw = Get-ScriptRaw 'scripts/labop-gate-readiness.sh'
+        $raw | Should -Match '_detect_sudo_narrow'
+        $raw | Should -Match '_detect_doas_narrow'
+        $raw | Should -Match 'sudo -n -l'
+        $raw | Should -Match 'doas -C'
+        $raw | Should -Match 'no_narrow_grant'
+        $raw | Should -Match '_FW_GUARD_PROBE_DONE'
+    }
+}

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -919,15 +919,42 @@ def test_handle_web_post_fallback_retry_backoff() -> None:
 
 
 def test_target_nfs_deep_apply_fail_is_real_fail() -> None:
-    """#954/#949 bundle: Deep ensure --apply failure must exit non-zero and write sentinel 1."""
+    """#954/#949: Deep ensure --apply hard failure (exit 1) must exit non-zero; exit 3 = graceful."""
     root = _project_root()
     text = (
         root / "scripts" / "maestro" / "handlers" / "Handle-target_nfs.ps1"
     ).read_text(encoding="utf-8", errors="replace")
     assert "elseif ($Deep)" in text
     assert "[REAL FAIL] NFS ensure --apply" in text
+    assert "elseif ($ensureExit -eq 3)" in text
+    assert "Get-EnsureAlarmFromOutput" in text
     assert "Write-RemoteSentinel" in text
     assert "exit 1" in text
+
+
+def test_nfs_smb_ensure_graceful_alarm_exit_3() -> None:
+    """#1021 R9: ensure scripts emit ALARM markers and exit 3 for known infra gaps."""
+    root = _project_root()
+    nfs = (root / "scripts" / "labop-nfs-server-ensure.sh").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    smb = (root / "scripts" / "labop-smb-server-ensure.sh").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "ALARM=nfs_server_unavailable" in nfs
+    assert "ALARM=nfs_export_unavailable" in nfs
+    assert "exit 3" in nfs
+    assert "ALARM=smbd_start_failed" in smb
+    assert "exit 3" in smb
+
+
+def test_target_cifs_graceful_alarm_on_exit_3() -> None:
+    root = _project_root()
+    text = (
+        root / "scripts" / "maestro" / "handlers" / "Handle-target_cifs.ps1"
+    ).read_text(encoding="utf-8", errors="replace")
+    assert "elseif ($ensureExit -eq 3)" in text
+    assert "Get-EnsureAlarmFromOutput" in text
 
 
 def test_target_cifs_skips_server_ensure_on_maestro_orchestrator() -> None:

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -1072,6 +1072,32 @@ def test_labop_dep_doctor_persona_os_failure_not_swallowed() -> None:
     assert "personas=${PERSONAS_RAW:-<none>}" in text
 
 
+def test_labop_dep_doctor_graceful_optional_modules() -> None:
+    """#1021 R6: min-spec py7zr/lzma degrade with hints; uv probes as operator."""
+    root = _project_root()
+    text = (root / "scripts" / "labop-dep-doctor.sh").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "_uv_run_as_operator" in text
+    assert "_uv_sync_compressed_graceful" in text
+    assert "optional_modules_degraded" in text
+    assert "uv sync --extra compressed" in text
+    assert "7z_UNSUPPORTED" in text
+    assert "scikit-learn" in text
+
+
+def test_labop_gate_readiness_fw_apply_check_fallback() -> None:
+    """#1021 R6: fw-guard --apply 126 falls back to --check or probe cache."""
+    root = _project_root()
+    text = (root / "scripts" / "labop-gate-readiness.sh").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "FW_APPLY_FALLBACK" in text
+    assert "check_only_apply_grant_missing" in text
+    assert "optional_modules_degraded" in text
+    assert "_dep_optional_degraded" in text
+
+
 def test_labop_gate_readiness_narrow_grant_invoke() -> None:
     """#1020: privileged nested calls use .labop-gate context + fixed sudoers args."""
     root = _project_root()

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -1086,14 +1086,16 @@ def test_labop_dep_doctor_graceful_optional_modules() -> None:
     assert "scikit-learn" in text
 
 
-def test_labop_gate_readiness_fw_apply_check_fallback() -> None:
-    """#1021 R6: fw-guard --apply 126 falls back to --check or probe cache."""
+def test_labop_gate_readiness_canonical_bash_bin_for_grants() -> None:
+    """#1021 R6 RCA: prefer /usr/bin/bash over command -v (secure_path /usr/sbin trap)."""
     root = _project_root()
     text = (root / "scripts" / "labop-gate-readiness.sh").read_text(
         encoding="utf-8", errors="replace"
     )
-    assert "FW_APPLY_FALLBACK" in text
-    assert "check_only_apply_grant_missing" in text
+    assert "/usr/bin/bash" in text
+    assert "bash_bin=" in text
+    assert "FW_APPLY_FALLBACK" not in text
+    assert "check_only_apply_grant_missing" not in text
     assert "optional_modules_degraded" in text
     assert "_dep_optional_degraded" in text
 

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -866,19 +866,56 @@ def test_handlers_use_per_persona_tmux_helper() -> None:
 
 
 def test_target_nfs_cifs_use_priv_env_bash_ensure() -> None:
-    """#954: ensure runs as `$PRIV env ... bash` (doas strips caller env without env prefix)."""
+    """#954/#1021 R8: ensure uses .labop-gate context + canonical bash (no env-prefix on priv argv)."""
     root = _project_root()
+    common = (root / "scripts" / "maestro" / "Lab-MaestroCommon.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
     for name in ("Handle-target_nfs.ps1", "Handle-target_cifs.ps1"):
         text = (root / "scripts" / "maestro" / "handlers" / name).read_text(
             encoding="utf-8", errors="replace"
         )
         assert "Build-EnsureRemoteCommand" in text
-        assert "command -v doas" in (
-            root / "scripts" / "maestro" / "Lab-MaestroCommon.ps1"
-        ).read_text(encoding="utf-8", errors="replace")
-        assert "`$PRIV $envPrefix bash" in (
-            root / "scripts" / "maestro" / "Lab-MaestroCommon.ps1"
-        ).read_text(encoding="utf-8", errors="replace")
+    assert "Get-LabCanonicalBashProbe" in common
+    assert ".labop-gate" in common
+    assert "env VAR=val" not in common
+    assert "`$ENSURE_SCRIPT`" in common
+    assert "Get-LabCanonicalBashProbe" in common
+
+
+def test_nfs_smb_ensure_read_labop_gate_context() -> None:
+    """#1021 R8: NFS/SMB ensure reads subnet from .labop-gate before firewall checks."""
+    root = _project_root()
+    for script in ("labop-nfs-server-ensure.sh", "labop-smb-server-ensure.sh"):
+        text = (root / "scripts" / script).read_text(encoding="utf-8", errors="replace")
+        assert ".labop-gate/LAB_OP_SUBNET" in text
+    nfs = (root / "scripts" / "labop-nfs-server-ensure.sh").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "LAB_NFS_SVC" in nfs
+    assert "LAB_PKG_MGR" in nfs
+
+
+def test_maestro_gate_invoke_canonical_bash_no_env_prefix() -> None:
+    """#1021 R8: Invoke-LabopGateReadiness uses .labop-gate + canonical bash, not env bash."""
+    root = _project_root()
+    common = (root / "scripts" / "maestro" / "Lab-MaestroCommon.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "Get-LabCanonicalBashProbe" in common
+    assert ".labop-gate/LAB_OP_SUBNET" in common
+    assert "env LAB_OP_SUBNET" not in common
+
+
+def test_handle_web_post_fallback_retry_backoff() -> None:
+    """#1021 R8: web handler retries localhost curl + external health after fallback start."""
+    root = _project_root()
+    text = (root / "scripts" / "maestro" / "handlers" / "Handle-web.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "web_check_post_fallback_retries" in text
+    assert "postFallbackWaitSeconds" in text
+    assert "for ($curlAttempt = 1" in text
 
 
 def test_target_nfs_deep_apply_fail_is_real_fail() -> None:

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -157,6 +157,7 @@ def test_confirm_target_db_synthetic_data_contract() -> None:
     assert "docker compose exec -T lab-postgres" in common
     assert "docker compose exec -T lab-mariadb" in common
     assert "docker-compose.mongo.yml exec -T lab-mongodb" in common
+    assert '-replace "`r", ""' in common
 
 
 def test_handle_web_health_contract() -> None:

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -1082,12 +1082,14 @@ def test_labop_gate_readiness_narrow_grant_invoke() -> None:
     assert "privilege_denied" in text
     assert 'bash "$DEP_SCRIPT" --check --personas' in text
     assert '_invoke_priv_script "$DEP_SCRIPT" --privileged' in text
-    assert "Plano B" in text or ".labop-gate/PERSONAS" in text
+    assert "Plano B" in text or "Capture exit directly" in text
     assert "authentication required" in text.lower()
     assert "packages_still_missing_after_remediate" in text
     assert "DEP_RECHECK_EC" in text
     assert "rust_toolchain_unavailable" in text
     assert "maturin develop" in text
+    assert "if ! _invoke_priv_script" not in text
+    assert "Capture exit directly" in text
     assert "env LAB_OP_SUBNET" not in text
 
 

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -181,7 +181,7 @@ def test_db_handlers_stage_init_for_podman() -> None:
 
 
 def test_maestro_deep_gate_detach_tmux() -> None:
-    """#1021 R11/R12: re-Deep harness tmux detach + idempotent compare helper."""
+    """#1021 R11/R12/R12.1: re-Deep harness tmux detach + idempotent compare + row guard."""
     root = _project_root()
     text = (root / "scripts" / "maestro" / "Maestro-Deep-5Host-Gate.ps1").read_text(
         encoding="utf-8", errors="replace"
@@ -191,10 +191,16 @@ def test_maestro_deep_gate_detach_tmux() -> None:
     assert "setsid pwsh" in text
     assert "IdempotentTwice" in text
     assert "Compare-MaestroDeepGateSummaries" in text
+    assert "Get-MaestroDeepSummaryRows" in text
     assert "IDEMPOTENCY: pass1 and pass2 SUMMARY match" in text
+    assert "IDEMPOTENCY: ROW_COUNT_FAIL" in text
+    assert "expectedGateHosts" in text
+    assert "return ,@($passSummary)" not in text
+    assert "return @($passSummary)" in text
     assert "Format-Table | Out-String" in text
     assert "pass1_rows=" in text
     assert "exit 1" in text.split("IDEMPOTENCY: MISMATCH")[1][:400]
+    assert "exit 1" in text.split("IDEMPOTENCY: ROW_COUNT_FAIL")[1][:300]
 
 
 def test_handle_web_health_contract() -> None:

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -1172,3 +1172,40 @@ def test_labop_gate_readiness_validates_rfc1918_on_write() -> None:
     assert "labop-rfc1918-cidr-lib.sh" in fw
     assert "is not a private RFC1918 CIDR" in fw
     assert "zero-trust" in fw
+
+
+def test_sync_working_tree_canonical_guard_dot_source() -> None:
+    """#1022: Sync-WorkingTree dots Maestro-CanonicalGuard from PSScriptRoot."""
+    root = _project_root()
+    text = (root / "scripts" / "maestro/Sync-WorkingTree.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "$PSScriptRoot/Maestro-CanonicalGuard.ps1" in text
+    assert "maestro/maestro/Maestro-CanonicalGuard" not in text
+
+
+def test_lab_maestro_common_remote_repo_path_expands_tilde() -> None:
+    """#1022: SSH gate cd uses $HOME instead of literal ~."""
+    root = _project_root()
+    text = (root / "scripts/maestro/Lab-MaestroCommon.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "function Get-MaestroRemoteRepoPath" in text
+    assert "`$HOME" in text
+    assert "cd $repoPath" in text
+    assert "cd '$repoPath'" not in text
+
+
+def test_labop_gate_readiness_narrow_privilege_probe() -> None:
+    """#1022: privilege probe detects narrow grants (not only sudo -n true)."""
+    root = _project_root()
+    text = (root / "scripts" / "labop-gate-readiness.sh").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "_detect_sudo_narrow" in text
+    assert "_detect_doas_narrow" in text
+    assert "sudo -n -l" in text
+    assert "doas -C" in text
+    assert "no_narrow_grant" in text
+    assert "_FW_GUARD_PROBE_DONE" in text
+    assert "no doas/sudo -n" not in text

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -137,6 +137,26 @@ def test_db_target_handlers_use_compose_contract() -> None:
             f"DB handler must write {persona}_sentinel.txt (#953)"
         )
         assert "__SENTINEL__" in text or "SENTINEL=" in text
+        assert "Confirm-TargetDbSyntheticData" in text
+        assert "[VERIFY]" in text
+        assert "[REAL FAIL]" in text
+
+
+def test_confirm_target_db_synthetic_data_contract() -> None:
+    """#1021 R9c: post-READY oracle via count(*) / countDocuments on lab smoke seeds."""
+    root = _project_root()
+    common = (root / "scripts" / "maestro" / "Lab-MaestroCommon.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "function Confirm-TargetDbSyntheticData" in common
+    assert "SYNTHETIC_DATA_OK" in common
+    assert "SYNTHETIC_DATA_FAIL" in common
+    assert "lab_customers" in common
+    assert "lab_people" in common
+    assert "lab_smoke_mongo" in common
+    assert "docker compose exec -T lab-postgres" in common
+    assert "docker compose exec -T lab-mariadb" in common
+    assert "docker-compose.mongo.yml exec -T lab-mongodb" in common
 
 
 def test_handle_web_health_contract() -> None:

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -1081,9 +1081,12 @@ def test_labop_gate_readiness_narrow_grant_invoke() -> None:
     assert "_invoke_priv_script" in text
     assert "privilege_denied" in text
     assert 'bash "$DEP_SCRIPT" --check --personas' in text
-    assert "--privileged --personas" in text
+    assert '_invoke_priv_script "$DEP_SCRIPT" --privileged' in text
+    assert "Plano B" in text or ".labop-gate/PERSONAS" in text
+    assert "authentication required" in text.lower()
     assert "packages_still_missing_after_remediate" in text
     assert "DEP_RECHECK_EC" in text
+    assert "rust_toolchain_unavailable" in text
     assert "maturin develop" in text
     assert "env LAB_OP_SUBNET" not in text
 

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -1100,6 +1100,28 @@ def test_labop_gate_readiness_canonical_bash_bin_for_grants() -> None:
     assert "_dep_optional_degraded" in text
 
 
+def test_labop_gate_readiness_graceful_rust_accelerator() -> None:
+    """#1021 R7: baremetal rust-wheel/maturin degrade without FAIL=1 (MiM 17:42)."""
+    root = _project_root()
+    text = (root / "scripts" / "labop-gate-readiness.sh").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "_emit_rust_accel_hints" in text
+    assert "RUST_ACCEL_UNSUPPORTED" in text
+    assert "pure_python_fallback" in text
+    assert "optional_accelerator_missing" in text
+    assert "maturin develop" in text
+    assert (
+        "boar_fast_filter_missing_in_venv" not in text or "pure_python_fallback" in text
+    )
+    # rust-wheel ALARM paths must not set FAIL=1 (uv still required)
+    assert 'rust-wheel ALARM "boar_fast_filter_missing_in_venv"' not in text
+    assert (
+        "FAIL=1"
+        not in text.split("optional_accelerator_missing")[1].split("# --- fail2ban")[0]
+    )
+
+
 def test_labop_gate_readiness_narrow_grant_invoke() -> None:
     """#1020: privileged nested calls use .labop-gate context + fixed sudoers args."""
     root = _project_root()

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -927,6 +927,7 @@ def test_target_nfs_deep_apply_fail_is_real_fail() -> None:
     assert "elseif ($Deep)" in text
     assert "[REAL FAIL] NFS ensure --apply" in text
     assert "elseif ($ensureExit -eq 3)" in text
+    assert "exit 3" in text
     assert "Get-EnsureAlarmFromOutput" in text
     assert "Write-RemoteSentinel" in text
     assert "exit 1" in text
@@ -954,7 +955,29 @@ def test_target_cifs_graceful_alarm_on_exit_3() -> None:
         root / "scripts" / "maestro" / "handlers" / "Handle-target_cifs.ps1"
     ).read_text(encoding="utf-8", errors="replace")
     assert "elseif ($ensureExit -eq 3)" in text
+    assert "exit 3" in text
     assert "Get-EnsureAlarmFromOutput" in text
+
+
+def test_maestro_handler_exit_3_alarm_tally() -> None:
+    """#1021 R9b: exit 3 = ALARM tally; exit 1 = REAL FAIL; summary ALARM:N."""
+    root = _project_root()
+    common = (root / "scripts" / "maestro" / "Lab-MaestroCommon.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    maestro = (root / "scripts" / "maestro" / "Maestro.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    deep = (root / "scripts" / "maestro" / "Maestro-Deep-5Host-Gate.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "Add-MaestroHandlerExitTally" in common
+    assert "Format-MaestroHandlersSummary" in common
+    assert 'return "ALARM:$HandlerAlarms"' in common
+    assert "$handlerAlarmCount" in maestro
+    assert "$LASTEXITCODE -eq 3" in maestro
+    assert "Add-MaestroHandlerExitTally" in deep
+    assert "Format-MaestroHandlersSummary" in deep
 
 
 def test_target_cifs_skips_server_ensure_on_maestro_orchestrator() -> None:

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -1050,6 +1050,8 @@ def test_labop_dep_doctor_persona_packages() -> None:
     assert "nfs-utils" in text
     assert "samba" in text
     assert "procps" in text
+    assert "procps-ng" in text
+    assert "_pkg_logical_to_pm" in text
     assert "iproute2" in text
     assert "apk" in text
     assert 'xbps-query "$pkg"' in text
@@ -1090,6 +1092,10 @@ def test_labop_gate_readiness_narrow_grant_invoke() -> None:
     assert "maturin develop" in text
     assert "if ! _invoke_priv_script" not in text
     assert "Capture exit directly" in text
+    assert "_resolve_bash_bin" in text
+    assert "LABOP_BASH_BIN" in text
+    assert '"$LABOP_BASH_BIN"' in text
+    assert "maestro_orchestrator_skip" in text
     assert "env LAB_OP_SUBNET" not in text
 
 

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -679,6 +679,12 @@ def test_build_container_artefact_degrades_without_hub() -> None:
         "Build-ContainerArtefact must exit with an actionable code when no engine and "
         "no local artefact exist (#888)."
     )
+    assert "podman info --format '{{.Host.OS}}'" in text, (
+        "Podman engine probe must not use Docker-only .ServerVersion template (#1021)."
+    )
+    assert re.search(r"\$null\s*=\s*&\s*podman build -q", text), (
+        "Quiet podman build must not leak image id into function return (#1021)."
+    )
 
 
 def test_sync_container_artefact_scp_fallback_is_actionable() -> None:
@@ -887,6 +893,16 @@ def test_target_nfs_deep_apply_fail_is_real_fail() -> None:
     assert "exit 1" in text
 
 
+def test_target_cifs_skips_server_ensure_on_maestro_orchestrator() -> None:
+    """#1021: maestro orchestrator is CIFS client-only; no LABOP_SMB_SERVER grant needed."""
+    root = _project_root()
+    text = (
+        root / "scripts" / "maestro" / "handlers" / "Handle-target_cifs.ps1"
+    ).read_text(encoding="utf-8", errors="replace")
+    assert "maestro" in text
+    assert "Skip server ensure on maestro orchestrator" in text
+
+
 def test_collect_artifacts_uses_repo_log_path() -> None:
     """#956/#968: post-flight collect pulls from <repo>/log/; Join-Path; REAL FAIL if empty."""
     root = _project_root()
@@ -1050,6 +1066,8 @@ def test_labop_dep_doctor_persona_os_failure_not_swallowed() -> None:
     assert "Persona OS packages still missing" in text
     assert "still missing after phase" in text
     assert "no package manager (ALARM)" in text
+    assert "_load_personas_from_gate_context" in text
+    assert "personas=${PERSONAS_RAW:-<none>}" in text
 
 
 def test_labop_gate_readiness_narrow_grant_invoke() -> None:
@@ -1063,6 +1081,10 @@ def test_labop_gate_readiness_narrow_grant_invoke() -> None:
     assert "_invoke_priv_script" in text
     assert "privilege_denied" in text
     assert 'bash "$DEP_SCRIPT" --check --personas' in text
+    assert "--privileged --personas" in text
+    assert "packages_still_missing_after_remediate" in text
+    assert "DEP_RECHECK_EC" in text
+    assert "maturin develop" in text
     assert "env LAB_OP_SUBNET" not in text
 
 
@@ -1116,14 +1138,24 @@ def _run_fw_guard_subnet_check(
 ) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env["LAB_OP_SUBNET"] = subnet
-    return subprocess.run(
-        ["bash", str(root / "scripts" / "labop-fw-guard-ensure.sh"), "--check"],
-        cwd=root,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    gate_file = root / ".labop-gate" / "LAB_OP_SUBNET"
+    gate_backup: str | None = None
+    if gate_file.is_file():
+        gate_backup = gate_file.read_text(encoding="utf-8", errors="replace")
+        gate_file.unlink()
+    try:
+        return subprocess.run(
+            ["bash", str(root / "scripts" / "labop-fw-guard-ensure.sh"), "--check"],
+            cwd=root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    finally:
+        if gate_backup is not None:
+            gate_file.parent.mkdir(parents=True, exist_ok=True)
+            gate_file.write_text(gate_backup, encoding="utf-8")
 
 
 def test_labop_fw_guard_rfc1918_subnet_accepts_private_cidr() -> None:
@@ -1142,14 +1174,28 @@ def test_labop_fw_guard_rfc1918_subnet_rejects_non_private() -> None:
     root = _project_root()
     for subnet in ("0.0.0.0/0", "1.2.3.0/24", "192.168.40.0/0", "not-a-cidr", ""):
         if subnet == "":
-            proc = subprocess.run(
-                ["bash", str(root / "scripts" / "labop-fw-guard-ensure.sh"), "--check"],
-                cwd=root,
-                env={k: v for k, v in os.environ.items() if k != "LAB_OP_SUBNET"},
-                capture_output=True,
-                text=True,
-                check=False,
-            )
+            gate_file = root / ".labop-gate" / "LAB_OP_SUBNET"
+            gate_backup: str | None = None
+            if gate_file.is_file():
+                gate_backup = gate_file.read_text(encoding="utf-8", errors="replace")
+                gate_file.unlink()
+            try:
+                proc = subprocess.run(
+                    [
+                        "bash",
+                        str(root / "scripts" / "labop-fw-guard-ensure.sh"),
+                        "--check",
+                    ],
+                    cwd=root,
+                    env={k: v for k, v in os.environ.items() if k != "LAB_OP_SUBNET"},
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+            finally:
+                if gate_backup is not None:
+                    gate_file.parent.mkdir(parents=True, exist_ok=True)
+                    gate_file.write_text(gate_backup, encoding="utf-8")
         else:
             proc = _run_fw_guard_subnet_check(root, subnet)
         assert proc.returncode == 2, (

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -143,14 +143,18 @@ def test_db_target_handlers_use_compose_contract() -> None:
 
 
 def test_confirm_target_db_synthetic_data_contract() -> None:
-    """#1021 R9c: post-READY oracle via count(*) / countDocuments on lab smoke seeds."""
+    """#1021 R9c/R11: post-READY oracle; R11 splits seed_empty vs confirm_unreachable."""
     root = _project_root()
     common = (root / "scripts" / "maestro" / "Lab-MaestroCommon.ps1").read_text(
         encoding="utf-8", errors="replace"
     )
     assert "function Confirm-TargetDbSyntheticData" in common
+    assert "function Get-LabDbInitStageBash" in common
+    assert "stage_lab_db_init" in common
+    assert "chmod -R a+rX" in common
     assert "SYNTHETIC_DATA_OK" in common
-    assert "SYNTHETIC_DATA_FAIL" in common
+    assert "reason=seed_empty" in common
+    assert "reason=confirm_unreachable" in common
     assert "lab_customers" in common
     assert "lab_people" in common
     assert "lab_smoke_mongo" in common
@@ -158,6 +162,35 @@ def test_confirm_target_db_synthetic_data_contract() -> None:
     assert "docker compose exec -T lab-mariadb" in common
     assert "docker-compose.mongo.yml exec -T lab-mongodb" in common
     assert '-replace "`r", ""' in common
+
+
+def test_db_handlers_stage_init_for_podman() -> None:
+    """#1021 R11: podman bind-mount uses staged a+rX init, not 660 repo files."""
+    root = _project_root()
+    for name, token in (
+        ("Handle-target_postgres.ps1", "PG_INIT"),
+        ("Handle-target_mariadb.ps1", "MY_INIT"),
+        ("Handle-target_mongodb.ps1", "MONGO_INIT"),
+    ):
+        text = (root / "scripts" / "maestro" / "handlers" / name).read_text(
+            encoding="utf-8", errors="replace"
+        )
+        assert "__DB_INIT_STAGE__" in text or "stage_lab_db_init" in text
+        assert token in text
+        assert "TARGET_" in text and "_INIT_FAIL" in text
+
+
+def test_maestro_deep_gate_detach_tmux() -> None:
+    """#1021 R11: re-Deep harness supports tmux+setsid detach and idempotent pass."""
+    root = _project_root()
+    text = (root / "scripts" / "maestro" / "Maestro-Deep-5Host-Gate.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "[switch]`$Detach" in text or "[switch]$Detach" in text
+    assert "tmux new-session" in text
+    assert "setsid pwsh" in text
+    assert "IdempotentTwice" in text
+    assert "IDEMPOTENCY" in text
 
 
 def test_handle_web_health_contract() -> None:

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -181,16 +181,20 @@ def test_db_handlers_stage_init_for_podman() -> None:
 
 
 def test_maestro_deep_gate_detach_tmux() -> None:
-    """#1021 R11: re-Deep harness supports tmux+setsid detach and idempotent pass."""
+    """#1021 R11/R12: re-Deep harness tmux detach + idempotent compare helper."""
     root = _project_root()
     text = (root / "scripts" / "maestro" / "Maestro-Deep-5Host-Gate.ps1").read_text(
         encoding="utf-8", errors="replace"
     )
-    assert "[switch]`$Detach" in text or "[switch]$Detach" in text
+    assert "[switch]$Detach" in text or "[switch]`$Detach" in text
     assert "tmux new-session" in text
     assert "setsid pwsh" in text
     assert "IdempotentTwice" in text
-    assert "IDEMPOTENCY" in text
+    assert "Compare-MaestroDeepGateSummaries" in text
+    assert "IDEMPOTENCY: pass1 and pass2 SUMMARY match" in text
+    assert "Format-Table | Out-String" in text
+    assert "pass1_rows=" in text
+    assert "exit 1" in text.split("IDEMPOTENCY: MISMATCH")[1][:400]
 
 
 def test_handle_web_health_contract() -> None:

--- a/tests/test_pester_harness.py
+++ b/tests/test_pester_harness.py
@@ -34,6 +34,7 @@ def test_pester_tranche1_files_exist() -> None:
         "Audit.Tests.ps1",
         "CheckAll.Tests.ps1",
         "InvAdr.Tests.ps1",
+        "Maestro-GateReadiness.Tests.ps1",
         "Wrappers.Tranche1.Tests.ps1",
     )
     for name in expected:


### PR DESCRIPTION
## Summary

Bundles smoke-surfaced FASE 2 wiring fixes from [#1021](https://github.com/FabioLeitao/data-boar/issues/1021) async bus (Auditor ACK):

- **Sync-WorkingTree.ps1:** dot-source `Maestro-CanonicalGuard.ps1` from `$PSScriptRoot` (was broken `maestro/maestro/` path).
- **Lab-MaestroCommon.ps1:** `Get-MaestroRemoteRepoPath` expands `~` → `$HOME` for SSH gate `cd`.
- **labop-gate-readiness.sh:** privilege probe detects **narrow grants** (`sudo -l`, `doas -C` + `/etc/doas.d/*.conf`, empirical `fw-guard --check`) instead of only `sudo/doas -n true` (blanket). Reuses fw-guard probe cache in fail2ban `--check` path.

## Test plan

- [x] `./scripts/check-all.sh` green (pytest + pre-commit + Pester)
- [x] New pytest contracts (`test_maestro_scripts.py` #1022)
- [x] New `tests/pester/Maestro-GateReadiness.Tests.ps1`

## Out of scope (per #1021)

- No version bump (marco #1023/#1024 later)
- Does not close #406
- Operator grants per-host + re-smoke + `-Deep` after merge

Part of #1021.

Made with [Cursor](https://cursor.com)