### PR TITLE
ci(gitleaks): binary install — no org-license Action

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -38,11 +38,18 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Gitleaks
-        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
-        env:
-          # GITLEAKS_LICENSE only needed for org features; OSS works without.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # gitleaks BINARIO (open-source, gratis) — evita a licenca que a Action exige em ORG.
+      # Ver DataBoar/maestro#10. Confirmar VER com a release atual antes do merge.
+      - name: gitleaks (binary, no org-license)
+        run: |
+          VER="8.30.1"
+          BASE="https://github.com/gitleaks/gitleaks/releases/download/v${VER}"
+          TARBALL="gitleaks_${VER}_linux_x64.tar.gz"
+          curl -sSfL "${BASE}/${TARBALL}" -o "${TARBALL}"
+          curl -sSfL "${BASE}/gitleaks_${VER}_checksums.txt" -o gl.sums
+          grep " ${TARBALL}$" gl.sums | sha256sum -c -
+          tar -xzf "${TARBALL}" gitleaks
+          ./gitleaks git . --no-banner --redact --exit-code 1
 
   slack-notify-on-failure:
     name: Slack CI failure notify

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -239,7 +239,14 @@ def test_gitleaks_workflow_present_and_valid() -> None:
         if isinstance(step, dict) and step.get("uses")
     ]
     assert any("actions/checkout@" in line for line in uses_lines)
-    assert any("gitleaks/gitleaks-action@" in line for line in uses_lines)
+    run_blob = "\n".join(
+        str(step.get("run", ""))
+        for step in steps
+        if isinstance(step, dict) and step.get("run")
+    )
+    assert "gitleaks_${VER}_linux_x64.tar.gz" in run_blob
+    assert "sha256sum -c" in run_blob
+    assert "./gitleaks git ." in run_blob
 
 
 def test_gitleaks_yml_pins_actions_to_shas() -> None:
@@ -252,7 +259,7 @@ def test_gitleaks_yml_pins_actions_to_shas() -> None:
             continue
         if "./.github/workflows/" in code:
             continue
-        if not any(p in code for p in ("actions/", "github/", "gitleaks/")):
+        if not any(p in code for p in ("actions/", "github/")):
             continue
         assert sha_40.search(code), (
             f"expected full commit SHA in uses line: {line.strip()!r}"


### PR DESCRIPTION
## Summary

Replicates the proven recipe from DataBoar/maestro#11 (DataBoar/maestro#10):

- Replace `gitleaks/gitleaks-action` with pinned **gitleaks 8.30.1** binary download + `sha256sum -c` (tarball name unchanged).
- Update `tests/test_github_workflows.py` guards for the binary run block.

## Test plan

- [x] `pytest tests/test_github_workflows.py::test_gitleaks_*` local
- [ ] CI job **scan** (Gitleaks workflow) green before merge

Refs: DataBoar/maestro#10, DataBoar/maestro#11 (merged).

Made with [Cursor](https://cursor.com)