### PR TITLE
fix(prefilter): preserve recall parity for compliance profile signals

### DIFF
--- a/core/discovery_orchestrator.py
+++ b/core/discovery_orchestrator.py
@@ -39,6 +39,8 @@ class BoarDiscovery:
         target_latency_ms: float = 200.0,
         sleep_fn: Any = time.sleep,
         enable_pro_prefilter: bool = False,
+        profile_terms: Sequence[str] | None = None,
+        profile_regexes: Sequence[str] | None = None,
     ) -> None:
         self.db = DataDiscoveryEngine(db_url)
         self.validator = PIIValidator()
@@ -50,7 +52,11 @@ class BoarDiscovery:
             target_latency_ms=target_latency_ms,
             max_workers=self.worker_processes,
         )
-        self.prefilter: PreFilter = get_prefilter(enable_pro=enable_pro_prefilter)
+        self.prefilter: PreFilter = get_prefilter(
+            enable_pro=enable_pro_prefilter,
+            profile_terms=profile_terms,
+            profile_regexes=profile_regexes,
+        )
 
     def run_full_scan(self) -> dict[str, Any]:
         """
@@ -163,6 +169,7 @@ class BoarOrchestrator:
         target_latency_ms: float = 250.0,
         batch_limit: int = 1000,
         sleep_fn: Any = time.sleep,
+        profile_signals_active: bool = False,
     ) -> None:
         resolved_workers = max(1, int(max_workers or 1))
         self.db = DataDiscoveryEngine(db_url)
@@ -173,6 +180,7 @@ class BoarOrchestrator:
         )
         self.results: list[str] = []
         self.sleep_fn = sleep_fn
+        self.profile_signals_active = bool(profile_signals_active)
 
     def run_discovery(self, table_name: str) -> list[str]:
         """
@@ -191,7 +199,9 @@ class BoarOrchestrator:
             while len(futures) >= allowed:
                 self._collect_completed(futures)
 
-            future = executor.submit(process_chunk_pro, batch)
+            future = executor.submit(
+                process_chunk_pro, batch, self.profile_signals_active
+            )
             futures[future] = None
             self._collect_completed(futures)
 

--- a/core/prefilter.py
+++ b/core/prefilter.py
@@ -8,6 +8,7 @@ the downstream raw findings contract.
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 from typing import Protocol, runtime_checkable
 
 _CPF_CANDIDATE_RX = re.compile(r"\d{3}\D?\d{3}\D?\d{3}\D?\d{2}")
@@ -34,7 +35,31 @@ class OpenCorePreFilter:
 
     name = "open_core_regex_prefilter_v1"
 
+    def __init__(
+        self,
+        *,
+        profile_terms: Sequence[str] | None = None,
+        profile_regexes: Sequence[str] | None = None,
+        recall_first_passthrough_on_profile: bool = False,
+    ) -> None:
+        self._profile_terms = tuple(
+            t.strip().lower()
+            for t in (profile_terms or [])
+            if isinstance(t, str) and t.strip()
+        )
+        self._profile_regexes = tuple(self._compile_profile_regexes(profile_regexes))
+        self._profile_signals_active = bool(
+            self._profile_terms or self._profile_regexes
+        )
+        self._recall_first_passthrough_on_profile = bool(
+            recall_first_passthrough_on_profile
+        )
+
     def filter_candidates(self, payloads: list[str]) -> list[str]:
+        if self._profile_signals_active and self._recall_first_passthrough_on_profile:
+            # Recall-first contract: when profile signals are active and this prefilter
+            # is used as an eliminating gate, pass all rows downstream.
+            return list(payloads)
         out: list[str] = []
         for item in payloads:
             if self._looks_sensitive(item):
@@ -42,9 +67,29 @@ class OpenCorePreFilter:
         return out
 
     @staticmethod
-    def _looks_sensitive(value: str) -> bool:
+    def _compile_profile_regexes(
+        profile_regexes: Sequence[str] | None,
+    ) -> list[re.Pattern[str]]:
+        out: list[re.Pattern[str]] = []
+        for raw in profile_regexes or ():
+            if not isinstance(raw, str):
+                continue
+            pattern = raw.strip()
+            if not pattern:
+                continue
+            try:
+                out.append(re.compile(pattern, re.IGNORECASE))
+            except re.error:
+                # Invalid profile regex should not break scanning.
+                continue
+        return out
+
+    def _looks_sensitive(self, value: str) -> bool:
         if not value:
             return False
-        return bool(
-            _CPF_CANDIDATE_RX.search(value) or _EMAIL_CANDIDATE_RX.search(value)
-        )
+        if _CPF_CANDIDATE_RX.search(value) or _EMAIL_CANDIDATE_RX.search(value):
+            return True
+        lowered = value.lower()
+        if any(term in lowered for term in self._profile_terms):
+            return True
+        return any(rx.search(value) for rx in self._profile_regexes)

--- a/pro/engine.py
+++ b/pro/engine.py
@@ -36,13 +36,24 @@ class ProScanner:
         *,
         deep_scan_fn: Callable[[list[str]], Any] | None = None,
         legacy_scan_fn: Callable[[list[str]], Any] | None = None,
