### PR TITLE
feat(workflow): Maestro login-env parity and min-spec docs (#1003)

### DIFF
--- a/docs/ops/MAESTRO_ARCHITECTURE_AND_ROADMAP.md
+++ b/docs/ops/MAESTRO_ARCHITECTURE_AND_ROADMAP.md
@@ -18,7 +18,7 @@ Maestro exists because lab validation — real hosts, real SSH, real containers,
 | ------------ | --------------- |
 | Maestro (conductor) | `Maestro.ps1` — reads the score, controls tempo and sequence |
 | Section lead *(informally: capo di sezione — metaphor flavor only)* | `Handle-*.ps1` **handlers** — each owns its instrument section completely; the canonical term in code and docs is **handler** |
-| Musician | Lab node (LAB-NODE-01, LAB-NODE-03, LAB-T14, …) — the performer |
+| Musician | Lab node (inventory aliases such as `<lab-node-a>`, `<lab-node-b>`, …) — the performer |
 | Instrument / Voice (Persona) | The role each node plays: `docker`, `podman`, `baremetal`, `web`, `target_postgres`, … |
 | Score | `docs/private/homelab/data/inventory.json` — who plays what |
 | Performance (Completão) | One full run across all nodes, all personas, all target surfaces |
@@ -138,6 +138,17 @@ Handlers are additive — one node can have multiple. The inventory entry lists 
   "web_scheme": "http"
 }
 ```
+
+### 3.5 Lab min-spec floor (bare-metal / musl hosts)
+
+When bare-metal personas run `uv`, `maturin`, or optional ML stacks on resource-constrained lab nodes (notably **Alpine/musl** SBCs measured in GitHub issue **#1003**), two build constraints recur:
+
+| Constraint | Symptom | Mitigation |
+| ---------- | ------- | ---------- |
+| **crt-static** | Raw `cargo build` fails with *"does not support these crate types"* for PyO3 `cdylib` on musl when static CRT is the default | **`maturin`** injects `RUSTFLAGS="-C target-feature=-crt-static"` automatically; plain `cargo build` without that flag will fail on musl |
+| **sklearn-wheel** | `uv sync` attempts to compile **scikit-learn** from source on no-AVX / low-RAM Alpine hosts | Depends on a **pre-built wheel** from the **#782 Build-Once** pipeline (or accept degraded optional ML); see `labop-dep-doctor.sh` and `lab-completao-host-smoke.sh` |
+
+**Login-env parity (#1003):** non-interactive SSH and tmux sessions often omit `~/.local/bin` and `~/.cargo/env` from `PATH`. Maestro centralizes a remote bash prelude in `Lab-MaestroCommon.ps1` (`Get-MaestroRemoteLoginPathPrelude`) for all tmux-injected handlers; `Handle-web.ps1` and `lab-completao-host-smoke.sh` apply the same pattern before `uv` / `maturin`; `labop-gate-readiness.sh` probes `login-env:uv`, `login-env:cargo`, and `login-env:maturin` after `_ensure_login_path`.
 
 ---
 

--- a/docs/ops/MAESTRO_ARCHITECTURE_AND_ROADMAP.pt_BR.md
+++ b/docs/ops/MAESTRO_ARCHITECTURE_AND_ROADMAP.pt_BR.md
@@ -18,7 +18,7 @@ O Maestro existe porque a validação em laboratório — hosts reais, SSH real,
 | ------------- | ---------------------- |
 | Maestro (regente) | `Maestro.ps1` — lê a partitura, controla o andamento e a sequência |
 | Chefe de seção *(metáfora: capo di sezione — apenas narrativa)* | **Handlers** `Handle-*.ps1` — cada um lidera sua seção com total autonomia; o termo canônico é sempre **handler** |
-| Músico | Nó do lab (LAB-NODE-01, LAB-NODE-03, LAB-T14, …) — o performer |
+| Músico | Nó do lab (aliases do inventário como `<lab-node-a>`, `<lab-node-b>`, …) — o performer |
 | Instrumento / Voz (Persona) | O papel que cada nó desempenha: `docker`, `podman`, `baremetal`, `web`, `target_postgres`, … |
 | Partitura | `docs/private/homelab/data/inventory.json` — quem toca o quê |
 | Apresentação (Completão) | Um ciclo completo em todos os nós, todas as personas, todas as superfícies de alvo |
@@ -137,6 +137,17 @@ Handlers são aditivos — um nó pode ter múltiplos. A entrada do inventário 
   "web_scheme": "http"
 }
 ```
