### PR TITLE
[P0][ci] chore(release): 1.7.4.post3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ Human-readable summary of user-facing changes. **Detailed release notes:** [docs
 
 ---
 
+## 1.7.4.post3 (pending PyPI dispatch)
+
+> Post-release on the **`1.7.4`** public line. **`[project] version = 1.7.4.post3`** and **`[tool.databoar] maturity_build = 211`** (ADR-0073 dual counter policy).
+
+### Fixed (post3)
+
+- **Dependency security:** `soupsieve` **2.8.3 → 2.8.4** to remove findings for **CVE-2026-49476** and **CVE-2026-49477** ([#1177](https://github.com/FabioLeitao/data-boar/pull/1177)).
+- **SQL connector observability:** SQL sampling failures now surface in `scan_failures` (bundle includes [#1144](https://github.com/FabioLeitao/data-boar/pull/1144), issue [#1140](https://github.com/FabioLeitao/data-boar/issues/1140)).
+- **Archive observability:** encrypted/corrupt archive members now surface in `scan_failures` (bundle includes [#1146](https://github.com/FabioLeitao/data-boar/pull/1146), issue [#828](https://github.com/FabioLeitao/data-boar/issues/828)).
+
+### Changed (post3)
+
+- **Onboarding docs (`pipx`):** RHEL9-family (`python3.12`) and Alpine/musl (toolchain prerequisites) edge cases documented ([#1175](https://github.com/FabioLeitao/data-boar/pull/1175)).
+- **Contributor command docs:** canonical `uv export --frozen --no-emit-project -o requirements.txt` guidance applied in EN/pt-BR ([#1179](https://github.com/FabioLeitao/data-boar/pull/1179), issue [#1176](https://github.com/FabioLeitao/data-boar/issues/1176)).
+
+---
+
 ## 1.7.4 (2026-06-26)
 
 > **Stable GA** on the **`1.7.4` line** — release gate **#406** closed with Maestro Deep 5-host completão evidence ([#1021](https://github.com/FabioLeitao/data-boar/issues/1021)). **#970** was a **premature** stable bump/tag **without** the gate — corrected by **ADR-0072**; **`1.7.4` is not VOID**. Public version **`1.7.4`**; **`[tool.databoar] maturity_build = 201`** (side-channel per **ADR-0073** — #976, #977).

--- a/core/about.py
+++ b/core/about.py
@@ -11,7 +11,7 @@ def _package_version() -> str:
 
         return version("data-boar")
     except Exception:
-        return "1.7.4.post2"
+        return "1.7.4.post3"
 
 
 def get_http_user_agent() -> str:

--- a/docs/releases/1.7.4.post3.md
+++ b/docs/releases/1.7.4.post3.md
@@ -1,0 +1,49 @@
+# Release 1.7.4.post3 (PyPI publish counter)
+
+**Status:** Pending PyPI upload after merge (operator **`publish-pypi`** `workflow_dispatch`).
+
+**Public line (marketing):** **`1.7.4`** — README, man pages, stakeholder copy unchanged.
+
+**Build / PyPI / About:** **`1.7.4.post3`** — PEP 440 post-release (publish counter per [ADR-0073](../adr/ADR-0073-version-scheme-octet-maturity-and-roadmap.md) § *PyPI dual counters*).
+
+---
+
+## Mandatory map: `postN` ↔ `maturity_build`
+
+Per ADR-0073: **`postN`** counts **PyPI uploads**; **`maturity_build`** counts **discrete fixes** and may run ahead. This map is the mandatory audit trail.
+
+| PyPI / `[project] version` | `maturity_build` (octet) | Notes |
+| --- | --- | --- |
+| **`1.7.4`** | **`.201`** | GA on PyPI (immutable); release PR **#1024** |
+| **`1.7.4.post1`** | **`.202`** | SQL drivers → optional extras ([#1047](https://github.com/FabioLeitao/data-boar/issues/1047)) — published |
+| *(fix, unpublished on PyPI)* | **`.203`** | [#1026](https://github.com/FabioLeitao/data-boar/pull/1026) |
+| *(fix, unpublished on PyPI)* | **`.204`** | [#1028](https://github.com/FabioLeitao/data-boar/pull/1028) |
+| *(fix, unpublished on PyPI)* | **`.205`** | Deploy / packaging fix train |
+| *(fix, unpublished on PyPI)* | **`.206`** | `main.py --version` without config |
+| *(fix, unpublished on PyPI)* | **`.207`** | `fix(connectors)` symlink / reparse-point loop guard ([#1080](https://github.com/FabioLeitao/data-boar/pull/1080)) |
+| **`1.7.4.post2`** | **`.208`** | Prior upload on this line |
+| *(fix, unpublished on PyPI)* | **`.209`** | SQL sampling failures now surface in `scan_failures` ([#1140](https://github.com/FabioLeitao/data-boar/issues/1140), [#1144](https://github.com/FabioLeitao/data-boar/pull/1144)) |
+| *(fix, unpublished on PyPI)* | **`.210`** | Encrypted/corrupt archive members now surface in `scan_failures` (open-core slice of [#828](https://github.com/FabioLeitao/data-boar/issues/828), [#1146](https://github.com/FabioLeitao/data-boar/pull/1146)) |
+| **`1.7.4.post3`** | **`.211`** | **This upload** — `soupsieve` CVE fix ([#1177](https://github.com/FabioLeitao/data-boar/pull/1177)) |
+
+---
+
+## Highlights (why post3)
+
+- **Dependency security:** `soupsieve` **2.8.3 → 2.8.4** to remove findings for **CVE-2026-49476** and **CVE-2026-49477** ([#1177](https://github.com/FabioLeitao/data-boar/pull/1177)).
+- **Observability reliability (already on `main`, now bundled in this publish):**
+  - SQL sampling failures are no longer silently swallowed; they are tracked in `scan_failures` ([#1140](https://github.com/FabioLeitao/data-boar/issues/1140), [#1144](https://github.com/FabioLeitao/data-boar/pull/1144)).
+  - Encrypted/corrupt archive members are now tracked in `scan_failures` instead of appearing as silently clean ([#828](https://github.com/FabioLeitao/data-boar/issues/828), [#1146](https://github.com/FabioLeitao/data-boar/pull/1146)).
+- **Docs bundled (no maturity octet increment):**
+  - `pipx` onboarding edge-case guidance for RHEL9-family and Alpine/musl ([#1175](https://github.com/FabioLeitao/data-boar/pull/1175)).
+  - Canonical `uv export` command fix in contributor docs ([#1176](https://github.com/FabioLeitao/data-boar/issues/1176), [#1179](https://github.com/FabioLeitao/data-boar/pull/1179)).
+
+---
+
+## Install
+
+```bash
+pip install 'data-boar==1.7.4.post3'
+```
+
+See [USAGE.md](../USAGE.md), [QUICKSTART.md](../QUICKSTART.md), and [TROUBLESHOOTING.md](../TROUBLESHOOTING.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-boar"
-version = "1.7.4.post2"
+version = "1.7.4.post3"
 description = "Data Boar — compliance-aware discovery and mapping of personal and sensitive data across databases, files, and APIs (LGPD, GDPR, CCPA, and configurable frameworks)."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -302,6 +302,6 @@ dev = [
 ]
 
 # Operator-only maturity octet (ADR-0073). Never copy into [project].version.
-# postN <-> maturity_build map: docs/releases/1.7.4.post2.md (canonical; includes post1 rows).
+# postN <-> maturity_build map: docs/releases/1.7.4.post3.md (canonical; includes post1/post2 rows).
 [tool.databoar]
-maturity_build = 208
+maturity_build = 211

--- a/tests/test_pyproject_sql_extras.py
+++ b/tests/test_pyproject_sql_extras.py
@@ -64,11 +64,11 @@ def test_sql_optional_extras_present() -> None:
 def test_maturity_build_bumped_for_packaging_fix() -> None:
     data = _load_pyproject()
     maturity = data.get("tool", {}).get("databoar", {}).get("maturity_build")
-    assert maturity == 208
+    assert maturity == 211
 
 
 def test_version_is_174_post_release_not_semver_bump() -> None:
     version = _load_pyproject().get("project", {}).get("version")
-    assert version == "1.7.4.post2"
+    assert version == "1.7.4.post3"
     assert not str(version).startswith("1.7.5")
     assert not str(version).startswith("1.8.")

--- a/uv.lock
+++ b/uv.lock
@@ -757,7 +757,7 @@ validation = [
 
 [[package]]
 name = "data-boar"
-version = "1.7.4.post2"
+version = "1.7.4.post3"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-doc" },


### PR DESCRIPTION
## Summary
- prepara a release `1.7.4.post3` sem publish: bump de `[project] version` para `1.7.4.post3` e `[tool.databoar] maturity_build` para `211`
- adiciona `docs/releases/1.7.4.post3.md` com o mapa de octetos e o racional do post3
- atualiza `CHANGELOG.md`, `core/about.py`, `tests/test_pyproject_sql_extras.py` e `uv.lock` para manter consistência de versão

## Octet map (post3)
- `.209` -> `#1140` (connector scan_failures)
- `.210` -> `#828` (encrypted archive members em scan_failures, slice open-core)
- `.211` -> `#1177` (soupsieve CVE-2026-49476/49477)

## Validation
- [x] `./scripts/check-all.sh --enforced`
- [x] `requirements.txt` sem drift
- [x] `uv.lock` com mudança apenas da versão do projeto nesta branch

## References
- #1177
- #1140
- #828


Made with [Cursor](https://cursor.com)