### PR TITLE
chore(docker): daemonless Linux build — appuser perms + log/ context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@ docs/stacked_private_repo/
 *.txt
 !requirements.txt
 *.log
+log/
 
 # --- Contexto enxuto (sem isto, COPY . . herda .venv/tests e dispara tamanho ~GB) ---
 scripts/pii_history_guard.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,17 +65,17 @@ RUN pip uninstall -y wheel || true && \
     pip install --no-cache-dir --force-reinstall "wheel>=0.46.2" && \
     python -c "import wheel; import sys; sys.exit(0 if tuple(map(int, wheel.__version__.split('.'))) >= (0,46,2) else 1)"
 
-# Copy application code
-COPY . .
+# Copy application code (daemonless Linux: host umask 007 can leave 660 root:root)
+RUN useradd -r -u 1000 -d /data appuser && \
+    mkdir -p /data && chown -R appuser:appuser /data
+
+COPY --chown=appuser:appuser . .
 
 ENV CONFIG_PATH=/data/config.yaml
 ENV PYTHONUNBUFFERED=1
 # Docker image default: expose web API on all interfaces inside the container
 # so published ports work from outside Docker Desktop/WSL host.
 ENV API_HOST=0.0.0.0
-
-RUN useradd -r -u 1000 -d /data appuser && \
-    mkdir -p /data && chown -R appuser:appuser /data
 
 USER appuser
 


### PR DESCRIPTION
## Summary

Fixes two Docker build issues found on **podman/T14** (daemonless Linux) during the first **1.7.4 GA** image build — not caught on Windows Docker Desktop.

1. **Runtime `COPY` permissions:** `COPY . .` inherited host umask `007` → `660 root:root`; `appuser` could not read `/app/main.py`. Now `useradd` runs before app copy; `COPY --chown=appuser:appuser . .`.
2. **Build context bloat:** root-only `*.log` in `.dockerignore` did not exclude `log/*.log` from completão monitors. Added `log/`.

**No version bump** — stays **1.7.4**.

## Commits

- `chore(docker): COPY --chown=appuser:appuser so non-root appuser can read /app (daemonless Linux build)`
- `chore(docker): exclude log/ from build context (stray lab-monitor logs)`

## Test plan

- [x] `./scripts/check-all.sh` green locally
- [ ] Operator: `podman build` on T14 + `podman run --rm … python main.py --version`

## Scope

Dockerfile + `.dockerignore` only. No pyproject, app code, or release docs.

Made with [Cursor](https://cursor.com)