### PR TITLE
ci(release): OIDC PyPI publish workflow and package metadata (#1042)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
 
       - name: Build sdist and wheel
         run: uv build

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,94 @@
+# PyPI publish machinery (GitHub #74 / #1042): OIDC Trusted Publishing — no API token in CI.
+# Dist is built in CI from checkout (tag on release, or HEAD on dispatch) — no local build in workflow design.
+# Production PyPI upload is deliberate: workflow_dispatch with target=pypi only (environment: pypi).
+# TestPyPI: release published OR workflow_dispatch default (testpypi).
+# ADR-0074: all third-party Actions pinned to full commit SHAs.
+name: Publish to PyPI
+
+permissions:
+  contents: read
+
+'on':
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Onde publicar"
+        type: choice
+        options: [testpypi, pypi]
+        default: testpypi
+
+concurrency:
+  group: publish-pypi-${{ github.workflow }}-${{ github.event.release.tag_name || github.ref }}-${{ github.event.inputs.target || 'release' }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build dist
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Validate dist (twine check)
+        run: uvx twine check dist/*
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    if: >-
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'testpypi')
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: testpypi
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI (OIDC)
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Publish to PyPI
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'pypi'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI (OIDC)
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,33 @@ version = "1.7.4"
 description = "Data Boar — compliance-aware discovery and mapping of personal and sensitive data across databases, files, and APIs (LGPD, GDPR, CCPA, and configurable frameworks)."
 readme = "README.md"
 requires-python = ">=3.12"
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
+authors = [{ name = "Fabio Tavares Leitão", email = "author@databoar.com.br" }]
+keywords = [
+    "lgpd",
+    "gdpr",
+    "ccpa",
+    "pii",
+    "data-discovery",
+    "compliance",
+    "privacy",
+    "ropa",
+    "data-mapping",
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "Intended Audience :: Legal Industry",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Security",
+    "Topic :: Database",
+]
 # Dependabot-friendly: minimum versions (>=) allow security patches; pin (==) only where needed for reproducibility.
 dependencies = [
     "annotated-doc>=0.0.4",
@@ -95,6 +122,13 @@ build-backend = "hatchling.build"
 [project.scripts]
 data-boar = "main:main"
 data-boar-report = "cli.reporter:main"
+
+[project.urls]
+Homepage = "https://github.com/FabioLeitao/data-boar"
+Repository = "https://github.com/FabioLeitao/data-boar"
+Issues = "https://github.com/FabioLeitao/data-boar/issues"
+Changelog = "https://github.com/FabioLeitao/data-boar/blob/main/CHANGELOG.md"
+"Docker Hub" = "https://hub.docker.com/r/fabioleitao/data_boar"
 
 [project.optional-dependencies]
 nosql = ["pymongo>=4.0", "redis>=8.0.0"]

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -479,3 +479,71 @@ def test_operator_gated_reopen_workflow_present_and_valid() -> None:
             assert sha_40.search(code), (
                 f"expected full commit SHA for github-script: {line.strip()!r}"
             )
+
+
+def test_publish_pypi_workflow_present_and_valid() -> None:
+    """#1042 / #74: OIDC PyPI publish — build in CI, prod gated on dispatch target=pypi."""
+    data = _load_workflow("publish-pypi.yml")
+    assert data.get("name") == "Publish to PyPI"
+    on = data.get("on") or {}
+    assert "release" in on
+    rel = on["release"]
+    assert isinstance(rel, dict)
+    assert rel.get("types") == ["published"]
+    assert "workflow_dispatch" in on
+    wd = on["workflow_dispatch"]
+    assert isinstance(wd, dict)
+    target = (wd.get("inputs") or {}).get("target") or {}
+    assert target.get("type") == "choice"
+    assert target.get("default") == "testpypi"
+    assert set(target.get("options") or []) == {"testpypi", "pypi"}
+
+    jobs = data.get("jobs") or {}
+    for job_id in ("build", "publish-testpypi", "publish-pypi"):
+        assert job_id in jobs, f"missing job {job_id}"
+
+    build = jobs["build"]
+    runs = "\n".join(_ci_step_run_texts(build))
+    assert "uv build" in runs
+    assert "twine check" in runs
+
+    testpypi = jobs["publish-testpypi"]
+    assert testpypi.get("environment") == "testpypi"
+    test_if = str(testpypi.get("if") or "")
+    assert "release" in test_if
+    assert "testpypi" in test_if
+    test_perms = testpypi.get("permissions") or {}
+    assert test_perms.get("id-token") == "write"
+
+    prod = jobs["publish-pypi"]
+    assert prod.get("environment") == "pypi"
+    prod_if = str(prod.get("if") or "")
+    assert "pypi" in prod_if
+    assert "workflow_dispatch" in prod_if
+    prod_perms = prod.get("permissions") or {}
+    assert prod_perms.get("id-token") == "write"
+
+
+def test_publish_pypi_yml_pins_actions_to_shas() -> None:
+    """ADR-0074: publish-pypi.yml pins all third-party Actions (incl. pypa/gh-action-pypi-publish)."""
+    text = (WORKFLOWS / "publish-pypi.yml").read_text(encoding="utf-8")
+    sha_40 = re.compile(r"@[0-9a-f]{40}")
+    for line in text.splitlines():
+        code = line.split("#", 1)[0]
+        if "uses:" not in code or "docker://" in code:
+            continue
+        if "./.github/workflows/" in code:
+            continue
+        if not any(
+            p in code
+            for p in (
+                "actions/",
+                "github/",
+                "astral-sh/",
+                "pypa/gh-action-pypi-publish@",
+            )
+        ):
+            continue
+        assert sha_40.search(code), (
+            f"expected full commit SHA in uses line: {line.strip()!r}"
+        )

--- a/tests/test_pyproject_pypi_metadata.py
+++ b/tests/test_pyproject_pypi_metadata.py
@@ -1,0 +1,77 @@
+"""PyPI packaging metadata guards (#1042 / ADR-0031)."""
+
+from __future__ import annotations
+
+import subprocess
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+# Trove classifiers must match PyPI allow-list (invalid = upload rejected).
+_EXPECTED_CLASSIFIERS = (
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "Intended Audience :: Legal Industry",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Security",
+    "Topic :: Database",
+)
+
+
+def _project() -> dict:
+    with PYPROJECT.open("rb") as handle:
+        data = tomllib.load(handle)
+    project = data.get("project")
+    assert isinstance(project, dict), "pyproject.toml must define [project]"
+    return project
+
+
+def test_pyproject_pypi_license_and_authors() -> None:
+    project = _project()
+    assert project.get("license") == "BSD-3-Clause"
+    assert project.get("license-files") == ["LICENSE"]
+    authors = project.get("authors")
+    assert isinstance(authors, list) and authors
+    first = authors[0]
+    assert isinstance(first, dict)
+    assert first.get("name")
+    assert first.get("email") == "author@databoar.com.br"
+
+
+def test_pyproject_pypi_classifiers_are_valid_trove() -> None:
+    """Classifiers must be on PyPI trove allow-list (uvx — no lock churn)."""
+    project = _project()
+    classifiers = project.get("classifiers")
+    assert isinstance(classifiers, list)
+    assert tuple(classifiers) == _EXPECTED_CLASSIFIERS
+    script = (
+        "from trove_classifiers import sorted_classifiers\n"
+        "import sys\n"
+        "valid = set(sorted_classifiers)\n"
+        "bad = [c for c in sys.argv[1:] if c not in valid]\n"
+        "sys.exit(1) if bad else sys.exit(0)\n"
+    )
+    proc = subprocess.run(
+        ["uvx", "--from", "trove-classifiers", "python", "-c", script, *classifiers],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout or "trove check failed"
+
+
+def test_pyproject_pypi_urls_present() -> None:
+    with PYPROJECT.open("rb") as handle:
+        data = tomllib.load(handle)
+    urls = data.get("project", {}).get("urls")
+    assert isinstance(urls, dict)
+    for key in ("Homepage", "Repository", "Issues", "Changelog", "Docker Hub"):
+        assert urls.get(key), f"missing [project.urls] {key}"


### PR DESCRIPTION
## Summary

- Add `.github/workflows/publish-pypi.yml`: CI builds `dist/` with `uv build`, validates with `uvx twine check`, publishes to **TestPyPI** on `release: published` or `workflow_dispatch` default (`testpypi`), and to **production PyPI** only on deliberate `workflow_dispatch` with `target=pypi` (OIDC; environments `testpypi` / `pypi` already configured).
- Pin all third-party Actions by full commit SHA (ADR-0074), including `pypa/gh-action-pypi-publish`.
- Extend `pyproject.toml` `[project]` with PyPI metadata: BSD-3-Clause + `license-files`, authors (`author@databoar.com.br`), keywords, trove-validated classifiers, and `[project.urls]`.
- Add regression tests for workflow shape/SHA pins and PyPI metadata (classifiers checked via `uvx trove-classifiers` — no lock churn).

Closes #1042

Does **not** close #74 — production claim/publish remains operator dispatch after Trusted Publishing is verified on PyPI.

## Test plan

- [x] `./scripts/check-all.sh` green locally
- [x] `uv build && uvx twine check dist/*` clean
- [x] `pytest tests/test_pyproject_pypi_metadata.py` + publish workflow guards
- [ ] CI green on PR (incl. workflow YAML / zizmor advisory)
- [ ] Post-merge: operator verifies Pending Publisher + first `workflow_dispatch` → TestPyPI


Made with [Cursor](https://cursor.com)