### PR TITLE
[P1][ci] fix(actions): corrige pins mortos do operator-gated-reopen (ressuscita guardrail)

### DIFF
--- a/.github/workflows/operator-gated-reopen.yml
+++ b/.github/workflows/operator-gated-reopen.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (SSHSIG verify)
-        uses: actions/checkout@de0fac2e93aed2066c531a69177474906a2fae52 # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           sparse-checkout: |
             scripts/gate_trailer_attest.py
@@ -34,7 +34,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b3a37ed9102738c8e3c5c0c03e8e2a2b0 # v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 


### PR DESCRIPTION
## Summary
- corrige os dois SHAs mortos em `.github/workflows/operator-gated-reopen.yml`
- restaura o guardrail de reopen para issues `operator-gated` sem quebrar por pin inválido

## Changes
- `actions/checkout` `de0fac2e...` (`v6.0.2`) -> `df4cb1c0...` (`v6.0.3`)
- `actions/setup-python` `a309ff8b...` -> `a309ff8b426b58ec0e2a45f0f869d46889d02405` (`v6.2.0`)

## Validation
- [x] `./scripts/check-all.sh --enforced`

Closes #990


Made with [Cursor](https://cursor.com)