+        profile_terms: Sequence[str] | None = None,
+        profile_regexes: Sequence[str] | None = None,
     ) -> None:
-        self._fallback = OpenCorePreFilter()
+        self._profile_signals_active = bool(profile_terms or profile_regexes)
+        self._fallback = OpenCorePreFilter(
+            profile_terms=profile_terms,
+            profile_regexes=profile_regexes,
+            recall_first_passthrough_on_profile=True,
+        )
         self._deep_scan_fn = deep_scan_fn
         self._legacy_scan_fn = legacy_scan_fn
         self.fast_filter = FastFilter() if RUST_AVAILABLE and FastFilter else None
 
     def scan(self, data_batch: list[str]) -> Any:
+        if self._profile_signals_active:
+            if self._deep_scan_fn is None:
+                return data_batch
+            return self._deep_scan_fn(data_batch)
         if self.fast_filter is not None:
             suspect_indices = self.fast_filter.filter_batch(data_batch)
             filtered_data = [
@@ -60,7 +71,9 @@ class ProScanner:
         return self._legacy_scan_fn(filtered_data)
 
 
-def process_chunk_worker(chunk: Sequence[str]) -> list[str]:
+def process_chunk_worker(
+    chunk: Sequence[str], profile_signals_active: bool = False
+) -> list[str]:
     """
     Process worker entrypoint for ``ProcessPoolExecutor``.
 
@@ -105,6 +118,9 @@ def process_chunk_worker(chunk: Sequence[str]) -> list[str]:
 
     if _worker_filter_instance is None and RUST_AVAILABLE and FastFilter is not None:
         _worker_filter_instance = FastFilter()
+
+    if profile_signals_active:
+        return deep_ml_analysis(data_batch)
 
     if _worker_filter_instance is not None:
         suspect_indices = _worker_filter_instance.filter_batch(data_batch)

--- a/pro/prefilter.py
+++ b/pro/prefilter.py
@@ -7,6 +7,7 @@ Open Core filter so the pipeline stays functional.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any
 
 from core.prefilter import OpenCorePreFilter, PreFilter
@@ -21,8 +22,18 @@ class ProPreFilter:
 
     name = "pro_prefilter_auto_v1"
 
-    def __init__(self) -> None:
-        self._fallback = OpenCorePreFilter()
+    def __init__(
+        self,
+        *,
+        profile_terms: Sequence[str] | None = None,
+        profile_regexes: Sequence[str] | None = None,
+    ) -> None:
+        self._profile_signals_active = bool(profile_terms or profile_regexes)
+        self._fallback = OpenCorePreFilter(
+            profile_terms=profile_terms,
+            profile_regexes=profile_regexes,
+            recall_first_passthrough_on_profile=True,
+        )
         self._rust_impl = self._load_rust_impl()
 
     @staticmethod
@@ -41,6 +52,9 @@ class ProPreFilter:
             return None
 
     def filter_candidates(self, payloads: list[str]) -> list[str]:
+        if self._profile_signals_active:
+            # Recall-first parity: custom profile signals loaded => do not eliminate rows.
+            return list(payloads)
         if self._rust_impl is None:
             return self._fallback.filter_candidates(payloads)
         try:
@@ -56,12 +70,23 @@ class ProPreFilter:
         return self._fallback.filter_candidates(payloads)
 
 
-def get_prefilter(*, enable_pro: bool = False) -> PreFilter:
+def get_prefilter(
+    *,
+    enable_pro: bool = False,
+    profile_terms: Sequence[str] | None = None,
+    profile_regexes: Sequence[str] | None = None,
+) -> PreFilter:
     """
     Return active pre-filter implementation.
 
     ``enable_pro=False`` keeps Open Core behavior; ``True`` tries Pro+ then fallback.
     """
     if enable_pro:
-        return ProPreFilter()
-    return OpenCorePreFilter()
+        return ProPreFilter(
+            profile_terms=profile_terms,
+            profile_regexes=profile_regexes,
+        )
+    return OpenCorePreFilter(
+        profile_terms=profile_terms,
+        profile_regexes=profile_regexes,
+    )

--- a/pro/worker_logic.py
+++ b/pro/worker_logic.py
@@ -51,7 +51,9 @@ _CARD_PATTERN = re.compile(r"\b(?:\d[ -]?){13,19}\b")
 _filter_instance: Any = None
 
 
-def process_chunk_pro(chunk: Sequence[Any]) -> list[str]:
+def process_chunk_pro(
+    chunk: Sequence[Any], profile_signals_active: bool = False
+) -> list[str]:
     """
     Process one chunk in a worker process.
 
@@ -68,6 +70,9 @@ def process_chunk_pro(chunk: Sequence[Any]) -> list[str]:
 
     if HAS_RUST and _filter_instance is None and FastFilter is not None:
         _filter_instance = FastFilter()
+
+    if profile_signals_active:
+        return data_strings
 
     if HAS_RUST and _filter_instance is not None:
         suspect_indices = _filter_instance.filter_batch(data_strings)

--- a/tests/test_prefilter_contract.py
+++ b/tests/test_prefilter_contract.py
@@ -30,3 +30,14 @@ def test_pro_prefilter_fallback_without_rust() -> None:
 def test_get_prefilter_switch() -> None:
     assert get_prefilter(enable_pro=False).name == "open_core_regex_prefilter_v1"
     assert get_prefilter(enable_pro=True).name == "pro_prefilter_auto_v1"
+
+
+def test_prefilter_recall_first_passthrough_when_profile_terms_active() -> None:
+    rows = ["clean text", "diagnóstico oncológico", "biometric_template"]
+    oc = OpenCorePreFilter(
+        profile_terms=["diagnóstico oncológico"],
+        recall_first_passthrough_on_profile=True,
+    )
+    pro = ProPreFilter(profile_terms=["diagnóstico oncológico"])
+    assert oc.filter_candidates(rows) == rows
+    assert pro.filter_candidates(rows) == rows

--- a/tests/test_prefilter_recall_parity_1198.py
+++ b/tests/test_prefilter_recall_parity_1198.py
@@ -1,0 +1,94 @@
+"""Recall-first parity guard for issue #1198 (prefilter must not drop profile hits)."""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+
+import pytest
+import yaml
+
+from core.scanner import DataScanner
+from pro.prefilter import ProPreFilter
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+COMPLIANCE_SAMPLES_DIR = REPO_ROOT / "docs" / "compliance-samples"
+
+
+def _compliance_sample_yaml_files() -> list[Path]:
+    if not COMPLIANCE_SAMPLES_DIR.is_dir():
+        return []
+    return sorted(COMPLIANCE_SAMPLES_DIR.glob("compliance-sample-*.yaml"))
+
+
+def _sensitive_terms(sample_data: dict) -> list[str]:
+    terms = sample_data.get("terms") or []
+    out: list[str] = []
+    for item in terms:
+        if not isinstance(item, dict):
+            continue
+        text = str(item.get("text") or "").strip()
+        if not text:
+            continue
+        label = item.get("label")
+        label_s = str(label).strip().lower()
+        if label in (1, True) or label_s in {"1", "true", "yes", "sensitive"}:
+            out.append(text)
+    return out
+
+
+def _regex_patterns(sample_data: dict) -> list[str]:
+    regex_items = sample_data.get("regex") or []
+    out: list[str] = []
+    for item in regex_items:
+        if not isinstance(item, dict):
+            continue
+        pattern = str(item.get("pattern") or "").strip()
+        if pattern:
+            out.append(pattern)
+    return out
+
+
+def _findings_fingerprint(
+    scanner: DataScanner, probes: list[str]
+) -> Counter[tuple[str, str, str]]:
+    found: Counter[tuple[str, str, str]] = Counter()
+    for probe in probes:
+        result = scanner.scan_column("profile_probe", probe)
+        if result.get("sensitivity_level") != "LOW":
+            found[
+                (
+                    str(result.get("sensitivity_level") or ""),
+                    str(result.get("norm_tag") or ""),
+                    str(result.get("pattern_detected") or ""),
+                )
+            ] += 1
+    return found
+
+
+@pytest.mark.parametrize(
+    "sample_path", _compliance_sample_yaml_files(), ids=lambda p: p.name
+)
+def test_prefilter_recall_parity_for_compliance_samples(sample_path: Path) -> None:
+    """
+    Golden rule: findings_with_prefilter == findings_without_prefilter.
+
+    For each compliance sample YAML, use synthetic probes from declared sensitive terms.
+    """
+    sample_data = yaml.safe_load(sample_path.read_text(encoding="utf-8")) or {}
+    terms = _sensitive_terms(sample_data)
+    regexes = _regex_patterns(sample_data)
+    assert terms, f"{sample_path.name}: expected at least one sensitive term for probes"
+    probes = [f"probe {term} probe" for term in terms[:12]]
+
+    scanner = DataScanner(
+        regex_overrides_path=str(sample_path),
+        ml_patterns_path=str(sample_path),
+    )
+    baseline = _findings_fingerprint(scanner, probes)
+
+    prefilter = ProPreFilter(profile_terms=terms, profile_regexes=regexes)
+    filtered_probes = prefilter.filter_candidates(probes)
+    accelerated = _findings_fingerprint(scanner, filtered_probes)
+
+    assert accelerated == baseline


### PR DESCRIPTION
## Summary
- make Pro/OpenCore prefilter recall-first when custom profile signals (terms/regex) are active, bypassing eliminating behavior before downstream detection
- thread profile-signal context through Pro/discovery paths (`core/discovery_orchestrator.py`, `pro/prefilter.py`, `pro/engine.py`, `pro/worker_logic.py`) without changing default behavior when no profile is active
- add a differential parity regression test parametrized over every `docs/compliance-samples/compliance-sample-*.yaml`, asserting findings are identical with and without prefiltering

## Test plan
- [x] `uv run python scripts/gate_change_tripwire.py --base origin/main`
- [x] `./scripts/check-all.sh --enforced`

Closes #1198.

Made with [Cursor](https://cursor.com)