### PR TITLE
docs(man): make data-boar the canonical man page name

### DIFF
--- a/api/locales/en.json
+++ b/api/locales/en.json
@@ -172,7 +172,7 @@
     "run_web_shot_caption": "Dashboard — optional tenant/technician fields and Start scan (no shell required).",
     "run_auto_h3": "For automation / scripting",
     "run_cli_h3": "From the CLI",
-    "run_cli_p1": "From the repo root, prefer uv run python main.py (or activate your venv and run python main.py). Full flag list: python main.py --help. Packaged installs: man 1 data_boar (command) and man 5 data_boar (config file format).",
+    "run_cli_p1": "From the repo root, prefer uv run python main.py (or activate your venv and run python main.py). Full flag list: python main.py --help. Packaged installs: man 1 data-boar (command) and man 5 data-boar (config file format).",
     "run_cli_oneshot": "One-shot audit (same targets as a dashboard scan):",
     "run_cli_api": "Start the API / dashBOARd (no scan until you use the browser or HTTP):",
     "run_cli_tls": "You must either terminate TLS at the process (--https-cert-file + --https-key-file, or the same under api: in config) or explicitly accept plaintext with --allow-insecure-http (or api.allow_insecure_http: true). The official Docker image passes --allow-insecure-http by default; mount certs and remove it for HTTPS.",

--- a/api/locales/pt-BR.json
+++ b/api/locales/pt-BR.json
@@ -172,7 +172,7 @@
     "run_web_shot_caption": "Painel — campos opcionais de cliente/técnico e Iniciar varredura (sem shell).",
     "run_auto_h3": "Para automação / scripting",
     "run_cli_h3": "Pela CLI",
-    "run_cli_p1": "Na raiz do repositório, prefira uv run python main.py (ou ative o venv e execute python main.py). Lista completa de flags: python main.py --help. Instalações empacotadas: man 1 data_boar (comando) e man 5 data_boar (formato do arquivo de configuração).",
+    "run_cli_p1": "Na raiz do repositório, prefira uv run python main.py (ou ative o venv e execute python main.py). Lista completa de flags: python main.py --help. Instalações empacotadas: man 1 data-boar (comando) e man 5 data-boar (formato do arquivo de configuração).",
     "run_cli_oneshot": "Auditoria pontual (mesmos alvos que uma varredura pelo painel):",
     "run_cli_api": "Subir a API / dashBOARd (sem varredura até usar o navegador ou HTTP):",
     "run_cli_tls": "É preciso terminar TLS no processo (--https-cert-file + --https-key-file, ou o mesmo em api: na config) ou aceitar explicitamente texto claro com --allow-insecure-http (ou api.allow_insecure_http: true). A imagem Docker oficial passa --allow-insecure-http por padrão; monte certificados e remova para HTTPS.",

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -124,7 +124,9 @@ When you bump the version, update **all** of the following so the number is cons
 | Location               | What to change                                                                                                  |
 | ---                    | ---                                                                                                             |
 | **`docs/data_boar.1`** | In the `.TH` line (e.g. `"Data Boar 1.5.4"`), set the version to the new one.                                   |
-| **`docs/data_boar.5`** | Same: update the version in the `.TH` line. (Legacy: `lgpd_crawler` is a compatibility symlink to these pages.) |
+| **`docs/data_boar.5`** | Same: update the version in the `.TH` line.                                                                     |
+
+**Command vs man page names:** The packaged CLI is **`data-boar`** (hyphen). The primary installed man pages are **`data-boar`** (sections 1 and 5). Source files remain **`docs/data_boar.{1,5}`** in the repository; install copies them as `data-boar.{1,5}` with optional symlinks **`data_boar`** and **`lgpd_crawler`** (legacy aliases). See the **INSTALLATION OF THIS MAN PAGE** section in `docs/data_boar.1`.
 
 ### 4. Deploy and Docker
 

