### PR TITLE
refactor(api): remove routes import cycle in webauthn HTML gate

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -85,6 +85,7 @@ from api.locale_i18n import (
     negotiate_locale_tag,
 )
 from api.webauthn_html_gate import (
+    configure_routes_context as configure_webauthn_html_gate_context,
     csrf_context_for_request,
     is_locale_login_get,
     safe_next_path,
@@ -672,6 +673,9 @@ def _get_engine():
         _audit_engine = AuditEngine(cfg)
         get_license_guard(cfg)
     return _audit_engine
+
+
+configure_webauthn_html_gate_context(_get_config, _get_engine)
 
 
 def _license_public_dict() -> dict:

--- a/api/webauthn_html_gate.py
+++ b/api/webauthn_html_gate.py
@@ -18,6 +18,16 @@ from core.webauthn_rp import session_cookie
 from core.webauthn_rp.html_csrf import issue_html_csrf_token, verify_html_csrf_token
 from core.webauthn_rp.settings import resolve_token_secret, webauthn_block
 
+_routes_get_config: Any | None = None
+_routes_get_engine: Any | None = None
+
+
+def configure_routes_context(get_config: Any, get_engine: Any) -> None:
+    """Inject route-layer config/engine resolvers without importing api.routes."""
+    global _routes_get_config, _routes_get_engine
+    _routes_get_config = get_config
+    _routes_get_engine = get_engine
+
 
 def locale_path_segments(path: str) -> tuple[str | None, list[str]]:
     """
@@ -71,9 +81,9 @@ def safe_next_path(next_q: str | None, fallback: str) -> str:
 
 
 def _routes_config_engine():
-    import api.routes as routes_mod
-
-    return routes_mod._get_config(), routes_mod._get_engine()
+    if _routes_get_config is None or _routes_get_engine is None:
+        raise RuntimeError("webauthn_html_gate route context was not configured")
+    return _routes_get_config(), _routes_get_engine()
 
 
 def csrf_context_for_request(request: Request) -> dict[str, str]:


### PR DESCRIPTION
## Summary
- move webauthn HTML gate route-context wiring to callback injection (`configure_routes_context`) instead of importing `api.routes` from `api/webauthn_html_gate.py`
- configure those callbacks from `api/routes.py` at module load, preserving behavior while removing the structural import cycle risk
- keep this PR strictly scoped as a follow-up to #1202 / merged PR #1206 (no reopening of #1206 scope)

## Test plan
- [x] `./scripts/check-all.sh --enforced`
- [x] `uv run python scripts/gate_change_tripwire.py --base origin/main`

## References
- Follow-up: #1202
- Prior merged PR: #1206

Made with [Cursor](https://cursor.com)