### PR TITLE
feat(cli): add --version flag to main.py (#1027)

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,6 +21,13 @@ from core.licensing import LicenseBlockedError
 from core.runtime_trust import get_runtime_trust_snapshot
 
 
+def _cli_public_version_line() -> str:
+    """Public CLI --version string (no maturity_build octet; see ADR-0073)."""
+    from core.about import _package_version
+
+    return f"Data Boar {_package_version()}"
+
+
 def _emit_runtime_trust_info(
     snapshot: dict[str, Any], *, to_stdout: bool = True, to_stderr: bool = True
 ) -> None:
@@ -309,6 +316,12 @@ def main() -> None:
             "scans, list sessions and download the latest reports through the browser."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=_cli_public_version_line(),
+        help="Show the public product version and exit (no scan or API startup).",
     )
     parser.add_argument(
         "--config",

--- a/tests/test_main_version_cli.py
+++ b/tests/test_main_version_cli.py
@@ -1,0 +1,42 @@
+"""CLI: main.py --version prints public version and exits before config load."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+from core.about import _package_version
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _maturity_build_octet() -> int:
+    with (_repo_root() / "pyproject.toml").open("rb") as f:
+        return int(tomllib.load(f)["tool"]["databoar"]["maturity_build"])
+
+
+def test_main_version_prints_public_version_exit_zero(tmp_path):
+    """--version must not require config.yaml and must not leak maturity_build."""
+    repo = _repo_root()
+    # Run from an empty dir so default config.yaml is absent.
+    r = subprocess.run(
+        [sys.executable, str(repo / "main.py"), "--version"],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+        timeout=30,
+        check=False,
+    )
+    assert r.returncode == 0, r.stderr
+    expected = f"Data Boar {_package_version()}"
+    assert r.stdout.strip() == expected
+    assert r.stderr == ""
+
+    maturity = _maturity_build_octet()
+    assert f".{maturity}" not in r.stdout
+    assert not re.search(r"\d+\.\d+\.\d+\.\d+", r.stdout)


### PR DESCRIPTION
## Summary

- Adds `--version` to `main.py` (`action='version'`) using `_cli_public_version_line()` → `Data Boar {_package_version()}`.
- Exits **before** config load (works without `config.yaml` in cwd).
- Does **not** surface `[tool.databoar] maturity_build` (ADR-0073 / octet-leak guard).

## Test plan

- [x] `./scripts/check-all.sh` green (pre-commit + full pytest)
- [x] `tests/test_main_version_cli.py` — exit 0, public line, no `.201` / no four-segment semver

Closes #1027

Made with [Cursor](https://cursor.com)