--- a/docs/VERSIONING.pt_BR.md
+++ b/docs/VERSIONING.pt_BR.md
@@ -124,7 +124,9 @@ Ao dar bump na versão, atualize **todos** os itens abaixo para manter o número
 | Local                  | O que alterar                                                                                  |
 | ---                    | ---                                                                                            |
 | **`docs/data_boar.1`** | Na linha `.TH` (ex.: `"Data Boar 1.5.4"`), defina a versão para a nova.                        |
-| **`docs/data_boar.5`** | Idem: atualize a versão na linha `.TH`. (Legado: `lgpd_crawler` é symlink de compatibilidade.) |
+| **`docs/data_boar.5`** | Idem: atualize a versão na linha `.TH`.                                                         |
+
+**Comando vs nome da man:** O CLI empacotado é **`data-boar`** (hífen). As man pages primárias instaladas são **`data-boar`** (seções 1 e 5). Os arquivos-fonte no repositório continuam **`docs/data_boar.{1,5}`**; na instalação copie como `data-boar.{1,5}` com symlinks opcionais **`data_boar`** e **`lgpd_crawler`** (aliases legados). Veja a seção **INSTALLATION OF THIS MAN PAGE** em `docs/data_boar.1`.
 
 ### 4. Deploy e Docker
 

--- a/docs/data_boar.1
+++ b/docs/data_boar.1
@@ -1,11 +1,11 @@
 .\" data_boar.1 - man page for Data Boar (application; PyPI distribution: data-boar)
-.\" View as: man data_boar or man lgpd_crawler (symlink for compatibility)
-.TH DATA_BOAR 1 "May 2026" "Data Boar 1.7.4" "User Commands"
+.\" View as: man data-boar (primary), man data_boar or man lgpd_crawler (symlink aliases)
+.TH DATA-BOAR 1 "May 2026" "Data Boar 1.7.4" "User Commands"
 .SH NAME
-data_boar, lgpd_crawler \- enterprise data discovery and risk governance (Data Boar)
+data-boar, data_boar, lgpd_crawler \- enterprise data discovery and risk governance (Data Boar)
 .
 .SH SYNOPSIS
