### PR TITLE
fix(config): redact DSN/URL embedded credentials in /config (#1137)

### DIFF
--- a/config/redact_config.py
+++ b/config/redact_config.py
@@ -8,7 +8,9 @@ Used by Phase A of the secrets plan: UI never shows or writes plain secrets.
 from __future__ import annotations
 
 import copy
+import re
 from typing import Any
+from urllib.parse import parse_qsl, quote, urlencode, urlsplit, urlunsplit
 
 # Placeholder shown in UI instead of secret values; also used to detect "do not overwrite" on save
 REDACTED_PLACEHOLDER = "# REDACTED - set via env or vault"
@@ -31,6 +33,13 @@ _SECRET_SUBSTRINGS = frozenset(
 
 # Keys that contain a substring above but are not secrets (e.g. OAuth token_url is a URL).
 _SECRET_KEY_ALLOWLIST = frozenset({"token_url"})
+_INLINE_SECRET_PLACEHOLDER = "***"
+_URL_QUERY_SECRET_SUBSTRINGS = frozenset(
+    {"password", "pwd", "secret", "token", "api_key", "apikey", "pass"}
+)
+_GENERIC_KV_SECRET_RE = re.compile(
+    r"(?i)(\b(?:password|pwd|secret|token|api_key|apikey|pass)\b\s*[:=]\s*)([^;\s,&]+)"
+)
 
 
 def _is_secret_key(key: str) -> bool:
@@ -38,6 +47,48 @@ def _is_secret_key(key: str) -> bool:
     if k in _SECRET_KEY_ALLOWLIST:
         return False
     return any(sub in k for sub in _SECRET_SUBSTRINGS)
+
+
+def _is_sensitive_query_key(key: str) -> bool:
+    k = key.strip().lower()
+    return any(sub in k for sub in _URL_QUERY_SECRET_SUBSTRINGS)
+
+
+def _redact_url_like_string(value: str) -> str:
+    if "://" not in value:
+        return value
+    split = urlsplit(value)
+    if not split.scheme:
+        return value
+    out_netloc = split.netloc
+    if split.username is not None and split.password is not None:
+        username = quote(split.username, safe="")
+        host = split.hostname or ""
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        port_part = f":{split.port}" if split.port is not None else ""
+        out_netloc = f"{username}:{_INLINE_SECRET_PLACEHOLDER}@{host}{port_part}"
+    pairs = parse_qsl(split.query, keep_blank_values=True)
+    if pairs:
+        redacted_pairs = [
+            (k, _INLINE_SECRET_PLACEHOLDER if _is_sensitive_query_key(k) else v)
+            for k, v in pairs
+        ]
+        out_query = urlencode(redacted_pairs, doseq=True)
+    else:
+        out_query = split.query
+    return urlunsplit((split.scheme, out_netloc, split.path, out_query, split.fragment))
+
+
+def _redact_generic_key_value_pairs(value: str) -> str:
+    return _GENERIC_KV_SECRET_RE.sub(
+        lambda m: f"{m.group(1)}{_INLINE_SECRET_PLACEHOLDER}", value
+    )
+
+
+def _redact_inline_string_secrets(value: str) -> str:
+    url_redacted = _redact_url_like_string(value)
+    return _redact_generic_key_value_pairs(url_redacted)
 
 
 def _redact_value(val: Any) -> Any:
@@ -68,9 +119,12 @@ def _walk_redact(obj: Any, in_api: bool = False) -> Any:
                 else:
                     out[k] = copy.deepcopy(v)
             else:
-                out[k] = _walk_redact(
-                    v, in_api=(in_api or (isinstance(k, str) and k == "api"))
-                )
+                if isinstance(v, str):
+                    out[k] = _redact_inline_string_secrets(v)
+                else:
+                    out[k] = _walk_redact(
+                        v, in_api=(in_api or (isinstance(k, str) and k == "api"))
+                    )
         return out
     if isinstance(obj, list):
         return [_walk_redact(i, in_api) for i in obj]
@@ -104,6 +158,12 @@ def _walk_merge(
         ):
             return current
         return submitted
+
+    if isinstance(submitted, str) and isinstance(current, str):
+        if submitted.strip() == REDACTED_PLACEHOLDER:
+            return current
+        if submitted == _redact_inline_string_secrets(current):
+            return current
 
     if isinstance(submitted, dict) and isinstance(current, dict):
         out = dict(current)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -460,6 +460,106 @@ def test_merge_config_on_save_preserves_secrets_when_submitted_is_placeholder():
     assert merged2["targets"][0]["pass"] == "newpass"
 
 
+def test_merge_config_on_save_preserves_current_when_submitted_is_redacted_dsn():
+    """Round-trip save keeps current DSN when submitted value is redacted display form."""
+    from config.redact_config import merge_config_on_save
+
+    current = {
+        "targets": [
+            {
+                "name": "db1",
+                "url": (
+                    "postgresql://db_user:RealSecret@db.example.com:5432/appdb"
+                    "?token=sensitive-token"
+                ),
+            }
+        ]
+    }
+    submitted = {
+        "targets": [
+            {
+                "name": "db1",
+                "url": ("postgresql://db_user:***@db.example.com:5432/appdb?token=***"),
+            }
+        ]
+    }
+    merged = merge_config_on_save(submitted, current)
+    assert merged["targets"][0]["url"] == current["targets"][0]["url"]
+
+
+def test_redact_config_for_display_masks_dsn_userinfo_and_query_secrets():
+    """DSN/URL credential fragments are redacted even when key name is not secret-like."""
+    from config.redact_config import redact_config_for_display
+
+    data = {
+        "targets": [
+            {
+                "name": "db1",
+                "type": "database",
+                "connection_string": (
+                    "postgresql://audit_user:UltraSecretPwd@db.example.com:5432/audit_db"
+                    "?sslmode=require&token=abc123&password=hidden-value"
+                ),
+            }
+        ],
+        "api": {"token_url": "https://idp.example.com/oauth/token"},
+    }
+    redacted = redact_config_for_display(data)
+    dsn = redacted["targets"][0]["connection_string"]
+    assert "UltraSecretPwd" not in dsn
+    assert "abc123" not in dsn
+    assert "hidden-value" not in dsn
+    assert "db.example.com:5432/audit_db" in dsn
+    assert "audit_user:***@" in dsn
+    assert "token=***" in dsn
+    assert "password=***" in dsn
+    # token_url key remains allowlisted by name when it only carries endpoint path.
+    assert redacted["api"]["token_url"] == "https://idp.example.com/oauth/token"
+
+
+def test_config_get_never_exposes_password_in_dsn_url(tmp_path):
+    """GET /config must not render DSN/URL passwords in the HTML editor payload."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        f"""targets:
+  - name: db1
+    type: database
+    url: postgresql://db_user:SuperSecretPass@db.example.com:5432/appdb?token=abc123
+report:
+  output_dir: {tmp_path}
+api:
+  port: 8088
+  require_api_key: true
+  api_key: secret123
+sqlite_path: {tmp_path}/audit.db
+""",
+        encoding="utf-8",
+    )
+    import api.routes as routes
+
+    orig_path = routes._config_path
+    orig_cfg = routes._config
+    orig_engine = routes._audit_engine
+    try:
+        routes._config_path = str(config_path)
+        routes._config = None
+        routes._audit_engine = None
+        from fastapi.testclient import TestClient
+
+        client = TestClient(routes.app)
+        resp = client.get("/config", headers={"X-API-Key": "secret123"})
+        assert resp.status_code == 200
+        html = resp.text
+        assert "SuperSecretPass" not in html
+        assert "abc123" not in html
+        assert "db.example.com:5432/appdb" in html
+        assert "db_user:***@" in html
+    finally:
+        routes._config_path = orig_path
+        routes._config = orig_cfg
+        routes._audit_engine = orig_engine
+
+
 def test_normalize_config_resolves_pass_from_env_and_user_from_env(monkeypatch):
     """Loader resolves pass_from_env, password_from_env, user_from_env for targets."""
     from config.loader import normalize_config


### PR DESCRIPTION
## Summary
- extend `config/redact_config.py` with value-based secret masking for DSN/URL/connection-string strings in any config depth, even when the key name is non-secret (for example `url`, `dsn`, `connection_string`)
- redact only inline credential material (`user:password@` password segment and sensitive query keys such as `password`, `pwd`, `secret`, `token`, `api_key`) while preserving host/port/path visibility for operator troubleshooting
- harden merge-on-save round-trip so already-redacted inline DSN/URL values from the config editor do not overwrite the current secret with placeholder text
- add regression coverage asserting both `redact_config_for_display` and `GET /config` never expose DSN/URL passwords/tokens

## Test plan
- [x] `uv run pytest tests/test_security.py -k "redact_config_for_display_masks_dsn_userinfo_and_query_secrets or config_get_never_exposes_password_in_dsn_url or merge_config_on_save_preserves_current_when_submitted_is_redacted_dsn or redact_config_for_display_redacts_secrets or merge_config_on_save_preserves_secrets_when_submitted_is_placeholder" -q`
- [x] `uv run python scripts/gate_change_tripwire.py --base origin/main`
- [x] `./scripts/check-all.sh --enforced`

Closes #1137

Made with [Cursor](https://cursor.com)