### PR TITLE
docs(deploy): README index, pt-BR mirrors, Podman section (#1036 #1037 #1038)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -11,5 +11,9 @@ Contents of this folder:
 - `docker-compose.yml` — Docker Compose stack (web API + frontend).
 - `docker-compose.override.example.yml` — Example override for bind-mounting `./data`; copy to `docker-compose.override.yml`.
 - `kubernetes/` — Kubernetes manifests (Deployment, Service, ConfigMap) and optional examples (NetworkPolicy, PDB).
+- `ansible/` — Ansible playbooks for Debian/Ubuntu hosts (Docker Compose stack or full install); see `ansible/README.md`.
+- `opentofu/` — OpenTofu/Terraform module for container runtime, ports, and volumes (application config via Ansible).
+- `lab-smoke-stack/` — Docker Compose bundle for LAN-only multi-DB lab smoke tests (PostgreSQL, MariaDB, optional MongoDB).
+- `samples/` — Tracked starter configs for evaluators (LGPD starter YAML and scope-import pointers); see `samples/README.md`.
 
 All paths in the deploy guides assume you run commands from the **repository root** or from this folder as indicated.

--- a/deploy/ansible/README.md
+++ b/deploy/ansible/README.md
@@ -117,4 +117,4 @@ ssh user@your-server docker logs -f data_boar
 - `deploy/docker-compose.yml` — base compose definition
 - `docs/USAGE.md` — CLI and configuration reference
 - `docs/TECH_GUIDE.md` — architecture overview
-- `docs/DEPLOY.md` — Docker and manual deployment alternatives (if present)
+- `docs/deploy/DEPLOY.md` — Docker and manual deployment alternatives

--- a/deploy/ansible/README.pt_BR.md
+++ b/deploy/ansible/README.pt_BR.md
@@ -1,0 +1,123 @@
+# Data Boar — implantação com Ansible
+
+**English:** [README.md](README.md)
+
+Dois caminhos de automação para implantar o Data Boar em qualquer host Debian/Ubuntu.
+Escolha o caminho que combina com a sua infraestrutura.
+
+Todos os plays definem **`environment: "{{ labop_debian_unattended_apt_environment }}"`** (em **`group_vars/all.yml`**) para o **`apt-listbugs`** não abortar instalações `apt` não assistidas em Debian/Ubuntu. Novos playbooks devem manter esse padrão; o CI reforça — veja **`tests/test_ansible_playbooks_unattended_apt.py`** e **[ops/automation/ansible/README.md](../../ops/automation/ansible/README.md)**.
+
+---
+
+## Pré-requisitos (ambos os caminhos)
+
+```bash
+# Instale o Ansible (na máquina de controle, não no alvo)
+sudo apt install ansible          # Debian/Ubuntu
+# ou: pip install ansible
+
+# Instale a collection community.docker
+ansible-galaxy collection install community.docker
+
+# Clone o repositório Data Boar
+git clone https://github.com/FabioLeitao/data-boar.git
+cd data-boar/deploy/ansible
+
+# Crie o inventário
+cp inventory/hosts.ini.example inventory/hosts.ini
+# Edite hosts.ini: adicione o IP do servidor e o usuário SSH
+
+```
+
+---
+
+## Caminho A — Simples: pull da imagem + Docker Compose (sem Swarm)
+
+Melhor para: servidor único, avaliação rápida, instalações Docker já existentes.
+
+```bash
+# Dry-run (mostra o que mudaria, nada é aplicado)
+ansible-playbook site.yml --check
+
+# Aplicar
+ansible-playbook site.yml
+
+```
+
+O Data Boar ficará acessível em `http://<seu-servidor>:8088` após o playbook concluir.
+
+---
+
+## Caminho B — Stack completa: Docker CE + Swarm + ctop + serviço Data Boar
+
+Melhor para: servidores novos, ambientes de laboratório reproduzíveis, Swarm multi-nó (estenda o
+inventário com hosts adicionais no grupo `[data_boar]`).
+
+```bash
+# Dry-run
+ansible-playbook site-full.yml --check
+
+# Aplicar
+ansible-playbook site-full.yml
+
+```
+
+Este playbook:
+
+1. Instala o Docker CE (do repositório oficial do Docker)
+2. Inicializa um Docker Swarm de nó único (`docker swarm init`)
+3. Instala `ctop` para monitoramento de contêineres em tempo real
+4. Faz pull da imagem Data Boar e implanta como serviço Swarm
+
+Após aplicar:
+
+```bash
+# Monitore contêineres no alvo
+ssh user@your-server ctop
+
+# Verifique o status do serviço Swarm
+ssh user@your-server docker service ps data_boar
+
+```
+
+---
+
+## Variáveis
+
+Substitua qualquer padrão em `group_vars/all.yml` ou passe via `-e`:
+
+| Variável | Padrão | Descrição |
+|---|---|---|
+| `data_boar_image` | `fabioleitao/data_boar:latest` | Imagem Docker para pull |
+| `data_boar_port` | `8088` | Porta no host para a API |
+| `data_boar_dir` | `/opt/data_boar` | Diretório de trabalho no alvo |
+| `swarm_enabled` | `false` | Defina `true` para o Caminho B / Swarm |
+
+Exemplo de substituição:
+
+```bash
+ansible-playbook site.yml -e "data_boar_port=9000"
+
+```
+
+---
+
+## Verificação
+
+```bash
+# Health check (da máquina de controle)
+curl http://<server>:8088/health
+
+# Ver logs no alvo
+ssh user@your-server docker logs -f data_boar
+
+```
+
+---
+
+## Documentação relacionada
+
+- `deploy/docker-compose.yml` — definição base do compose
+- `docs/USAGE.md` — referência de CLI e configuração
+- `docs/TECH_GUIDE.md` — visão geral da arquitetura
+- `docs/DEPLOY.md` — alternativas de implantação Docker e manual (se existir)

--- a/deploy/ansible/README.pt_BR.md
+++ b/deploy/ansible/README.pt_BR.md
@@ -120,4 +120,4 @@ ssh user@your-server docker logs -f data_boar
 - `deploy/docker-compose.yml` — definição base do compose
 - `docs/USAGE.md` — referência de CLI e configuração
 - `docs/TECH_GUIDE.md` — visão geral da arquitetura
-- `docs/DEPLOY.md` — alternativas de implantação Docker e manual (se existir)
+- `docs/deploy/DEPLOY.md` — alternativas de implantação Docker e manual

--- a/deploy/opentofu/README.pt_BR.md
+++ b/deploy/opentofu/README.pt_BR.md
@@ -1,0 +1,174 @@
+# Data Boar — módulo OpenTofu
+
+**English:** [README.md](README.md)
+
+Implante a infraestrutura do Data Boar com [OpenTofu](https://opentofu.org/) (fork open source do Terraform).
+
+Este módulo provisiona a **camada de infraestrutura** (runtime de contêiner, portas, volumes). Para
+**configuração da aplicação** (alvos de varredura, credenciais de banco, agendamento), use os playbooks
+Ansible em `deploy/ansible/` como segundo passo.
+
+---
+
+## Quem deve usar
+
+Use este módulo quando a equipe já gerencia infraestrutura via OpenTofu ou Terraform 1.5.x.
+Se você quer uma implantação mais simples em um comando, sem fluxo IaC existente, veja
+`deploy/ansible/README.md` ([pt-BR](../ansible/README.pt_BR.md)) (Caminhos A e B).
+
+---
+
+## Pré-requisitos
+
+- **OpenTofu >= 1.6** ou **Terraform >= 1.5** instalado.
+- **Docker** em execução no host alvo.
+- Um `config.yaml` do Data Boar já no disco no caminho que você passará via `data_boar_config_path`.
+- Um diretório de saída de relatórios criado no host.
+
+Instale o OpenTofu: <https://opentofu.org/docs/intro/install/>
+
+---
+
+## Início rápido
+
+```bash
+# 1. Entre neste diretório
+cd deploy/opentofu
+
+# 2. Inicialize os providers
+tofu init
+
+# 3. Pré-visualize o que será criado
+tofu plan
+
+# 4. Aplique (implanta o contêiner no daemon Docker local)
+tofu apply
+
+# 5. Abra o Data Boar
+open http://localhost:8088
+```
+
+---
+
+## Fluxo corporativo em dois passos (OpenTofu + Ansible)
+
+O OpenTofu provisiona a infraestrutura; o Ansible configura a aplicação.
+
+```bash
+# Passo 1: provisionar infra
+cd deploy/opentofu
+tofu apply
+
+# Passo 2: configurar e implantar o app
+#   O OpenTofu gerou um generated_inventory.ini para você:
+cd ../..
+ansible-playbook -i deploy/opentofu/generated_inventory.ini deploy/ansible/site.yml
+```
+
+---
+
+## Com banco POC (PostgreSQL)
+
+Para subir um contêiner PostgreSQL local junto ao Data Boar para testes POC:
+
+```bash
+tofu apply -var="db_enabled=true" -var="db_password=poc-test-123"
+```
+
+Depois popule o banco com PII sintética:
+
+```bash
+uv run python scripts/populate_poc_database.py \
+  --db-type postgres \
+  --host localhost \
+  --port 5432 \
+  --write-config
+```
+
+---
+
+## Variáveis
+
+| Nome | Padrão | Descrição |
+|---|---|---|
+| `data_boar_image` | `fabioleitao/data-boar:latest` | Imagem Docker para pull |
+| `data_boar_port` | `8088` | Porta no host para a interface web |
+| `data_boar_config_path` | `/etc/data-boar/config.yaml` | Caminho do config.yaml no host |
+| `data_boar_output_dir` | `/var/data-boar/reports` | Diretório de saída de relatórios no host |
+| `container_name` | `data-boar` | Nome do contêiner Docker |
+| `restart_policy` | `unless-stopped` | Política de reinício do Docker |
+| `db_enabled` | `false` | Subir banco PostgreSQL POC local |
+| `db_password` | `""` (sensível) | Senha do banco PostgreSQL POC |
+
+---
+
+## Outputs
+
+| Output | Descrição |
+|---|---|
+| `data_boar_url` | URL da interface web do Data Boar |
+| `data_boar_port` | Porta no host à qual o contêiner está vinculado |
+| `container_name` | Nome do contêiner em execução |
+| `ansible_inventory_path` | Caminho do inventário Ansible gerado |
+| `poc_db_host` | Host PostgreSQL (quando `db_enabled = true`) |
+| `poc_db_port` | Porta PostgreSQL (quando `db_enabled = true`) |
+
+---
+
+## Provedores cloud / remotos
+
+O módulo padrão usa o provider Docker (daemon local). Para apontar a um host remoto ou a um provedor
+cloud, substitua a configuração do provider em um arquivo `provider_override.tf` no seu diretório
+de trabalho. Exemplos:
+
+**AWS ECS:**
+
+```hcl
+# Substitua docker_container por aws_ecs_service / aws_ecs_task_definition
+# e use o provider aws da hashicorp/aws
+```
+
+**Docker remoto via SSH:**
+
+```hcl
+provider "docker" {
+  host     = "ssh://<ssh-user>@myserver.example.com"
+  ssh_opts = ["-i", "~/.ssh/id_ed25519"]
+}
+```
+
+---
+
+## Backend de state (recomendado para uso corporativo)
+
+Armazene o state remotamente para a equipe compartilhar a mesma visão de infraestrutura:
+
+```hcl
+# backend.tf (crie em deploy/opentofu/ antes de tofu init)
+terraform {
+  backend "s3" {
+    bucket = "my-company-tf-state"
+    key    = "data-boar/terraform.tfstate"
+    region = "us-east-1"
+  }
+}
+```
+
+Backends compatíveis: S3, GCS, Azure Blob, MinIO (S3-compatível self-hosted).
+
+---
+
+## Compatibilidade
+
+Este módulo usa apenas recursos HCL compatíveis com **OpenTofu >= 1.6** e **Terraform >= 1.5**.
+Se a equipe já migrou para OpenTofu, use `tofu`; se ainda estiver no Terraform BSL, os comandos
+`terraform` funcionam de forma idêntica.
+
+---
+
+## Relacionados
+
+- `deploy/ansible/README.md` ([pt-BR](../ansible/README.pt_BR.md)) — playbooks Ansible Caminho A (Docker Compose) e Caminho B (stack completa)
+- `deploy/kubernetes/` — manifestos Kubernetes
+- `docs/adr/ADR-0016-opentofu-corporate-iac-path-alongside-ansible.md` — racional de design
+- `docs/USAGE.md` — documentação completa de implantação

--- a/docs/deploy/DEPLOY.md
+++ b/docs/deploy/DEPLOY.md
@@ -264,7 +264,6 @@ Podman is a daemonless, rootless container runtime — the default on
 RHEL/Fedora and recommended for zero-trust environments.
 
 ```bash
-# Pull and run (rootless — no sudo required)
 podman run -d --name data-boar \
   -p 8088:8088 \
   -v ./data:/data:z \
@@ -272,13 +271,14 @@ podman run -d --name data-boar \
 ```
 
 > **SELinux note:** Use `:z` (shared label) or `:Z` (private label)
-> on the volume mount when SELinux is enforcing. Omit on non-SELinux hosts.
+> on the volume mount when SELinux is enforcing.
+> Omit the label on non-SELinux hosts.
 
-For Compose-style workflows, `podman-compose` accepts the existing
-`deploy/docker-compose.yml` without changes:
+For Compose-style workflows, `podman-compose` is compatible with the
+existing `deploy/docker-compose.yml`:
 
 ```bash
-pip install podman-compose
+pipx install podman-compose
 podman-compose -f deploy/docker-compose.yml up -d
 ```
 

--- a/docs/deploy/DEPLOY.md
+++ b/docs/deploy/DEPLOY.md
@@ -258,6 +258,30 @@ docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.override.ym
 
 In `deploy/docker-compose.yml` set `image: fabioleitao/data_boar:latest` (or your registry) and remove or comment out the `build:` block. Then run the same `docker compose ... up -d` commands.
 
+## Podman (rootless)
+
+Podman is a daemonless, rootless container runtime — the default on
+RHEL/Fedora and recommended for zero-trust environments.
+
+```bash
+# Pull and run (rootless — no sudo required)
+podman run -d --name data-boar \
+  -p 8088:8088 \
+  -v ./data:/data:z \
+  fabioleitao/data_boar:latest
+```
+
+> **SELinux note:** Use `:z` (shared label) or `:Z` (private label)
+> on the volume mount when SELinux is enforcing. Omit on non-SELinux hosts.
+
+For Compose-style workflows, `podman-compose` accepts the existing
+`deploy/docker-compose.yml` without changes:
+
+```bash
+pip install podman-compose
+podman-compose -f deploy/docker-compose.yml up -d
+```
+
 ## 5. Deploy with Docker Swarm
 
 Docker Swarm is an alternative for orchestrating the service across a cluster. Use the same Compose file with `docker stack deploy`.

--- a/docs/deploy/DEPLOY.pt_BR.md
+++ b/docs/deploy/DEPLOY.pt_BR.md
@@ -121,6 +121,30 @@ docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.override.ym
 
 Logs: `docker compose -f deploy/docker-compose.yml logs -f data-boar`. Parar: `docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.override.yml down`.
 
+## Podman (rootless)
+
+Podman é um runtime de contêiner daemonless e rootless — o padrão em
+RHEL/Fedora e recomendado em ambientes zero-trust.
+
+```bash
+# Pull e execução (rootless — sem sudo)
+podman run -d --name data-boar \
+  -p 8088:8088 \
+  -v ./data:/data:z \
+  fabioleitao/data_boar:latest
+```
+
+> **Nota SELinux:** Use `:z` (rótulo compartilhado) ou `:Z` (rótulo privado)
+> no mount do volume quando o SELinux estiver em enforcing. Omita em hosts sem SELinux.
+
+Para fluxos estilo Compose, o `podman-compose` aceita o
+`deploy/docker-compose.yml` existente sem alterações:
+
+```bash
+pip install podman-compose
+podman-compose -f deploy/docker-compose.yml up -d
+```
+
 ## 5. Docker Swarm
 
 Use o mesmo Compose com `docker stack deploy`:

--- a/docs/deploy/DEPLOY.pt_BR.md
+++ b/docs/deploy/DEPLOY.pt_BR.md
@@ -127,7 +127,6 @@ Podman é um runtime de contêiner daemonless e rootless — o padrão em
 RHEL/Fedora e recomendado em ambientes zero-trust.
 
 ```bash
-# Pull e execução (rootless — sem sudo)
 podman run -d --name data-boar \
   -p 8088:8088 \
   -v ./data:/data:z \
@@ -135,13 +134,14 @@ podman run -d --name data-boar \
 ```
 
 > **Nota SELinux:** Use `:z` (rótulo compartilhado) ou `:Z` (rótulo privado)
-> no mount do volume quando o SELinux estiver em enforcing. Omita em hosts sem SELinux.
+> no mount do volume quando o SELinux estiver em enforcing.
+> Omita o rótulo em hosts sem SELinux.
 
-Para fluxos estilo Compose, o `podman-compose` aceita o
-`deploy/docker-compose.yml` existente sem alterações:
+Para fluxos estilo Compose, o `podman-compose` é compatível com o
+`deploy/docker-compose.yml` existente:
 
 ```bash
-pip install podman-compose
+pipx install podman-compose
 podman-compose -f deploy/docker-compose.yml up -d
 ```
 


### PR DESCRIPTION
## Summary

Deploy documentation hygiene batch — closes three P3 docs issues:

- **#1036** — `deploy/README.md` Contents lists `ansible/`, `opentofu/`, `lab-smoke-stack/`, and `samples/` (one descriptive line each).
- **#1037** — pt-BR mirrors: `deploy/ansible/README.pt_BR.md`, `deploy/opentofu/README.pt_BR.md` (EN canonical; locale guard passed).
- **#1038** — Short **Podman (rootless)** section in `docs/deploy/DEPLOY.md` + `.pt_BR.md` after Docker Compose (before Swarm/Kubernetes): `podman run` with SELinux `:z`/`:Z`, `pipx install podman-compose`.

Long-form Podman (§10) unchanged — complements the quick path for RHEL/Fedora/zero-trust audiences.

## Files

| Path | Change |
|------|--------|
| `deploy/README.md` | Subdir index |
| `deploy/ansible/README.pt_BR.md` | New mirror |
| `deploy/opentofu/README.pt_BR.md` | New mirror |
| `docs/deploy/DEPLOY.md` | Podman section + pipx wording |
| `docs/deploy/DEPLOY.pt_BR.md` | Podman mirror |

## Test plan

- [x] `uv run pytest tests/test_markdown_lint.py::test_markdown_lint_no_violations`
- [x] `uv run pytest tests/test_docs_markdown.py`
- [x] `uv run pytest tests/test_docs_pt_br_locale.py`
- [x] `uv run python scripts/check_hubs.py`
- [x] pre-commit on commit

Closes #1036
Closes #1037
Closes #1038

Made with [Cursor](https://cursor.com)