### PR TITLE
chore: add FUNDING.yml (Sponsor → Patreon DataBoar)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+patreon: DataBoar


### PR DESCRIPTION
## Summary

Adds `.github/FUNDING.yml` with community Patreon vanity only:

```yaml
patreon: DataBoar
```

Enables the public **Sponsor** button → `patreon.com/DataBoar`. Commercial tiers/licensing stay on product surfaces (low-key community lane).

Closes #1110.

## Test plan

- [x] File is single-line vanity (no UTM / full URL)
- [ ] After merge: confirm **Sponsor** on repo resolves to Patreon `DataBoar`

Made with [Cursor](https://cursor.com)