### PR TITLE
workflow(ci): tiered security scans in check-all mirror (#1044)

### DIFF
--- a/.cursor/rules/quality-sonarqube-codeql.mdc
+++ b/.cursor/rules/quality-sonarqube-codeql.mdc
@@ -16,6 +16,8 @@ Other **`CI`** jobs: **test** (pytest matrix 3.12/3.13), **bandit**, **dependenc
 
 **Windows (operator):** Prefer **`.\scripts\check-all.ps1`** or **`.\scripts\lint-only.ps1`** over ad-hoc one-liners when iterating — same gates, consistent with **check-all-gate**. Install hooks once: **`uv run pre-commit install`** so **`git commit`** runs the same checks without waiting for CI.
 
+**Security scan tier (#1044):** Default **`check-all`** runs **Bandit** + **Zizmor** after pre-commit/pytest (`scripts/check-all-security-scans.*`, fail-collect). Use **`--enforced`** / **`-Enforced`** to add **Semgrep** (same command as **`semgrep.yml`**). Full mirror table: **`docs/QUALITY_WORKFLOW_RECOMMENDATIONS.md`** §4c.
+
 ## After editing Python
 
 1. **Lint bundle (Ruff + docs guards + plans-stats):** Run **`uv run pre-commit run --all-files`** (or rely on **`git commit`** after **`uv run pre-commit install`**). Fix format with **`uv run ruff format .`** when **ruff-format** fails. Same checks run in **`ci.yml`** **`lint`**; see **pre-commit-ruff** and **`.pre-commit-config.yaml`**.
@@ -48,6 +50,14 @@ Other **`CI`** jobs: **test** (pytest matrix 3.12/3.13), **bandit**, **dependenc
 1. Run the **markdown lint** flow (see rule **markdown-lint**): `uv run python scripts/fix_markdown_sonar.py` then `uv run pytest tests/test_markdown_lint.py -v -W error`.
 
 ## Full regression (recommended before PR)
+
+```bash
+./scripts/check-all.sh
+# Security-sensitive slice (connectors, workflows, auth):
+./scripts/check-all.sh --enforced
+```
+
+Default **`check-all`** mirrors CI lint/test plus **Bandit** + **Zizmor** (fail-collect). **`--enforced`** adds **Semgrep** — see **`docs/QUALITY_WORKFLOW_RECOMMENDATIONS.md`** §4c.
 
 ```bash
 uv run pytest -v -W error

--- a/.cursor/skills/quality-sonarqube-codeql/SKILL.md
+++ b/.cursor/skills/quality-sonarqube-codeql/SKILL.md
@@ -53,6 +53,8 @@ After changing Python or markdown:
 
 **Windows:** Prefer **`.\scripts\check-all.ps1`** (full gate) or **`.\scripts\lint-only.ps1`** (runs **`pre-commit run --all-files`**) per **check-all-gate** — matches the **CI lint** job.
 
+**Security tier (#1044):** Default **`check-all`** ends with **Bandit** + **Zizmor** (`check-all-security-scans.*`, fail-collect). **`--enforced`** / **`-Enforced`** adds **Semgrep** (parity with **`semgrep.yml`**). See **`docs/QUALITY_WORKFLOW_RECOMMENDATIONS.md`** §4c; **Wave 3 (future):** run **`--enforced`** before PR when touching connectors, workflows, or auth.
+
 **Once per clone:** **`uv run pre-commit install`** so **`git commit`** runs the same hooks locally.
 
 ```bash
@@ -79,6 +81,10 @@ uv run mypy api core
 Before opening a PR, run the full suite:
 
 ```bash
+./scripts/check-all.sh
+# Optional — Semgrep parity before security-sensitive PRs:
+./scripts/check-all.sh --enforced
+
 uv run pytest -v -W error
 ```
 

--- a/docs/QUALITY_WORKFLOW_RECOMMENDATIONS.md
+++ b/docs/QUALITY_WORKFLOW_RECOMMENDATIONS.md
@@ -68,9 +68,60 @@ This document suggests **additional layers** (tools, habits, and workflow) to ke
 ## What we do (Semgrep):
 
 - **GitHub Actions:** [`.github/workflows/semgrep.yml`](../.github/workflows/semgrep.yml) runs on push/PR to `main`/`master` using the official **`semgrep/semgrep`** container, ruleset **`p/python`**, **`--metrics=off`**, and one **excluded rule** documented in workflow comments (false positive on vetted `sqlalchemy.text` identifier paths).
-- **Local (optional):** `uvx semgrep scan --config p/python --metrics=off` (add the same `--exclude-rule` as in the workflow if you want parity). Custom rules can live under `.semgrep/` later.
+- **Local (optional):** `uvx semgrep scan --config p/python --metrics=off` with the same **`--exclude-rule`** as the workflow (see **§ check-all unified mirror** below). Custom rules can live under `.semgrep/` later.
 
-**Prevents:** Extra Python anti-patterns; complements CodeQL. **Slack:** **`Slack CI failure notify`** (`workflow_run`, lists **`Semgrep`** next to **`CI`**, etc.) ships on **`origin`** as **`.github/workflows/slack-ci-failure-notify.yml`**; a **private snapshot** for pause drills lives under **`docs/private/raw_pastes/cursor-incident/slack-ci-failure-notify.yml.old`** ([OPERATOR_NOTIFICATION_CHANNELS.md](ops/OPERATOR_NOTIFICATION_CHANNELS.md) §4.1.1). Pause again only deliberately (same doc).
+**Prevents:** Extra Python anti-patterns; complements CodeQL. **Slack:** **`Slack CI failure notify`** (`workflow_call`, lists **`Semgrep`** next to **`CI`**, etc.) ships on **`origin`** as **`.github/workflows/slack-ci-failure-notify.yml`**; a **private snapshot** for pause drills lives under **`docs/private/raw_pastes/cursor-incident/slack-ci-failure-notify.yml.old`** ([OPERATOR_NOTIFICATION_CHANNELS.md](ops/OPERATOR_NOTIFICATION_CHANNELS.md) §4.1.1). Pause again only deliberately (same doc).
+
+---
+
+### 4b. Zizmor (workflow static analysis)
+
+**Why:** GitHub Actions workflows are code — misconfigured `permissions`, unpinned actions, or dangerous `pull_request_target` patterns are supply-chain and abuse risks. **Zizmor** scans `.github/workflows/` for those classes of issues.
+
+## What we do (Zizmor):
+
+- **CI:** [`.github/workflows/zizmor.yml`](../.github/workflows/zizmor.yml) runs on push/PR via **`zizmorcore/zizmor-action`** (SHA-pinned). **Advisory** by default unless **`ZIZMOR_ENFORCE`** / repo **`ENFORCE_ZIZMOR`** is set — see [OPERATOR_NOTIFICATION_CHANNELS.md](ops/OPERATOR_NOTIFICATION_CHANNELS.md) and **`scripts/workflow-security-lint.sh`**.
+- **Local:** `uvx zizmor .github/workflows/` (same path as **`workflow-security-lint.sh`**). **`check-all`** runs Zizmor in the **default** security tier and **fails** on findings (shift-left mirror of a strict posture before merge).
+
+**Prevents:** Workflow misconfigurations that Bandit/Semgrep do not see.
+
+---
+
+### 4c. `check-all` as unified CI mirror (tiered)
+
+**Why:** Contributors on the **Linux primary** dev workstation and agents should run **one** local ritual that matches **what CI will run**, without re-typing job commands from five workflow files.
+
+## Tiers (`./scripts/check-all.sh` / `.\scripts\check-all.ps1`)
+
+| Tier | When | What (after existing gatekeeper, Rust, plans-stats, hubs, Pester, pre-commit, pytest) |
+| ---- | ---- | ---------------------------------------------------------------------------------------- |
+| **Default (offline-capable)** | Every pre-PR / agent slice | **Bandit** — `uv run bandit -c pyproject.toml -r api core config connectors database file_scan report main.py -ll -q` (same paths as QUALITY doc + CI product scope). **Zizmor** — `uvx zizmor .github/workflows/`. |
+| **Opt-in `--enforced` / `-Enforced`** | Before security-sensitive PRs; when Semgrep CI is the worry | **+ Semgrep** — `uvx semgrep scan --config p/python --metrics=off` with the same **`--exclude-rule`** as [`.github/workflows/semgrep.yml`](../.github/workflows/semgrep.yml), **`--error .`**. Requires network for `uvx`. |
+
+**Fail-collect:** The security tier runs **all** scans in the tier, then reports **every** failure (no fail-fast within Bandit / Zizmor / Semgrep). Earlier gates (PII gatekeeper, Rust, pre-commit) still abort immediately — see **`scripts/check-all-security-scans.sh`** / **`.ps1`**.
+
+**Not in default `check-all` (separate CI jobs):** CodeQL, Sonar, pip-audit, SBOM image build — run those via CI or dedicated scripts; do not bloat the daily loop.
+
+### Future waves (same doc — not implemented in #1044)
+
+| Wave | Intent | Status |
+| ---- | ------ | ------ |
+| **Wave 2** | Optional **pre-commit** hooks for Bandit / Zizmor (subset, fast) | Deferred — track in this section |
+| **Wave 3** | Cursor rule: **run `check-all --enforced` before PR** when the slice touches connectors, workflows, or auth | Deferred — pointer in **§10** below |
+
+---
+
+### ROI — shift-left economics
+
+Running **`check-all`** locally (default tier) trades **~2–5 minutes** on the dev PC for **avoiding a full CI round-trip** (queue + matrix + Semgrep container), which is typically **15–40+ minutes** wall-clock when a Bandit or workflow finding fails late.
+
+| Finding class | Without local mirror | With `check-all` default tier |
+| ------------- | ------------------- | ----------------------------- |
+| Bandit on connectors | Fails in CI **Bandit** job after lint+test already ran | Surfaces in one local pass |
+| Workflow permission drift | Fails in **Zizmor** workflow (or stays advisory until enforced) | Surfaces before push |
+| Semgrep SQLAlchemy FP path | Only when **`--enforced`** or CI Semgrep | Operator/agent opt-in — matches container command |
+
+**Token-aware habit:** Use **`./scripts/check-all.sh --skip-pre-commit`** only when iterating on tests; run **full** `check-all` before opening the PR. Use **`--enforced`** when the diff touches **security surfaces** listed in Wave 3 — not on every docs-only slice.
 
 ---
 
@@ -153,6 +204,7 @@ This document suggests **additional layers** (tools, habits, and workflow) to ke
 
 - When you add a **new** quality or security check (e.g. Ruff in CI, Bandit, a new Sonar rule): update the **quality rule** and **skill** with the new command and what to avoid. Keep TESTING.md and this doc in sync.
 - Consider a short **rule** that fires when editing config or connector code: "Use parameterized queries; no secrets in logs; run security tests after change."
+- **`check-all` mirror (#1044):** Default local gate = **`./scripts/check-all.sh`** / **`.\scripts\check-all.ps1`** (Bandit + Zizmor after pre-commit/pytest). Use **`--enforced`** / **`-Enforced`** for Semgrep parity before security-sensitive PRs — see **§4c** above. **Wave 3 (future):** codify "run `--enforced` before PR" in **`.cursor/rules/quality-sonarqube-codeql.mdc`** when the slice touches connectors, workflows, or auth.
 
 **Prevents:** Regressions and bad habits from creeping in during daily edits.
 
@@ -165,6 +217,8 @@ This document suggests **additional layers** (tools, habits, and workflow) to ke
 | Lint (pre-commit) in CI | Same hooks as `.pre-commit-config.yaml`    | Low    | Drift vs local hooks, failed lint job                        |
 | Pre-commit (local)      | Catch on `git commit`                      | Low    | Failed CI, rework                                            |
 | Bandit                  | Python security patterns (CI **medium+**)  | Low    | Anti-patterns tests may miss; **low** triage in plan Phase 3 |
+| Zizmor                  | GitHub Actions workflow hygiene            | Low    | Permission/pinning drift before CI                           |
+| `check-all` mirror      | Local tiered CI parity (Bandit+Zizmor+opt Semgrep) | Low | Late CI failures, rework loops                       |
 | Semgrep                 | Custom + community SAST                    | Medium | Extra vulnerability/bug patterns                             |
 | mypy                    | Type safety                                | Medium | Refactor bugs, wrong types                                   |
 | MD029 / fix script      | Avoid doc rework                           | Low    | Repeated manual numbering fixes                              |
@@ -178,7 +232,7 @@ This document suggests **additional layers** (tools, habits, and workflow) to ke
 
 ## What you might not be paying attention to yet
 
-1. **Lint vs local** – CI runs **`pre-commit run --all-files`**; install **`uv run pre-commit install`** so **`git commit`** matches.
+1. **Lint vs local** – CI runs **`pre-commit run --all-files`**; install **`uv run pre-commit install`** so **`git commit`** matches. **`check-all`** adds **Bandit + Zizmor** (default) and optional **`--enforced`** Semgrep — see **§4c**.
 1. **MD029 and semantic lists** – The fix script can overwrite intentional 1/2/3 numbering; see [ADR 0001](adr/ADR-0001-markdown-fix-script-md029-and-semantic-step-lists.md).
 1. **Branch protection** – Enable when required check names are stable (include **Semgrep** if merge-blocking). See [WORKFLOW_DEFERRED_FOLLOWUPS.md](ops/WORKFLOW_DEFERRED_FOLLOWUPS.md).
 1. **Types** – mypy is gradual dev-only until triage (§5).

--- a/docs/QUALITY_WORKFLOW_RECOMMENDATIONS.pt_BR.md
+++ b/docs/QUALITY_WORKFLOW_RECOMMENDATIONS.pt_BR.md
@@ -70,9 +70,60 @@ Este documento sugere **camadas adicionais** (ferramentas, hábitos e fluxo de t
 #### O que fazemos (Semgrep):
 
 - **GitHub Actions:** [`.github/workflows/semgrep.yml`](../.github/workflows/semgrep.yml) roda em push/PR para `main`/`master` usando o container oficial **`semgrep/semgrep`**, ruleset **`p/python`**, **`--metrics=off`** e uma **regra excluída** documentada nos comentários do workflow (falso positivo em caminhos `sqlalchemy.text` verificados).
-- **Local (opcional):** `uvx semgrep scan --config p/python --metrics=off` (adicione o mesmo `--exclude-rule` do workflow para paridade). Regras customizadas podem ficar sob `.semgrep/` no futuro.
+- **Local (opcional):** `uvx semgrep scan --config p/python --metrics=off` com o mesmo **`--exclude-rule`** do workflow (veja **§ check-all espelho unificado** abaixo). Regras customizadas podem ficar sob `.semgrep/` no futuro.
 
 **Previne:** Padrões extras de vulnerabilidade/bug em Python; complementa o CodeQL.
+
+---
+
+### 4b. Zizmor (análise estática de workflows)
+
+**Por quê:** Workflows do GitHub Actions são código — `permissions` mal configuradas, actions sem pin ou padrões perigosos de `pull_request_target` são riscos de cadeia de suprimentos e abuso. O **Zizmor** varre `.github/workflows/` nessas classes de problema.
+
+#### O que fazemos (Zizmor):
+
+- **CI:** [`.github/workflows/zizmor.yml`](../.github/workflows/zizmor.yml) roda em push/PR via **`zizmorcore/zizmor-action`** (SHA fixo). **Avisório** por padrão, salvo **`ZIZMOR_ENFORCE`** / **`ENFORCE_ZIZMOR`** no repo — veja [OPERATOR_NOTIFICATION_CHANNELS.md](ops/OPERATOR_NOTIFICATION_CHANNELS.md) e **`scripts/workflow-security-lint.sh`**.
+- **Local:** `uvx zizmor .github/workflows/` (mesmo caminho que **`workflow-security-lint.sh`**). O **`check-all`** executa Zizmor no tier **padrão** de security scans e **falha** em achados (postura shift-left antes do merge).
+
+**Previne:** Misconfigurações de workflow que Bandit/Semgrep não veem.
+
+---
+
+### 4c. `check-all` como espelho unificado do CI (tiered)
+
+**Por quê:** Contribuidores na estação **Linux primary** e agentes devem rodar **um** ritual local que espelha **o que o CI vai rodar**, sem redigitar comandos de cinco workflows.
+
+#### Tiers (`./scripts/check-all.sh` / `.\scripts\check-all.ps1`)
+
+| Tier | Quando | O quê (após gatekeeper, Rust, plans-stats, hubs, Pester, pre-commit, pytest) |
+| ---- | ------ | ---------------------------------------------------------------------------- |
+| **Padrão (offline-capable)** | Todo pré-PR / slice do agente | **Bandit** — `uv run bandit -c pyproject.toml -r api core config connectors database file_scan report main.py -ll -q`. **Zizmor** — `uvx zizmor .github/workflows/`. |
+| **Opt-in `--enforced` / `-Enforced`** | Antes de PRs sensíveis à segurança | **+ Semgrep** — `uvx semgrep scan --config p/python --metrics=off` com o mesmo **`--exclude-rule`** de [`.github/workflows/semgrep.yml`](../.github/workflows/semgrep.yml), **`--error .`**. Requer rede para `uvx`. |
+
+**Fail-collect:** O tier de security scans roda **todos** os scans do tier e só então reporta **todas** as falhas (sem fail-fast entre Bandit / Zizmor / Semgrep). Gates anteriores (gatekeeper PII, Rust, pre-commit) ainda abortam imediatamente — veja **`scripts/check-all-security-scans.sh`** / **`.ps1`**.
+
+**Fora do `check-all` padrão (jobs CI separados):** CodeQL, Sonar, pip-audit, build SBOM — rodar via CI ou scripts dedicados.
+
+#### Ondas futuras (mesmo doc — fora do escopo de #1044)
+
+| Onda | Intenção | Status |
+| ---- | -------- | ------ |
+| **Onda 2** | Hooks **pre-commit** opcionais para Bandit / Zizmor (subconjunto rápido) | Adiado |
+| **Onda 3** | Regra Cursor: **`check-all --enforced` antes de PR** quando o slice toca conectores, workflows ou auth | Adiado — ponteiro na **§10** |
+
+---
+
+### ROI — economia shift-left
+
+Rodar **`check-all`** localmente (tier padrão) troca **~2–5 minutos** no PC de dev por **evitar uma volta completa no CI** (fila + matriz + container Semgrep), tipicamente **15–40+ minutos** quando Bandit ou workflow falham tarde.
+
+| Classe de achado | Sem espelho local | Com tier padrão do `check-all` |
+| ---------------- | ----------------- | ------------------------------ |
+| Bandit em connectors | Falha no job **Bandit** depois de lint+test | Surge num passe local |
+| Drift de permissão em workflow | Falha no workflow **Zizmor** (ou fica avisório) | Surge antes do push |
+| Caminho FP SQLAlchemy no Semgrep | Só com **`--enforced`** ou Semgrep no CI | Opt-in operador/agente — mesmo comando do container |
+
+**Hábito token-aware:** Use **`./scripts/check-all.sh --skip-pre-commit`** só ao iterar testes; rode **`check-all` completo** antes de abrir o PR. Use **`--enforced`** quando o diff tocar **superfícies de segurança** da Onda 3 — não em todo slice só de docs.
 
 ---
 
@@ -154,6 +205,7 @@ Este documento sugere **camadas adicionais** (ferramentas, hábitos e fluxo de t
 
 - Ao adicionar uma **nova** verificação de qualidade ou segurança (ex.: Ruff no CI, Bandit, nova regra do Sonar): atualize a **regra de qualidade** e a **skill** com o novo comando e o que evitar. Manter TESTING.md e este doc em sincronia.
 - Considerar uma **regra** curta que dispare ao editar config ou código de conector: "Use queries parametrizadas; sem segredos em logs; execute testes de segurança após mudança."
+- **Espelho `check-all` (#1044):** Gate local padrão = **`./scripts/check-all.sh`** / **`.\scripts\check-all.ps1`** (Bandit + Zizmor após pre-commit/pytest). Use **`--enforced`** / **`-Enforced`** para paridade Semgrep antes de PRs sensíveis — veja **§4c**. **Onda 3 (futuro):** codificar "rodar `--enforced` antes do PR" em **`.cursor/rules/quality-sonarqube-codeql.mdc`** quando o slice tocar conectores, workflows ou auth.
 
 **Previne:** Regressões e maus hábitos que se infiltram durante edições cotidianas.
 
@@ -166,6 +218,8 @@ Este documento sugere **camadas adicionais** (ferramentas, hábitos e fluxo de t
 | Lint (pre-commit) no CI   | Mesmos hooks que `.pre-commit-config.yaml`         | Baixo  | Deriva em relação a hooks locais, job de lint falhando          |
 | Pre-commit (local)        | Capturar no `git commit`                           | Baixo  | CI falhando, retrabalho                                         |
 | Bandit                    | Padrões de segurança Python (CI **medium+**)       | Baixo  | Antipadrões que testes podem perder; triagem **low** na Phase 3 |
+| Zizmor                    | Higiene de workflows GitHub Actions                | Baixo  | Deriva de permissões/pins antes do CI                          |
+| Espelho `check-all`       | Paridade local tiered (Bandit+Zizmor+Semgrep opt.) | Baixo  | Falhas tardias no CI, loops de retrabalho                     |
 | Semgrep                   | SAST customizado + comunidade                      | Médio  | Padrões extras de vulnerabilidade/bug                           |
 | mypy                      | Segurança de tipos                                 | Médio  | Bugs de refatoração, tipos errados                              |
 | MD029 / script de correção | Evitar retrabalho em docs                         | Baixo  | Correções manuais repetidas de numeração                        |
@@ -179,7 +233,7 @@ Este documento sugere **camadas adicionais** (ferramentas, hábitos e fluxo de t
 
 ## O que você pode não estar monitorando ainda
 
-1. **Lint vs local** — CI roda **`pre-commit run --all-files`**; instale **`uv run pre-commit install`** para que **`git commit`** tenha paridade.
+1. **Lint vs local** — CI roda **`pre-commit run --all-files`**; instale **`uv run pre-commit install`** para que **`git commit`** tenha paridade. **`check-all`** adiciona **Bandit + Zizmor** (padrão) e **Semgrep** opcional com **`--enforced`** — veja **§4c**.
 1. **MD029 e listas semânticas** — O script de correção pode sobrescrever numeração intencional 1/2/3; veja [ADR 0001](adr/ADR-0001-markdown-fix-script-md029-and-semantic-step-lists.md).
 1. **Proteção de branch** — Habilitar quando os nomes de checks obrigatórios estiverem estáveis (incluir **Semgrep** se quiser bloquear merges). Veja [WORKFLOW_DEFERRED_FOLLOWUPS.md](ops/WORKFLOW_DEFERRED_FOLLOWUPS.md).
 1. **Tipos** — mypy é gradual somente-dev até triagem (§5).

--- a/docs/SECURITY_GOVERNANCE_POSTURE_HUB.md
+++ b/docs/SECURITY_GOVERNANCE_POSTURE_HUB.md
@@ -50,8 +50,8 @@
 | Topic | Entry points |
 | ----- | ------------ |
 | CI gate stack | [ADR-0005](adr/ADR-0005-ci-quality-gates-and-supply-chain-scanning.md) · `.github/workflows/ci.yml` |
-| Local gate ritual | [`docs/TESTING.md`](TESTING.md) · `./scripts/check-all.sh` / `.\scripts\check-all.ps1` |
-| Static analysis | Bandit · Semgrep · CodeQL (workflows) · Ruff/pre-commit |
+| Local gate ritual | [`docs/TESTING.md`](TESTING.md) · [`docs/QUALITY_WORKFLOW_RECOMMENDATIONS.md`](QUALITY_WORKFLOW_RECOMMENDATIONS.md) · `./scripts/check-all.sh` / `.\scripts\check-all.ps1` |
+| Static analysis | Bandit · Semgrep · Zizmor · CodeQL (workflows) · Ruff/pre-commit |
 | No brittle mitigations | [ADR-0049](adr/ADR-0049-no-brittle-mitigations-robust-input-handling.md) |
 
 ## Provenance

--- a/docs/SECURITY_GOVERNANCE_POSTURE_HUB.pt_BR.md
+++ b/docs/SECURITY_GOVERNANCE_POSTURE_HUB.pt_BR.md
@@ -50,8 +50,8 @@
 | Tema | Pontos de entrada |
 | ---- | ----------------- |
 | Stack de gates no CI | [ADR-0005](adr/ADR-0005-ci-quality-gates-and-supply-chain-scanning.md) · `.github/workflows/ci.yml` |
-| Ritual de gate local | [`docs/TESTING.md`](TESTING.md) · `./scripts/check-all.sh` / `.\scripts\check-all.ps1` |
-| Análise estática | Bandit · Semgrep · CodeQL (workflows) · Ruff/pre-commit |
+| Ritual de gate local | [`docs/TESTING.md`](TESTING.md) · [`docs/QUALITY_WORKFLOW_RECOMMENDATIONS.pt_BR.md`](QUALITY_WORKFLOW_RECOMMENDATIONS.pt_BR.md) · `./scripts/check-all.sh` / `.\scripts\check-all.ps1` |
+| Análise estática | Bandit · Semgrep · Zizmor · CodeQL (workflows) · Ruff/pre-commit |
 | Sem mitigações frágeis | [ADR-0049](adr/ADR-0049-no-brittle-mitigations-robust-input-handling.md) |
 
 ## Proveniência

--- a/docs/ops/SCRIPTS_CROSS_PLATFORM_PAIRING.md
+++ b/docs/ops/SCRIPTS_CROSS_PLATFORM_PAIRING.md
@@ -19,14 +19,15 @@ Some **developer gates** and **thin wrappers** exist in **two forms**: **PowerSh
 
 | Intent | Windows | Linux / macOS |
 | ------ | ------- | ------------- |
-| Full gate (gatekeeper + plans + pre-commit + pytest) | `scripts/check-all.ps1` | `scripts/check-all.sh` |
+| Full gate (gatekeeper + plans + pre-commit + pytest + security scans) | `scripts/check-all.ps1` (`-Enforced` = + Semgrep) | `scripts/check-all.sh` (`--enforced` = + Semgrep) |
+| Security scans only (Bandit + Zizmor; fail-collect) | `scripts/check-all-security-scans.ps1` | `scripts/check-all-security-scans.sh` |
 | Lint / hooks only | `scripts/lint-only.ps1` | `scripts/lint-only.sh` |
 | Pytest subset (`-Path` / `-Keyword`) | `scripts/quick-test.ps1` | `scripts/quick-test.sh` |
 | Pre-commit + full pytest (no gatekeeper / no plans-stats) | `scripts/pre-commit-and-tests.ps1` | `scripts/pre-commit-and-tests.sh` |
 | PowerShell logic (Pester, pinned) | `scripts/run-pester.ps1` | *(same — `check-all.sh` calls `pwsh run-pester.ps1` when `pwsh` on PATH)* |
 | Stacked private repo sync (`docs/private/`) | `scripts/private-git-sync.ps1` | `scripts/private-git-sync.sh` |
 
-**Note:** `check-all.ps1` calls **`gatekeeper-audit.ps1`**, the **Rust guard** (`cargo fmt` / `check` / `test` under `rust/boar_fast_filter/`), then **`plans-stats.py --write`**, **`check_hubs.py`**, **`run-pester.ps1`** (Pester **5.6.1** under `tests/pester/` — issue **#984**), then delegates to **`pre-commit-and-tests.ps1`**. **`check-all.sh`** mirrors that order: PII seeds through **`uv run python scripts/gatekeeper_audit.py`** (no **`pwsh`** dependency — issue **`#560`**), same Rust guard with **`PYO3_USE_ABI3_FORWARD_COMPATIBILITY`**, **`plans-stats.py`**, **`check_hubs.py`**, **`run-pester.ps1`** when **`pwsh`** is available, then **`pre-commit-and-tests.sh`**. The **`pre-commit`** bundle also invokes **`gatekeeper_audit.py`** on each commit alongside the other guards. **`pre-commit-and-tests.*`** skips gatekeeper, Rust, and plans-stats by design; it runs **`tests/security/test_mem_integrity.py`** first (Hypothesis + PyO3), then the full pytest suite with **`--deselect`** on that file so the gate stays explicit without duplicating Hypothesis examples.
+**Note:** `check-all.ps1` calls **`gatekeeper-audit.ps1`**, the **Rust guard** (`cargo fmt` / `check` / `test` under `rust/boar_fast_filter/`), then **`plans-stats.py --write`**, **`check_hubs.py`**, **`run-pester.ps1`** (Pester **5.6.1** under `tests/pester/` — issue **#984**), then delegates to **`pre-commit-and-tests.ps1`**, then **`check-all-security-scans.*`** (Bandit + Zizmor; optional Semgrep with **`-Enforced`** / **`--enforced`** — issue **#1044**, fail-collect). **`check-all.sh`** mirrors that order: PII seeds through **`uv run python scripts/gatekeeper_audit.py`** (no **`pwsh`** dependency — issue **`#560`**), same Rust guard with **`PYO3_USE_ABI3_FORWARD_COMPATIBILITY`**, **`plans-stats.py`**, **`check_hubs.py`**, **`run-pester.ps1`** when **`pwsh`** is available, then **`pre-commit-and-tests.sh`**, then **`check-all-security-scans.sh`**. The **`pre-commit`** bundle also invokes **`gatekeeper_audit.py`** on each commit alongside the other guards. **`pre-commit-and-tests.*`** skips gatekeeper, Rust, and plans-stats by design; it runs **`tests/security/test_mem_integrity.py`** first (Hypothesis + PyO3), then the full pytest suite with **`--deselect`** on that file so the gate stays explicit without duplicating Hypothesis examples.
 
 ## Verification
 

--- a/docs/ops/SCRIPTS_CROSS_PLATFORM_PAIRING.pt_BR.md
+++ b/docs/ops/SCRIPTS_CROSS_PLATFORM_PAIRING.pt_BR.md
@@ -19,13 +19,14 @@ Alguns **gates de desenvolvimento** e **wrappers finos** existem em **duas forma
 
 | Intenção | Windows | Linux / macOS |
 | -------- | ------- | ------------- |
-| Gate completo (*gatekeeper* + planos + *pre-commit* + *pytest*) | `scripts/check-all.ps1` | `scripts/check-all.sh` |
+| Gate completo (*gatekeeper* + planos + *pre-commit* + *pytest* + security scans) | `scripts/check-all.ps1` (`-Enforced` = + Semgrep) | `scripts/check-all.sh` (`--enforced` = + Semgrep) |
+| Security scans só (Bandit + Zizmor; fail-collect) | `scripts/check-all-security-scans.ps1` | `scripts/check-all-security-scans.sh` |
 | Só *lint* / *hooks* | `scripts/lint-only.ps1` | `scripts/lint-only.sh` |
 | Subconjunto *pytest* (`-Path` / `-Keyword`) | `scripts/quick-test.ps1` | `scripts/quick-test.sh` |
 | *Pre-commit* + *pytest* completo (sem *gatekeeper* / sem *plans-stats*) | `scripts/pre-commit-and-tests.ps1` | `scripts/pre-commit-and-tests.sh` |
 | Sync do repo privado empilhado (`docs/private/`) | `scripts/private-git-sync.ps1` | `scripts/private-git-sync.sh` |
 
-**Nota:** o **`check-all.ps1`** chama **`gatekeeper-audit.ps1`**, o **guard Rust** (`cargo fmt` / `check` / `test` em **`rust/boar_fast_filter/`**), depois **`plans-stats.py --write`** e delega ao **`pre-commit-and-tests.ps1`**. O **`check-all.sh`** espelha essa ordem: seeds PII via **`uv run python scripts/gatekeeper_audit.py`** (sem depender de **`pwsh`** — issue **`#560`**), mesmo guard Rust com **`PYO3_USE_ABI3_FORWARD_COMPATIBILITY`**, **`plans-stats.py`**, depois **`pre-commit-and-tests.sh`**. O pacote **`pre-commit`** também chama **`gatekeeper_audit.py`** em cada commit com os outros *hooks*. Os **`pre-commit-and-tests.*`** ignoram *gatekeeper*, Rust e *plans-stats* de propósito; executam primeiro **`tests/security/test_mem_integrity.py`** (Hypothesis + PyO3) e depois o *pytest* completo com **`--deselect`** nesse arquivo para não duplicar os exemplos Hypothesis.
+**Nota:** o **`check-all.ps1`** chama **`gatekeeper-audit.ps1`**, o **guard Rust**, **`plans-stats.py --write`**, **`check_hubs.py`**, **`run-pester.ps1`**, delega ao **`pre-commit-and-tests.ps1`**, depois **`check-all-security-scans.*`** (Bandit + Zizmor; Semgrep opcional com **`-Enforced`** / **`--enforced`** — issue **#1044**, fail-collect). O **`check-all.sh`** espelha essa ordem (PII via **`gatekeeper_audit.py`**, Rust, planos, hubs, Pester quando há **`pwsh`**, **`pre-commit-and-tests.sh`**, **`check-all-security-scans.sh`**). Os **`pre-commit-and-tests.*`** ignoram *gatekeeper*, Rust e *plans-stats* de propósito; executam primeiro **`tests/security/test_mem_integrity.py`** (Hypothesis + PyO3) e depois o *pytest* completo com **`--deselect`** nesse arquivo.
 
 ## Verificação
 

--- a/scripts/check-all-security-scans.ps1
+++ b/scripts/check-all-security-scans.ps1
@@ -1,0 +1,66 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Security scan tier for check-all (#1044) - Bandit + Zizmor; optional Semgrep with -Enforced.
+
+.DESCRIPTION
+    Fail-collect: runs every scan, reports all failures at the end (no fail-fast within tier).
+    Commands mirror CI (.github/workflows/ci.yml bandit paths, semgrep.yml, zizmor on workflows/).
+#>
+param(
+    [switch]$Enforced = $false
+)
+
+$ErrorActionPreference = "Continue"
+$repoRoot = (Get-Item $PSScriptRoot).Parent.FullName
+Set-Location $repoRoot
+
+if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
+    Write-Host "check-all-security-scans: ABORTED: uv not on PATH." -ForegroundColor Red
+    exit 2
+}
+
+$failures = [System.Collections.Generic.List[string]]::new()
+
+function Invoke-SecurityScan {
+    param(
+        [string]$Name,
+        [scriptblock]$Block
+    )
+    Write-Host "=== Security scan: $Name ===" -ForegroundColor Cyan
+    & $Block
+    $code = $LASTEXITCODE
+    if ($code -ne 0) {
+        Write-Host "$Name... Failed (exit $code)" -ForegroundColor Red
+        [void]$failures.Add("$Name (exit $code)")
+    } else {
+        Write-Host "$Name... Passed" -ForegroundColor Green
+    }
+}
+
+Invoke-SecurityScan -Name "Bandit" -Block {
+    uv run bandit -c pyproject.toml -r api core config connectors database file_scan report main.py -ll -q
+}
+
+Invoke-SecurityScan -Name "Zizmor" -Block {
+    uvx zizmor .github/workflows/
+}
+
+if ($Enforced) {
+    Invoke-SecurityScan -Name "Semgrep" -Block {
+        uvx semgrep scan --config p/python --metrics=off `
+            --exclude-rule python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text `
+            --error .
+    }
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host "check-all-security-scans: FAILED ($($failures.Count) scan(s)):" -ForegroundColor Red
+    foreach ($item in $failures) {
+        Write-Host "  - $item" -ForegroundColor Red
+    }
+    exit 1
+}
+
+Write-Host "check-all-security-scans: OK (all security scans passed)." -ForegroundColor Green
+exit 0

--- a/scripts/check-all-security-scans.sh
+++ b/scripts/check-all-security-scans.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Security scan tier for check-all (issue #1044) — commands mirror CI workflows.
+# Invoked from check-all.sh / check-all.ps1; fail-collect (run all, report at end).
+# Usage (from repo root):
+#   ./scripts/check-all-security-scans.sh
+#   ./scripts/check-all-security-scans.sh --enforced   # + Semgrep (semgrep.yml parity)
+set -uo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+cd "$REPO_ROOT" || exit 2
+
+ENFORCED=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --enforced | -Enforced) ENFORCED=1 ;;
+    -h | --help)
+      echo "Usage: $0 [--enforced]"
+      echo "  Default: Bandit + Zizmor (offline-capable after uv sync)."
+      echo "  --enforced: also run Semgrep (network; mirrors semgrep.yml)."
+      exit 0
+      ;;
+    *)
+      echo "check-all-security-scans.sh: unknown option: $1" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "check-all-security-scans.sh: ABORTED: uv not on PATH." >&2
+  exit 2
+fi
+
+FAILURES=()
+
+_run_scan() {
+  local name="$1"
+  shift
+  echo "=== Security scan: $name ===" >&2
+  set +e
+  "$@"
+  local code=$?
+  set -e
+  if [[ "$code" -eq 0 ]]; then
+    printf '\033[32m%s\033[0m\n' "$name... Passed" >&2
+  else
+    printf '\033[31m%s\033[0m\n' "$name... Failed (exit $code)" >&2
+    FAILURES+=("$name (exit $code)")
+  fi
+}
+
+# Mirrors ci.yml job Bandit (strict paths; QUALITY_WORKFLOW_RECOMMENDATIONS.md).
+_run_scan "Bandit" uv run bandit -c pyproject.toml -r api core config connectors database file_scan report main.py -ll -q
+
+# Mirrors zizmor CLI target (workflow-security-lint.sh); enforced in check-all default tier.
+_run_scan "Zizmor" uvx zizmor .github/workflows/
+
+if [[ "$ENFORCED" -eq 1 ]]; then
+  # Mirrors .github/workflows/semgrep.yml (container command; uvx for local parity).
+  _run_scan "Semgrep" uvx semgrep scan --config p/python --metrics=off \
+    --exclude-rule python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text \
+    --error .
+fi
+
+if [[ "${#FAILURES[@]}" -gt 0 ]]; then
+  echo "check-all-security-scans.sh: FAILED (${#FAILURES[@]} scan(s)):" >&2
+  for item in "${FAILURES[@]}"; do
+    echo "  - $item" >&2
+  done
+  exit 1
+fi
+
+echo "check-all-security-scans.sh: OK (all security scans passed)." >&2
+exit 0

--- a/scripts/check-all.ps1
+++ b/scripts/check-all.ps1
@@ -10,7 +10,8 @@
 
 param(
     [switch]$SkipPreCommit = $false,
-    [switch]$IncludeVersionSmoke = $false
+    [switch]$IncludeVersionSmoke = $false,
+    [switch]$Enforced = $false
 )
 
 $ErrorActionPreference = "Stop"
@@ -101,6 +102,14 @@ if ($SkipPreCommit) {
 & "$repoRoot\scripts\pre-commit-and-tests.ps1" @argsList
 $exitCode = $LASTEXITCODE
 
+if ($exitCode -eq 0) {
+    Write-Host "=== check-all: security scans (Bandit + Zizmor; fail-collect) ===" -ForegroundColor Cyan
+    $secArgs = @()
+    if ($Enforced) { $secArgs += "-Enforced" }
+    & "$repoRoot\scripts\check-all-security-scans.ps1" @secArgs
+    $exitCode = $LASTEXITCODE
+}
+
 if ($exitCode -eq 0 -and $IncludeVersionSmoke) {
     $smokeScript = "$repoRoot\scripts\version-readiness-smoke.ps1"
     if (Test-Path -LiteralPath $smokeScript) {
@@ -113,7 +122,7 @@ if ($exitCode -eq 0 -and $IncludeVersionSmoke) {
 }
 
 if ($exitCode -eq 0) {
-    Write-Host "check-all: OK (pre-commit and pytest passed)." -ForegroundColor Green
+    Write-Host "check-all: OK (pre-commit, pytest, and security scans passed)." -ForegroundColor Green
 } else {
     Write-Host "check-all: FAILED (see output above)." -ForegroundColor Red
 }

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -6,6 +6,7 @@
 #   ./scripts/check-all.sh
 #   ./scripts/check-all.sh --skip-pre-commit
 #   ./scripts/check-all.sh --include-version-smoke
+#   ./scripts/check-all.sh --enforced          # + Semgrep (semgrep.yml parity; network)
 # On Windows, prefer .\scripts\check-all.ps1 (gatekeeper stays gatekeeper-audit.ps1 per #560).
 # Linux/macOS: gatekeeper_audit.py avoids a silent skip when pwsh is absent (issue #560).
 # Rust requires cargo on PATH.
@@ -18,14 +19,17 @@ cd "$REPO_ROOT" || exit 2
 
 SKIP_PRECOMMIT=0
 INCLUDE_VERSION_SMOKE=0
+ENFORCED=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -SkipPreCommit | --skip-pre-commit) SKIP_PRECOMMIT=1 ;;
     -IncludeVersionSmoke | --include-version-smoke) INCLUDE_VERSION_SMOKE=1 ;;
+    -Enforced | --enforced) ENFORCED=1 ;;
     -h | --help)
       echo "Usage: $0 [options]"
       echo "  --skip-pre-commit          Only run pytest (same as check-all.ps1 -SkipPreCommit)"
       echo "  --include-version-smoke    After success, run version-readiness-smoke.ps1 (requires pwsh)"
+      echo "  --enforced                 Also run Semgrep (mirrors semgrep.yml; needs network)"
       echo "  -h, --help                 This help"
       exit 0
       ;;
@@ -116,6 +120,16 @@ if [[ "$exit_code" -ne 0 ]]; then
   exit "$exit_code"
 fi
 
+sec_args=()
+if [[ "$ENFORCED" -eq 1 ]]; then
+  sec_args+=(--enforced)
+fi
+echo "=== check-all.sh: security scans (Bandit + Zizmor; fail-collect) ===" >&2
+if ! bash "$REPO_ROOT/scripts/check-all-security-scans.sh" "${sec_args[@]}"; then
+  echo "check-all.sh: FAILED security scan tier." >&2
+  exit 1
+fi
+
 if [[ "$INCLUDE_VERSION_SMOKE" -eq 1 ]]; then
   vsmoke="$REPO_ROOT/scripts/version-readiness-smoke.ps1"
   if [[ -f "$vsmoke" ]]; then
@@ -130,5 +144,5 @@ if [[ "$INCLUDE_VERSION_SMOKE" -eq 1 ]]; then
   fi
 fi
 
-echo "check-all.sh: OK (pre-commit and pytest passed)." >&2
+echo "check-all.sh: OK (pre-commit, pytest, and security scans passed)." >&2
 exit 0

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -769,6 +769,38 @@ def test_check_all_supports_optional_version_smoke():
     assert "version-readiness-smoke.ps1" in text
 
 
+def test_check_all_supports_enforced_security_tier():
+    """check-all exposes --enforced / -Enforced for Semgrep parity (#1044)."""
+    root = _project_root()
+    for rel in ("scripts/check-all.ps1", "scripts/check-all.sh"):
+        script = root / rel
+        if not script.exists():
+            continue
+        text = script.read_text(encoding="utf-8", errors="replace")
+        assert "Enforced" in text or "enforced" in text
+        assert "check-all-security-scans" in text
+
+
+def test_check_all_security_scans_mirror_ci_commands():
+    """Security scan tier uses CI-parity Bandit, Zizmor, and Semgrep commands."""
+    root = _project_root()
+    sh = root / "scripts" / "check-all-security-scans.sh"
+    ps1 = root / "scripts" / "check-all-security-scans.ps1"
+    assert sh.is_file() and ps1.is_file()
+    sh_text = sh.read_text(encoding="utf-8", errors="replace")
+    ps1_text = ps1.read_text(encoding="utf-8", errors="replace")
+    for text in (sh_text, ps1_text):
+        assert (
+            "bandit -c pyproject.toml -r api core config connectors database file_scan report main.py -ll -q"
+            in text
+        )
+        assert "uvx zizmor .github/workflows/" in text
+        assert "semgrep scan --config p/python --metrics=off" in text
+        assert "avoid-sqlalchemy-text.avoid-sqlalchemy-text" in text
+    assert "FAILURES" in sh_text
+    assert "failures" in ps1_text.lower()
+
+
 def test_pr_hygiene_mentions_gh_preflight():
     """pr-hygiene-remind includes gh preflight reminder and quick checks switch."""
     root = _project_root()
@@ -983,6 +1015,7 @@ def test_paired_dev_gate_shell_scripts_bash_syntax():
     root = _project_root()
     rels = (
         "scripts/check-all.sh",
+        "scripts/check-all-security-scans.sh",
         "scripts/lint-only.sh",
         "scripts/quick-test.sh",
         "scripts/pre-commit-and-tests.sh",


### PR DESCRIPTION
## Summary

- Extend **`check-all.sh`** / **`check-all.ps1`** with a **security scan tier** after pre-commit/pytest: **Bandit** + **Zizmor** (default, offline-capable); **`--enforced`** / **`-Enforced`** adds **Semgrep** (parity with `semgrep.yml`).
- New paired scripts **`check-all-security-scans.sh`** / **`.ps1`** implement **fail-collect** within the tier (all scans run, failures reported at end).
- Commands mirror CI/product scope: Bandit paths from QUALITY doc, `uvx zizmor .github/workflows/`, Semgrep with the same `--exclude-rule` as `.github/workflows/semgrep.yml`.
- Enrich **`docs/QUALITY_WORKFLOW_RECOMMENDATIONS.md`** (+ pt-BR): Zizmor layer, check-all unified mirror table, ROI shift-left section, Wave 2/3 deferred pointers.
- **`SECURITY_GOVERNANCE_POSTURE_HUB`** Code-quality row links to QUALITY_WORKFLOW; sync **quality** rule + skill (§10).

Closes #1044

## Test plan

- [x] `./scripts/check-all.sh` exit 0 (default tier)
- [x] `./scripts/check-all-security-scans.sh` Bandit + Zizmor green
- [x] `bash ./scripts/check-hubs.sh` green
- [x] `pytest tests/test_scripts.py` guards for `--enforced` + CI command strings
- [x] CI green on PR


Made with [Cursor](https://cursor.com)