### PR TITLE
docs(today-mode): add 2026-06-27 checklist (post-1.7.4 pre-epic)

### DIFF
--- a/docs/ops/today-mode/OPERATOR_TODAY_MODE_2026-06-27.md
+++ b/docs/ops/today-mode/OPERATOR_TODAY_MODE_2026-06-27.md
@@ -1,0 +1,64 @@
+# Operator today-mode — 2026-06-27 (post-1.7.4 GA · pre-epic housekeeping)
+
+**pt-BR:** [OPERATOR_TODAY_MODE_2026-06-27.pt_BR.md](OPERATOR_TODAY_MODE_2026-06-27.pt_BR.md)
+
+**Headline:** **1.7.4 GA shipped** (2026-06-26). Today = **housekeeping / chore** on `main` before the **A.I.I.D.C.O.B.P.P. v2** epic (governance + vault + ADR — **serious slice**, not mixed with deps typo passes). **Composer-only** in Cursor until Ultra premium refill (**2026-07-09**).
+
+**`main` anchor:** `1a8d954d` — **`ci.yml` success** on merge of **#1033** (2026-06-26). **Published:** [PUBLISHED_SYNC.md](PUBLISHED_SYNC.md) (**v1.7.4**, Hub **:1.7.4** + **:latest**).
+
+**Private pre-epic queue:** see **`docs/private/ops/`** (auditor handoff — details stay private; ask Cursor for mechanical slices when you pick a row).
+
+---
+
+## Block 0 — Morning reality (10–15 min)
+
+Run **`carryover-sweep`** / **`./scripts/operator-day-ritual.sh -Mode Morning`** (or `.ps1`). Then:
+
+1. **`origin/main`:** `git fetch` · `git status -sb` · confirm **`ci.yml`** green on latest `main`.
+2. **Open PRs:** `gh pr list --state open` — Dependabot queue (**#1025**, **#1029**, **#1011**, **#1010**, **#975**, **#974**, **#915**, **#912**, …) — **`deps`** / **`houseclean`** only; **no blind-merge** (see `.cursor/skills/dependabot-recommendations/SKILL.md`).
+3. **Stacked private git:** if `docs/private/` changed overnight, `./scripts/private-git-sync.sh -Push` (EOD **2026-06-26** sync already ran — commit **`689261e`** on private `main`).
+
+**Rolling queue:** [CARRYOVER.md](CARRYOVER.md) · **Published truth:** [PUBLISHED_SYNC.md](PUBLISHED_SYNC.md)
+
+### Social / editorial (~2 min)
+
+- [ ] Skim **`docs/private/social_drafts/editorial/SOCIAL_HUB.md`** for **Alvo editorial** matching **today** / **tomorrow** — [SOCIAL_PUBLISH_AND_TODAY_MODE.md](SOCIAL_PUBLISH_AND_TODAY_MODE.md).
+
+---
+
+## Priority — pre-epic housekeeping (before A.I.I.D.C.O.B.P.P.)
+
+**Rule:** **A.I.I.D.C.O.B.P.P. v2** (vault `project_aiidcobpp_pattern`, ADR-0062 amend, issue-bus) = **operator Gate** + **Tier 2+** — **not** today's default unless you explicitly promote it.
+
+| Track | Intent | Notes |
+| ----- | ------ | ----- |
+| **Pre-epic chores** | Close stale **public** pointers + small **code** housekeeping the auditor listed | Composer + `lint-only` / `check-all`; one PR per coherent batch |
+| **Optional docs** | `PLANS_TODO.md` **~L621** (M-PILOT / “next patch” still says 1.7.3→1.7.4) · **CARRYOVER** row “v1.7.4-rc on main” → mark shipped | Doc-only; pair with **#1032** spirit |
+| **Dependabot** | Triage **one** PR if bandwidth (e.g. **#974** `py7zr` aligns with lab G1 narrative) | Held until bench stable if Maestro work resumes |
+| **Epic (defer)** | **A.I.I.D.C.O.B.P.P. v2 FINAL** capture + ADR | After Gate: `private-stack-sync` + `new-adr.ps1` amend **ADR-0062** |
+
+**Yesterday closed (do not reopen):** **#1024** release · **#1026** Docker daemonless · **#1031** man `data-boar` · **#1033** `PUBLISHED_SYNC` · **#406** gate close on `main`.
+
+---
+
+## Carryover — secondary
+
+- [ ] **Pre-epic list (private):** pick **one** row from auditor handoff; Cursor executes diff/tests/PR body.
+- [ ] **Maestro / #968 / R12.2** — post-gate backlog; not blocking 1.7.4 publish (see **#1021** / **PLANS_TODO**).
+- [ ] **Premium model roster (2026-07-09):** Codex 5.3 default slot **O** in Cursor Ultra — planning only today.
+- [ ] Rolling: [CARRYOVER.md](CARRYOVER.md) — refresh stale **1.7.4-rc** row when convenient.
+
+---
+
+## End of day (2026-06-27)
+
+- **`eod-sync`** + **`private-stack-sync`** if private or homelab evidence changed.
+- Next checklist: **`OPERATOR_TODAY_MODE_2026-06-28.md`** (create at next `eod-sync` if missing).
+
+---
+
+## Quick references
+
+- Session keywords: `.cursor/rules/session-mode-keywords.mdc` (`today-mode`, `carryover-sweep`, `eod-sync`, `houseclean`, `deps`, `private-stack-sync`)
+- Governance (defer epic): ADR-0062 · A.I.I.D.C.O.B.P.P. v2 FINAL (operator Gate pending)
+- Token-aware: `docs/plans/TOKEN_AWARE_USAGE.md`

--- a/docs/ops/today-mode/OPERATOR_TODAY_MODE_2026-06-27.pt_BR.md
+++ b/docs/ops/today-mode/OPERATOR_TODAY_MODE_2026-06-27.pt_BR.md
@@ -1,0 +1,64 @@
+# Today-mode do operador — 2026-06-27 (pós-1.7.4 GA · housekeeping pré-épico)
+
+**English:** [OPERATOR_TODAY_MODE_2026-06-27.md](OPERATOR_TODAY_MODE_2026-06-27.md)
+
+**Destaque:** **1.7.4 GA publicado** (2026-06-26). Hoje = **housekeeping / chore** no `main` antes do épico **A.I.I.D.C.O.B.P.P. v2** (governança + vault + ADR — **fatia séria**, sem misturar com deps/cosmética). **Só Composer** no Cursor até o refil Ultra (**2026-07-09**).
+
+**Âncora `main`:** `1a8d954d` — **`ci.yml` verde** no merge do **#1033** (2026-06-26). **Publicado:** [PUBLISHED_SYNC.pt_BR.md](PUBLISHED_SYNC.pt_BR.md) (**v1.7.4**, Hub **:1.7.4** + **:latest**).
+
+**Fila pré-épico (privada):** ver **`docs/private/ops/`** (handoff do auditor — detalhe fica no privado; peça ao Cursor os trechos mecânicos quando escolher uma linha).
+
+---
+
+## Bloco 0 — Realidade da manhã (10–15 min)
+
+Rode **`carryover-sweep`** / **`./scripts/operator-day-ritual.sh -Mode Morning`** (ou `.ps1`). Depois:
+
+1. **`origin/main`:** `git fetch` · `git status -sb` · confirme **`ci.yml`** verde no `main` atual.
+2. **PRs abertos:** `gh pr list --state open` — fila Dependabot (**#1025**, **#1029**, **#1011**, **#1010**, **#975**, **#974**, **#915**, **#912**, …) — só **`deps`** / **`houseclean`**; **sem merge cego** (`.cursor/skills/dependabot-recommendations/SKILL.md`).
+3. **Git privado empilhado:** se `docs/private/` mudou de madrugada, `./scripts/private-git-sync.sh -Push` (EOD **2026-06-26** já rodou — commit privado **`689261e`**).
+
+**Fila contínua:** [CARRYOVER.pt_BR.md](CARRYOVER.pt_BR.md) · **Verdade publicada:** [PUBLISHED_SYNC.pt_BR.md](PUBLISHED_SYNC.pt_BR.md)
+
+### Social / editorial (~2 min)
+
+- [ ] Passar o olho em **`docs/private/social_drafts/editorial/SOCIAL_HUB.md`** para **Alvo editorial** de **hoje** / **amanhã** — [SOCIAL_PUBLISH_AND_TODAY_MODE.pt_BR.md](SOCIAL_PUBLISH_AND_TODAY_MODE.pt_BR.md).
+
+---
+
+## Prioridade — housekeeping pré-épico (antes do A.I.I.D.C.O.B.P.P.)
+
+**Regra:** **A.I.I.D.C.O.B.P.P. v2** (vault `project_aiidcobpp_pattern`, amend ADR-0062, issue-bus) = **Gate do operador** + **Tier 2+** — **não** é o default de hoje salvo promoção explícita.
+
+| Trilha | Intenção | Notas |
+| ------ | -------- | ----- |
+| **Chores pré-épico** | Fechar ponteiros **públicos** obsoletos + housekeeping de **código** que o auditor listou | Composer + `lint-only` / `check-all`; um PR por lote coerente |
+| **Docs opcionais** | `PLANS_TODO.md` **~L621** (M-PILOT / “next patch” ainda fala 1.7.3→1.7.4) · **CARRYOVER** “v1.7.4-rc no main” → marcar shipado | Só doc; espírito do **#1032** |
+| **Dependabot** | Triar **um** PR se couber (ex. **#974** `py7zr` alinha com narrativa G1 do lab) | Segurar se o bench Maestro voltar |
+| **Épico (adiar)** | Captura **A.I.I.D.C.O.B.P.P. v2 FINAL** + ADR | Após Gate: `private-stack-sync` + amend **ADR-0062** |
+
+**Ontem fechado (não reabrir):** **#1024** release · **#1026** Docker daemonless · **#1031** man `data-boar` · **#1033** `PUBLISHED_SYNC` · **#406** gate no `main`.
+
+---
+
+## Carryover — secundário
+
+- [ ] **Lista pré-épico (privada):** escolher **uma** linha do handoff do auditor; Cursor executa diff/testes/corpo de PR.
+- [ ] **Maestro / #968 / R12.2** — backlog pós-gate; não bloqueia publish 1.7.4 (ver **#1021** / **PLANS_TODO**).
+- [ ] **Roster premium (2026-07-09):** Codex 5.3 como slot **O** default no Ultra — só planejamento hoje.
+- [ ] Rolagem: [CARRYOVER.pt_BR.md](CARRYOVER.pt_BR.md) — atualizar linha obsoleta **1.7.4-rc** quando der.
+
+---
+
+## Fim do dia (2026-06-27)
+
+- **`eod-sync`** + **`private-stack-sync`** se o privado ou evidência de homelab mudou.
+- Próximo checklist: **`OPERATOR_TODAY_MODE_2026-06-28.md`** (criar no próximo `eod-sync` se faltar).
+
+---
+
+## Referências rápidas
+
+- Tokens de sessão: `.cursor/rules/session-mode-keywords.mdc` (`today-mode`, `carryover-sweep`, `eod-sync`, `houseclean`, `deps`, `private-stack-sync`)
+- Governança (épico adiado): ADR-0062 · A.I.I.D.C.O.B.P.P. v2 FINAL (Gate do operador pendente)
+- Token-aware: `docs/plans/TOKEN_AWARE_USAGE.md`


### PR DESCRIPTION
## Summary

EOD prep for **2026-06-27**: post-1.7.4 GA focus on **pre-epic housekeeping** (not A.I.I.D.C.O.B.P.P. chore). Composer-only until Ultra refill **2026-07-09**.

## Test plan

- [x] `lint-only.sh` (markdown + pt-BR guards)

Made with [Cursor](https://cursor.com)