+
+### 3.5 Piso min-spec do lab (bare-metal / musl)
+
+Quando personas bare-metal executam `uv`, `maturin` ou stacks ML opcionais em nós de lab com poucos recursos (em especial **SBCs Alpine/musl** medidos na issue **#1003**), duas restrições de build se repetem:
+
+| Restrição | Sintoma | Mitigação |
+| --------- | ------- | --------- |
+| **crt-static** | `cargo build` cru falha com *"does not support these crate types"* para `cdylib` PyO3 em musl com CRT estático por padrão | O **`maturin`** injeta `RUSTFLAGS="-C target-feature=-crt-static"` automaticamente; `cargo build` sem essa flag falha em musl |
+| **sklearn-wheel** | `uv sync` tenta compilar **scikit-learn** from-source em Alpine sem AVX / com pouca RAM | Depende de **wheel pré-buildado** do pipeline **#782 Build-Once** (ou aceitar ML opcional degradado); ver `labop-dep-doctor.sh` e `lab-completao-host-smoke.sh` |
+
+**Paridade login-env (#1003):** sessões SSH e tmux não interativas costumam omitir `~/.local/bin` e `~/.cargo/env` do `PATH`. O Maestro centraliza um prelúdio bash remoto em `Lab-MaestroCommon.ps1` (`Get-MaestroRemoteLoginPathPrelude`) para todos os handlers injetados via tmux; `Handle-web.ps1` e `lab-completao-host-smoke.sh` aplicam o mesmo padrão antes de `uv` / `maturin`; `labop-gate-readiness.sh` sonda `login-env:uv`, `login-env:cargo` e `login-env:maturin` após `_ensure_login_path`.
 
 ---
 

--- a/scripts/build-rust-prefilter.ps1
+++ b/scripts/build-rust-prefilter.ps1
@@ -15,6 +15,9 @@ if (-not (Test-Path -LiteralPath $manifestPath)) {
     throw "Rust manifest not found: $manifestPath"
 }
 
+. (Join-Path $PSScriptRoot "maestro/Lab-MaestroCommon.ps1")
+Initialize-MaestroLoginToolPath
+
 Push-Location $repoRoot
 try {
     # maturin is a dev dependency (pyproject [dependency-groups].dev, #892), so it is

--- a/scripts/maestro/Handle-LicensingMatrix.ps1
+++ b/scripts/maestro/Handle-LicensingMatrix.ps1
@@ -20,6 +20,9 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+. (Join-Path $PSScriptRoot "Lab-MaestroCommon.ps1")
+Initialize-MaestroLoginToolPath
+
 function Write-MaestroStep {
     param(
         [Parameter(Mandatory = $true)]

--- a/scripts/maestro/Lab-MaestroCommon.ps1
+++ b/scripts/maestro/Lab-MaestroCommon.ps1
@@ -13,6 +13,32 @@
 
 Set-StrictMode -Version 2
 
+function Initialize-MaestroLoginToolPath {
+    <#
+    #1003: Non-interactive shells often omit ~/.local/bin and ~/.cargo/env from PATH.
+    Prepend operator tool paths before local uv/cargo/maturin invocations on the dev PC.
+    #>
+    $homeDir = if ($env:HOME) { $env:HOME } else { $env:USERPROFILE }
+    if (-not $homeDir) { return }
+    $cargoEnv = Join-Path $homeDir ".cargo" "env"
+    if (Test-Path -LiteralPath $cargoEnv) { . $cargoEnv }
+    foreach ($dir in @(
+            (Join-Path $homeDir ".local" "bin"),
+            (Join-Path $homeDir ".cargo" "bin")
+        )) {
+        if (Test-Path -LiteralPath $dir) {
+            $env:PATH = "$dir$([IO.Path]::PathSeparator)$env:PATH"
+        }
+    }
+}
+
+function Get-MaestroRemoteLoginPathPrelude {
+    <#
+    #1003: Bash prelude for SSH/tmux payloads (parity with lab-completao-host-smoke.sh).
+    #>
+    return 'export PATH="${HOME}/.local/bin:${PATH}"; [ -f "${HOME}/.cargo/env" ] && . "${HOME}/.cargo/env"; '
+}
+
 function Get-HandlerTmuxSessionName {
     param([Parameter(Mandatory = $true)][string]$Persona)
     # Per-persona session avoids C-c clobber on multi-persona nodes (#955).
@@ -357,7 +383,9 @@ function Invoke-HandlerTmuxPayload {
         "tmux has-session -t $session 2>/dev/null || tmux new-session -d -s $session ; "
     }
     # No C-c: dedicated session per persona (#955).
-    $tmuxCmd = "${create}tmux send-keys -t $session 'echo $PayloadB64 | base64 -d | bash' Enter"
+    # #1003: login-env PATH before decoded payload (non-interactive tmux lacks ~/.local/bin).
+    $prelude = Get-MaestroRemoteLoginPathPrelude
+    $tmuxCmd = "${create}tmux send-keys -t $session '${prelude}echo $PayloadB64 | base64 -d | bash' Enter"
     ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 `
         "$($Node.user)@$($Node.hostname)" "$tmuxCmd"
     return $LASTEXITCODE

--- a/scripts/maestro/handlers/Handle-web.ps1
+++ b/scripts/maestro/handlers/Handle-web.ps1
@@ -137,6 +137,8 @@ $portsJoined = ($candidatePorts -join " ")
 $benchPortFile = if ($benchTrackNormalized) { "~/.labop-web-port-$benchTrackNormalized" } else { "~/.labop-web-port" }
 $remoteStartCmd = @'
 set -e
+export PATH="${HOME}/.local/bin:${PATH}"
+[ -f "${HOME}/.cargo/env" ] && . "${HOME}/.cargo/env"
 cd __NODE_PATH__
 CHOSEN_PORT=""
 for P in __PORTS_JOINED__; do

--- a/tests/pester/Maestro-GateReadiness.Tests.ps1
+++ b/tests/pester/Maestro-GateReadiness.Tests.ps1
@@ -31,3 +31,58 @@ Describe 'labop-gate-readiness privilege probe (#1022)' {
         $raw | Should -Match '_FW_GUARD_PROBE_DONE'
     }
 }
+
+Describe 'Maestro login-env parity (#1003)' {
+    It 'Lab-MaestroCommon bootstraps local PATH before uv/cargo/maturin' {
+        $raw = Get-ScriptRaw 'scripts/maestro/Lab-MaestroCommon.ps1'
+        $raw | Should -Match 'function Initialize-MaestroLoginToolPath'
+        $raw | Should -Match '\.local/bin'
+        $raw | Should -Match '\.cargo/env'
+        $raw | Should -Match 'function Get-MaestroRemoteLoginPathPrelude'
+    }
+
+    It 'Invoke-HandlerTmuxPayload prepends remote login PATH before bash payload' {
+        $raw = Get-ScriptRaw 'scripts/maestro/Lab-MaestroCommon.ps1'
+        $raw | Should -Match 'Get-MaestroRemoteLoginPathPrelude'
+        $raw | Should -Match 'base64 -d \| bash'
+        $invokeIdx = $raw.IndexOf('function Invoke-HandlerTmuxPayload')
+        $preludeIdx = $raw.IndexOf('Get-MaestroRemoteLoginPathPrelude', $invokeIdx)
+        $preludeIdx | Should -BeGreaterThan $invokeIdx
+    }
+
+    It 'Handle-LicensingMatrix initializes login PATH before uv run' {
+        $raw = Get-ScriptRaw 'scripts/maestro/Handle-LicensingMatrix.ps1'
+        $initIdx = $raw.IndexOf('Initialize-MaestroLoginToolPath')
+        $uvIdx = $raw.IndexOf('& uv run python')
+        $initIdx | Should -BeGreaterThan -1
+        $uvIdx | Should -BeGreaterThan $initIdx
+    }
+
+    It 'Handle-web remote recovery bootstraps PATH and uses login shell for uv' {
+        $raw = Get-ScriptRaw 'scripts/maestro/handlers/Handle-web.ps1'
+        $raw | Should -Match '\.local/bin'
+        $raw | Should -Match '\.cargo/env'
+        $raw | Should -Match 'bash -lc'
+        $raw | Should -Match 'command -v uv'
+    }
+
+    It 'build-rust-prefilter initializes login PATH before uv run maturin' {
+        $raw = Get-ScriptRaw 'scripts/build-rust-prefilter.ps1'
+        $raw | Should -Match 'Initialize-MaestroLoginToolPath'
+        $raw | Should -Match 'uv run maturin'
+        $initIdx = $raw.IndexOf('Initialize-MaestroLoginToolPath')
+        $maturinIdx = $raw.IndexOf('uv run maturin')
+        $initIdx | Should -BeLessThan $maturinIdx
+    }
+
+    It 'lab-completao-host-smoke and gate-readiness mirror login-env for uv/cargo' {
+        $smoke = Get-ScriptRaw 'scripts/lab-completao-host-smoke.sh'
+        $gate = Get-ScriptRaw 'scripts/labop-gate-readiness.sh'
+        $smoke | Should -Match '\.local/bin'
+        $smoke | Should -Match 'uv run maturin'
+        $gate | Should -Match '_ensure_login_path'
+        $gate | Should -Match 'login-env:uv'
+        $gate | Should -Match 'for bin in cargo maturin'
+        $gate | Should -Match 'login-env:\$bin'
+    }
+}

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -1345,6 +1345,34 @@ def test_check_all_login_env_cargo_bootstrap() -> None:
     assert ".cargo" in ps1
 
 
+def test_maestro_handlers_login_env_parity_1003() -> None:
+    """#1003: Handle-* and tmux payloads bootstrap login PATH before uv/cargo/maturin."""
+    root = _project_root()
+    common = (root / "scripts" / "maestro" / "Lab-MaestroCommon.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    licensing = (root / "scripts" / "maestro" / "Handle-LicensingMatrix.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    web = (root / "scripts" / "maestro" / "handlers" / "Handle-web.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    rust_ps1 = (root / "scripts" / "build-rust-prefilter.ps1").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "Initialize-MaestroLoginToolPath" in common
+    assert "Get-MaestroRemoteLoginPathPrelude" in common
+    invoke_idx = common.index("function Invoke-HandlerTmuxPayload")
+    assert common.index("Get-MaestroRemoteLoginPathPrelude", invoke_idx) > invoke_idx
+    assert licensing.index("Initialize-MaestroLoginToolPath") < licensing.index(
+        "& uv run python"
+    )
+    assert ".local/bin" in web and "bash -lc" in web
+    assert rust_ps1.index("Initialize-MaestroLoginToolPath") < rust_ps1.index(
+        "uv run maturin"
+    )
+
+
 def _run_fw_guard_subnet_check(
     root: Path, subnet: str
 ) -> subprocess.CompletedProcess[str]:


### PR DESCRIPTION
## Summary

- **AC 2:** Centraliza paridade login-env no Maestro — `Initialize-MaestroLoginToolPath` / `Get-MaestroRemoteLoginPathPrelude` em `Lab-MaestroCommon.ps1` (tmux payloads), `Handle-LicensingMatrix.ps1`, `Handle-web.ps1` (SSH recovery) e `build-rust-prefilter.ps1`; cobertura Pester + pytest em `Maestro-GateReadiness.Tests.ps1` e `test_maestro_handlers_login_env_parity_1003`.
- **AC 3:** Seção **3.5 Lab min-spec floor** em `MAESTRO_ARCHITECTURE_AND_ROADMAP.md` (+ pt_BR): `crt-static` / `RUSTFLAGS` para musl+cdylib e **sklearn-wheel** / Build-Once (#782).
- **Higiene:** placeholders genéricos na tabela de metáfora (hostnames de lab removidos do doc público).

AC 1 (`check-all` twins) já estava em `main` — sem alteração neste PR.

Closes #1003

## Test plan

- [x] `./scripts/check-all.sh` verde (Pester 30/30 + pytest completo)
- [x] PII seed gate passa nos docs Maestro editados

Made with [Cursor](https://cursor.com)