-.B data_boar
+.B data-boar
 [
 .B \-\-config
 .I FILE
@@ -341,8 +341,10 @@ and
 fields (the CLI only logs warnings and exit codes remain unchanged). See
 .I docs/USAGE.md
 and
-.I data_boar (5)
+.I data-boar (5)
 (or
+.I data_boar (5)
+or
 .I lgpd_crawler (5))
 for full configuration examples.
 .IP \(bu 2
@@ -736,40 +738,73 @@ curl \-X POST http://localhost:8088/scan \\
 .RE
 .
 .SH INSTALLATION OF THIS MAN PAGE
-To install this man page system\-wide on a typical Linux or BSD system, ensure the target directories exist, copy both section 1 and 5 pages, create symlinks so that both
-.B data_boar
+Install the troff sources from this repository as
+.BR data-boar (1)
 and
-.B lgpd_crawler
-work, then update the man index:
+.BR data-boar (5)
+(the installed filenames use a hyphen, matching the packaged CLI
+.BR data-boar ).
+Create optional symlinks so
+.BR data_boar
+and
+.BR lgpd_crawler
+also resolve (legacy aliases).
 .PP
+Two common routes:
+.TP
+.B System\-wide
+(with
+.BR sudo ;
+typical Linux or BSD)
 .RS
 .nf
 sudo mkdir \-p /usr/local/share/man/man1/ /usr/local/share/man/man5/
 sudo chmod 755 /usr/local/share/man/man1/ /usr/local/share/man/man5/
-sudo cp docs/data_boar.1 /usr/local/share/man/man1/
-sudo cp docs/data_boar.5 /usr/local/share/man/man5/
-sudo chmod 644 /usr/local/share/man/man1/data_boar.1 /usr/local/share/man/man5/data_boar.5
-sudo ln \-sf data_boar.1 /usr/local/share/man/man1/lgpd_crawler.1
-sudo ln \-sf data_boar.5 /usr/local/share/man/man5/lgpd_crawler.5
+sudo cp docs/data_boar.1 /usr/local/share/man/man1/data-boar.1
+sudo cp docs/data_boar.5 /usr/local/share/man/man5/data-boar.5
+sudo chmod 644 /usr/local/share/man/man1/data-boar.1 \\
+    /usr/local/share/man/man5/data-boar.5
+sudo ln \-sf data-boar.1 /usr/local/share/man/man1/data_boar.1
+sudo ln \-sf data-boar.1 /usr/local/share/man/man1/lgpd_crawler.1
+sudo ln \-sf data-boar.5 /usr/local/share/man/man5/data_boar.5
+sudo ln \-sf data-boar.5 /usr/local/share/man/man5/lgpd_crawler.5
 sudo mandb
 .fi
 .RE
+.TP
+.B User\-local
+(no
+.BR sudo ;
+writes under your home directory; default
+.BR manpath
+on many distributions already includes
+.IR ~/.local/share/man )
+.RS
+.nf
+mkdir \-p ~/.local/share/man/man1 ~/.local/share/man/man5
+cp docs/data_boar.1 ~/.local/share/man/man1/data-boar.1
+cp docs/data_boar.5 ~/.local/share/man/man5/data-boar.5
+chmod 644 ~/.local/share/man/man1/data-boar.1 \\
+    ~/.local/share/man/man5/data-boar.5
+ln \-sf data-boar.1 ~/.local/share/man/man1/data_boar.1
+ln \-sf data-boar.1 ~/.local/share/man/man1/lgpd_crawler.1
+ln \-sf data-boar.5 ~/.local/share/man/man5/data_boar.5
+ln \-sf data-boar.5 ~/.local/share/man/man5/lgpd_crawler.5
+mandb \-u
+.fi
+.RE
 .PP
-After installation,
-.B "man data_boar"
+Source paths remain
+.I docs/data_boar.1
 and
-.B "man 5 data_boar"
-work; the optional symlinks make
-.B "man lgpd_crawler"
-and
-.B "man 5 lgpd_crawler"
-show the same pages (legacy command alias).
+.I docs/data_boar.5
+in the repository; only the installed primary names use the hyphen.
 .PP
 The
 .B chmod 755
-on the directories ensures all users can traverse them (new directories may be 750 with a restrictive umask). The
+on system directories ensures all users can traverse them (new directories may be 750 with a restrictive umask). The
 .B chmod 644
-on the files ensures all users can read the pages (the copies might otherwise be 640).
+on the installed pages ensures all users can read them.
 .PP
 On some BSD systems use
 .B "sudo makewhatis"
@@ -781,12 +816,16 @@ creates it so that
 .B "sudo cp"
 does not fail with "No such file or directory".
 .PP
-After installation, view the page with:
+After installation, view the pages with:
 .RS
-.B man data_boar
+.B "man data-boar"
+or the alias
+.B "man data_boar"
 or
-.B man lgpd_crawler
+.B "man lgpd_crawler"
 (section 1), and
+.B "man 5 data-boar"
+or
 .B "man 5 data_boar"
 or
 .B "man 5 lgpd_crawler"
@@ -803,12 +842,15 @@ describes
 .I configuration and file formats
 (config file topology, regex/ML/DL pattern files, examples).
 View it with
+.BR "man 5 data-boar"
+or
 .BR "man 5 data_boar"
 or
 .BR "man 5 lgpd_crawler" .
 On Unix/Linux/BSD, section 1 is for programs and commands; section 5 is for file formats and conventions.
 .
 .SH SEE ALSO
+.BR data-boar (5),
 .BR data_boar (5),
 .BR lgpd_crawler (5)
 (configuration and pattern file formats),

--- a/docs/data_boar.5
+++ b/docs/data_boar.5
@@ -1,8 +1,8 @@
 .\" data_boar.5 - file formats and configuration for Data Boar (PyPI distribution: data-boar)
-.\" View as: man 5 data_boar or man 5 lgpd_crawler (symlink for compatibility)
-.TH DATA_BOAR 5 "May 2026" "Data Boar 1.7.4" "File Formats"
+.\" View as: man 5 data-boar (primary), man 5 data_boar or man 5 lgpd_crawler (symlink aliases)
+.TH DATA-BOAR 5 "May 2026" "Data Boar 1.7.4" "File Formats"
 .SH NAME
-data_boar config, lgpd_crawler config \- configuration and pattern file formats for Data Boar (compliance-aware discovery and mapping)
+data-boar config, data_boar config, lgpd_crawler config \- configuration and pattern file formats for Data Boar (compliance-aware discovery and mapping)
 .
 .SH WHY TWO MAN PAGES (SECTION 1 AND 5)
 On Linux, BSD and most Unix-like systems, the
@@ -22,16 +22,23 @@ describes
 (e.g. configuration files and their syntax).
 .
 .P
-This project provides two man pages in different sections; both the
-.B data_boar
+This project provides two man pages in different sections; the primary installed names are
+.BR data-boar
 and
-.B lgpd_crawler
-names work (install with symlinks so both resolve):
+.BR data-boar (5);
+symlinks also expose
+.BR data_boar
+and
+.BR lgpd_crawler
+:
 .TP
+.B "man data-boar"
+or
 .B "man data_boar"
 or
 .B "man lgpd_crawler"
 (or
+.BR "man 1 data-boar" ,
 .BR "man 1 data_boar" ,
 .BR "man 1 lgpd_crawler" )
 Shows the
@@ -39,6 +46,8 @@ Shows the
 and its options (config path, \-\-web, \-\-host, \-\-port, \-\-tenant, \-\-technician, \-\-scan\-compressed, \-\-content\-type\-check, \-\-reset\-data, API usage, curl examples).
 Use this when you want to know how to run the application.
 .TP
+.B "man 5 data-boar"
+or
 .B "man 5 data_boar"
 or
 .B "man 5 lgpd_crawler"
@@ -49,11 +58,15 @@ Use this when you want to understand or edit config files and pattern definition
 .
 .P
 If you type only
+.B "man data-boar"
+,
 .B "man data_boar"
 or
 .B "man lgpd_crawler"
 the system usually shows section 1 first (the command).
 To open the config/file-format page explicitly, use
+.BR "man 5 data-boar"
+,
 .BR "man 5 data_boar"
 or
 .BR "man 5 lgpd_crawler" .
@@ -466,7 +479,7 @@ Example main config (excerpt):
 
 \fBapi:\fR
   port: 8088
-  # host: 127.0.0.1   # optional bind address; see man 1 data_boar for CLI and API_HOST
+  # host: 127.0.0.1   # optional bind address; see man 1 data-boar for CLI and API_HOST
   # https_cert_file: /path/server.crt   # optional: TLS for python main.py --web
   # https_key_file: /path/server.key    # optional: must pair with https_cert_file
   # allow_insecure_http: false           # explicit plaintext only when true (Docker image CMD often sets CLI flag instead)
@@ -708,49 +721,72 @@ Example output path when learned_patterns.enabled is true.
 .SH INSTALLATION OF THIS MAN PAGE
 Section 5 pages are installed in
 .IR man5 .
-Install both section 1 and 5 from the source tree, then create symlinks so that
-.B "man data_boar"
+Install both section 1 and 5 from the source tree as
+.BR data-boar.1
 and
-.B "man 5 data_boar"
-work in addition to
-.B lgpd_crawler .
+.BR data-boar.5
+(primary hyphenated names), then create symlinks for
+.BR data_boar
+and
+.BR lgpd_crawler
+aliases.
 See the
 .B "INSTALLATION OF THIS MAN PAGE"
 section in
-.BR data_boar (1)
+.BR data-boar (1)
 (or
+.BR data_boar (1)
+or
 .BR lgpd_crawler (1))
-for the full sequence (copy
+for the full sequence (system\-wide under
+.IR /usr/local/share/man
+or user\-local under
+.IR ~/.local/share/man ,
+copy
 .I docs/data_boar.1
 and
 .I docs/data_boar.5
-into
+to
+.IR data-boar.1
+and
+.IR data-boar.5
+in
 .I man1
 and
 .IR man5 ,
-then optionally
-.B "ln -sf data_boar.1 lgpd_crawler.1"
+then
+.B "ln -sf data-boar.1 data_boar.1"
+,
+.B "ln -sf data-boar.1 lgpd_crawler.1"
+,
+.B "ln -sf data-boar.5 data_boar.5"
 and
-.B "ln -sf data_boar.5 lgpd_crawler.5"
-in the respective directories for backward compatibility,
+.B "ln -sf data-boar.5 lgpd_crawler.5"
+in the respective directories,
 .BR mandb ).
 .PP
 After installation, view this page with:
 .RS
-.B man 5 data_boar
+.B "man 5 data-boar"
 or
-.B man 5 lgpd_crawler
+.B "man 5 data_boar"
+or
+.B "man 5 lgpd_crawler"
 .RE
 .PP
 To view the command and options (section 1) use
+.B "man data-boar"
+,
 .B "man data_boar"
 or
 .B "man lgpd_crawler"
 (or
+.BR "man 1 data-boar" ,
 .BR "man 1 data_boar" ,
 .BR "man 1 lgpd_crawler" ).
 .
 .SH SEE ALSO
+.BR data-boar (1),
 .BR data_boar (1),
 .BR lgpd_crawler (1)
 (command, options, API, curl examples),

--- a/scripts/build_locale_catalogs.py
+++ b/scripts/build_locale_catalogs.py
@@ -203,7 +203,7 @@ def _en() -> dict:
             "run_cli_p1": (
                 "From the repo root, prefer uv run python main.py (or activate your venv and run "
                 "python main.py). Full flag list: python main.py --help. Packaged installs: "
-                "man 1 data_boar (command) and man 5 data_boar (config file format)."
+                "man 1 data-boar (command) and man 5 data-boar (config file format)."
             ),
             "run_cli_oneshot": "One-shot audit (same targets as a dashboard scan):",
             "run_cli_api": "Start the API / dashBOARd (no scan until you use the browser or HTTP):",
@@ -580,7 +580,7 @@ def _pt_br(en: dict) -> dict:
     base["help"]["run_cli_p1"] = (
         "Na raiz do repositório, prefira uv run python main.py (ou ative o venv e execute "
         "python main.py). Lista completa de flags: python main.py --help. Instalações empacotadas: "
-        "man 1 data_boar (comando) e man 5 data_boar (formato do arquivo de configuração)."
+        "man 1 data-boar (comando) e man 5 data-boar (formato do arquivo de configuração)."
     )
     base["help"]["run_cli_oneshot"] = (
         "Auditoria pontual (mesmos alvos que uma varredura pelo painel):"


### PR DESCRIPTION
## Summary

- Canonical CLI and primary man page name is **`data-boar`** (hyphen); **`data_boar`** and **`lgpd_crawler`** remain documented aliases.
- Troff **sources** stay at `docs/data_boar.{1,5}` (no physical rename).
- `.TH` header uses `DATA-BOAR`; marketing version string **"Data Boar 1.7.4"** unchanged.
- **INSTALLATION** section documents primary install as `data-boar.{1,5}` plus symlinks, for both system-wide (`/usr/local/share/man`) and user-local (`~/.local/share/man`).
- `docs/VERSIONING.md` / `.pt_BR.md`, locale help strings, and `scripts/build_locale_catalogs.py` aligned.

Closes #1030

## Follow-up (out of scope)

- Man page for `data-boar-report`
- Physical rename of `docs/data_boar.{1,5}` (untangle from operator-help-sync)

## Test plan

- [x] `pytest tests/test_operator_help_sync.py tests/test_about_version_matches_pyproject.py tests/test_locale_catalog_parity.py`
- [x] `man -l docs/data_boar.1 | head` → `DATA-BOAR(1)`, NAME lists `data-boar` first
- [x] `grep -rn '\.B data_boar' docs/data_boar.{1,5}` → empty
- [x] `./scripts/check-all.sh` green

Made with [Cursor](https://cursor.com)