### PR TITLE
fix(help): correct runtime invocation and path examples

### DIFF
--- a/api/locales/en.json
+++ b/api/locales/en.json
@@ -172,7 +172,7 @@
     "run_web_shot_caption": "Dashboard — optional tenant/technician fields and Start scan (no shell required).",
     "run_auto_h3": "For automation / scripting",
     "run_cli_h3": "From the CLI",
-    "run_cli_p1": "From the repo root, prefer uv run python main.py (or activate your venv and run python main.py). Full flag list: python main.py --help. Packaged installs: man 1 data-boar (command) and man 5 data-boar (config file format).",
+    "run_cli_p1": "From the repo root, use python main.py as the canonical dev invocation (venv activation optional). Full flag list: python main.py --help. After installation, use data-boar as the entry point. See man 1 data-boar (command) and man 5 data-boar (config file format).",
     "run_cli_oneshot": "One-shot audit (config-driven; same targets as a dashboard scan with your config.yaml):",
     "run_cli_demo": "Zero-config demo (synthetic config + corpus under /tmp/data_boar_demo/; ignores config.yaml in the CWD):",
     "run_cli_api": "Start the API / dashBOARd (no scan until you use the browser or HTTP):",

--- a/api/locales/pt-BR.json
+++ b/api/locales/pt-BR.json
@@ -172,7 +172,7 @@
     "run_web_shot_caption": "Painel — campos opcionais de cliente/técnico e Iniciar varredura (sem shell).",
     "run_auto_h3": "Para automação / scripting",
     "run_cli_h3": "Pela CLI",
-    "run_cli_p1": "Na raiz do repositório, prefira uv run python main.py (ou ative o venv e execute python main.py). Lista completa de flags: python main.py --help. Instalações empacotadas: man 1 data-boar (comando) e man 5 data-boar (formato do arquivo de configuração).",
+    "run_cli_p1": "Na raiz do repositório, use python main.py como invocação canônica de desenvolvimento (ativar venv é opcional). Lista completa de flags: python main.py --help. Após instalação, use data-boar como entry point. Veja man 1 data-boar (comando) e man 5 data-boar (formato do arquivo de configuração).",
     "run_cli_oneshot": "Auditoria pontual (orientada ao config; mesmos alvos que uma varredura pelo painel com o seu config.yaml):",
     "run_cli_demo": "Demonstração zero-config (config + corpus sintéticos em /tmp/data_boar_demo/; ignora o config.yaml do diretório atual):",
     "run_cli_api": "Subir a API / dashBOARd (sem varredura até usar o navegador ou HTTP):",

--- a/api/routes.py
+++ b/api/routes.py
@@ -34,6 +34,7 @@ import io
 import os
 import re
 import secrets
+import sys
 import time
 from urllib.parse import quote
 from contextlib import asynccontextmanager
@@ -149,6 +150,14 @@ def _html_lang_attr(locale_tag: str) -> str:
 
 def _locale_tag_from_slug(slug: str) -> str:
     return LOCALE_TAG_BY_SLUG.get(slug.lower(), "en")
+
+
+def _display_prog(argv0: str | None = None) -> str:
+    """Return the operator-facing command form for this runtime."""
+    name = Path(argv0 or sys.argv[0] or "").name.lower()
+    if name in {"data-boar", "data-boar.exe"}:
+        return "data-boar"
+    return "python main.py"
 
 
 def _maturity_self_assessment_poc_allowed(cfg: dict) -> bool:
@@ -1858,10 +1867,20 @@ async def scan_database(config: DatabaseConfig, background_tasks: BackgroundTask
 async def help_page(request: Request, locale_slug: LocaleSlug):
     """Help and documentation page: quickstart, config example, links to README/USAGE docs."""
     tag = _locale_tag_from_slug(locale_slug.value)
+    home = Path.home()
     return templates.TemplateResponse(
         request=request,
         name="help.html",
-        context=_i18n_template_context(request, locale_slug.value, tag, {}),
+        context=_i18n_template_context(
+            request,
+            locale_slug.value,
+            tag,
+            {
+                "prog": _display_prog(),
+                "home_example": str(home),
+                "home_docs_example": str(home / "Documents" / "LGPD"),
+            },
+        ),
     )
 
 

--- a/api/templates/help.html
+++ b/api/templates/help.html
@@ -34,25 +34,24 @@
   <h3>{{ t('help.run_auto_h3') }}</h3>
   <p class="muted">{{ t('help.run_cli_p1') }}</p>
   <p><strong>{{ t('help.run_cli_demo') }}</strong></p>
-  <pre><code>uv run python main.py --demo
-data-boar --demo</code></pre>
+  <pre><code>{{ prog }} --demo</code></pre>
   <p><strong>{{ t('help.run_cli_oneshot') }}</strong></p>
-  <pre><code>uv run python main.py --config config.yaml
-uv run python main.py --config config.yaml --validate-config
-uv run python main.py --config config.yaml --diff &lt;session_a&gt; &lt;session_b&gt;
-uv run python main.py --config config.yaml --diff &lt;session_a&gt; &lt;session_b&gt; --fail-on-new-high
-uv run python main.py --config config.yaml --export-dsar &lt;session_id&gt;
-uv run python main.py --config config.yaml --export-dsar &lt;session_id&gt; --dsar-output dsar.json
-uv run python main.py --config config.yaml --tenant "Acme Corp" --technician "Alice Colleague-V"
+  <pre><code>{{ prog }} --config config.yaml
+{{ prog }} --config config.yaml --validate-config
+{{ prog }} --config config.yaml --diff &lt;session_a&gt; &lt;session_b&gt;
+{{ prog }} --config config.yaml --diff &lt;session_a&gt; &lt;session_b&gt; --fail-on-new-high
+{{ prog }} --config config.yaml --export-dsar &lt;session_id&gt;
+{{ prog }} --config config.yaml --export-dsar &lt;session_id&gt; --dsar-output dsar.json
+{{ prog }} --config config.yaml --tenant "Acme Corp" --technician "Alice Colleague-V"
 # Same optional toggles as the dashboard checkboxes (this run only):
-uv run python main.py --config config.yaml --scan-compressed --content-type-check --scan-stego --jurisdiction-hint</code></pre>
+{{ prog }} --config config.yaml --scan-compressed --content-type-check --scan-stego --jurisdiction-hint</code></pre>
   <p><strong>{{ t('help.run_cli_api') }}</strong></p>
   <p class="muted">{{ t('help.run_cli_tls') }}</p>
-  <pre><code>uv run python main.py --config config.yaml --web --https-cert-file server.crt --https-key-file server.key
+  <pre><code>{{ prog }} --config config.yaml --web --https-cert-file server.crt --https-key-file server.key
 # Lab / loopback only — explicit plaintext:
-uv run python main.py --config config.yaml --web --allow-insecure-http
+{{ prog }} --config config.yaml --web --allow-insecure-http
 # Default bind is loopback (127.0.0.1). Listen on all interfaces only with network controls:
-uv run python main.py --config config.yaml --web --allow-insecure-http --host 0.0.0.0 --port 8088</code></pre>
+{{ prog }} --config config.yaml --web --allow-insecure-http --host 0.0.0.0 --port 8088</code></pre>
   <p class="muted">{{ t('help.run_cli_bind') }}</p>
   <p><strong>{{ t('help.run_cli_danger') }}</strong></p>
   <p><strong>{{ t('help.run_cli_audit') }}</strong></p>
@@ -119,7 +118,7 @@ curl -o findings.csv   http://&lt;host&gt;:&lt;port&gt;/findings/&lt;session_id&
 
   - name: "Documentos_LGPD"
     type: filesystem
-    path: /home/user/Documents/LGPD
+    path: {{ home_docs_example }}
     recursive: true
 
 file_scan:

--- a/main.py
+++ b/main.py
@@ -262,8 +262,18 @@ def _run_session_diff_cli(
         mgr.dispose()
 
 
+def _display_prog(argv0: str | None = None) -> str:
+    """Return the operator-facing command form for this runtime."""
+    name = Path(argv0 or sys.argv[0] or "").name.lower()
+    if name in {"data-boar", "data-boar.exe"}:
+        return "data-boar"
+    return "python main.py"
+
+
 def main() -> None:
+    prog = _display_prog()
     parser = argparse.ArgumentParser(
+        prog=prog,
         description=(
             "Data Boar — enterprise data discovery and risk governance engine. "
             "Loads YAML/JSON config, scans configured databases/filesystems/APIs/shares, "
@@ -279,40 +289,39 @@ def main() -> None:
             "\n"
             "CLI examples:\n"
             "  # One-shot audit with the default config.yaml\n"
-            "  python main.py --config config.yaml\n"
+            f"  {prog} --config config.yaml\n"
             "\n"
             "  # One-shot audit tagging tenant/customer and technician/operator\n"
-            '  python main.py --config config.yaml --tenant "ACME Corp" --technician "Alice"\n'
+            f'  {prog} --config config.yaml --tenant "ACME Corp" --technician "Alice"\n'
             "\n"
             "  # One-shot with archive scan + content-type detection (this run only)\n"
-            "  python main.py --config config.yaml --scan-compressed --content-type-check\n"
+            f"  {prog} --config config.yaml --scan-compressed --content-type-check\n"
             "\n"
             "  # Validate config only (loader checks; no scan or API startup)\n"
-            "  python main.py --config config.yaml --validate-config\n"
+            f"  {prog} --config config.yaml --validate-config\n"
             "\n"
             "  # Compare two scan sessions (CI: add --fail-on-new-high)\n"
-            "  python main.py --config config.yaml --diff <session_a> <session_b>\n"
+            f"  {prog} --config config.yaml --diff <session_a> <session_b>\n"
             "\n"
             "  # DSAR-oriented JSON export for one session (stdout or --dsar-output)\n"
-            "  python main.py --config config.yaml --export-dsar <session_id>\n"
+            f"  {prog} --config config.yaml --export-dsar <session_id>\n"
             "\n"
             "  # Wipe all collected data and generated reports (dangerous, see SECURITY.md)\n"
-            "  python main.py --config config.yaml --reset-data\n"
+            f"  {prog} --config config.yaml --reset-data\n"
             "\n"
             "Web/API examples:\n"
             "  # HTTPS: PEM cert + key (TLS >= 1.2)\n"
-            "  python main.py --config config.yaml --web --https-cert-file server.crt --https-key-file server.key\n"
+            f"  {prog} --config config.yaml --web --https-cert-file server.crt --https-key-file server.key\n"
             "\n"
             "  # Plaintext HTTP (explicit risk acceptance; required when not using TLS)\n"
-            "  python main.py --config config.yaml --web --allow-insecure-http\n"
+            f"  {prog} --config config.yaml --web --allow-insecure-http\n"
             "\n"
             "  # Explicit port or bind (same flags as before, still need TLS or --allow-insecure-http)\n"
-            "  python main.py --config config.yaml --web --allow-insecure-http --port 9090\n"
-            "  python main.py --config config.yaml --web --allow-insecure-http --host 0.0.0.0\n"
+            f"  {prog} --config config.yaml --web --allow-insecure-http --port 9090\n"
+            f"  {prog} --config config.yaml --web --allow-insecure-http --host 0.0.0.0\n"
             "\n"
             "  # Zero-config demo (synthetic corpus, loopback dashboard — no config.yaml)\n"
-            "  python main.py --demo\n"
-            "  data-boar --demo\n"
+            f"  {prog} --demo\n"
             "\n"
             "Once a one-shot scan finishes, an Excel report and heatmap PNG are written under\n"
             "the configured report.output_dir (default: current directory). When the API is\n"

--- a/tests/operator_help_sync_manifest.py
+++ b/tests/operator_help_sync_manifest.py
@@ -158,8 +158,13 @@ OPERATOR_HELP_MARKERS: tuple[OperatorHelpMarker, ...] = (
         "--jurisdiction-hint",
         _MAN_JURISDICTION_HINT,
     ),
-    # Web /help recommends uv; full docs in README — not duplicated in argparse.
-    OperatorHelpMarker("uv_run", None, "uv run", None),
+    # Dev canonical invocation is python main.py; installed entry point is data-boar.
+    OperatorHelpMarker(
+        "python_main_invocation",
+        "python main.py --config config.yaml",
+        "python main.py --config config.yaml",
+        "python main.py",
+    ),
     OperatorHelpMarker("api_host_env", "API_HOST", "API_HOST", "API_HOST"),
     OperatorHelpMarker("bind_loopback", "127.0.0.1", "127.0.0.1", "127.0.0.1"),
     OperatorHelpMarker(

--- a/tests/test_operator_help_sync.py
+++ b/tests/test_operator_help_sync.py
@@ -106,3 +106,18 @@ def test_operator_help_markers_in_man1(man1_text: str) -> None:
             f"(expected troff substring {marker.man1_troff_substring!r}); "
             "update man page and tests/operator_help_sync_manifest.py"
         )
+
+
+def test_cli_help_uses_dev_canonical_invocation(cli_help_text: str) -> None:
+    assert "usage: python main.py" in cli_help_text
+    assert "python main.py --config config.yaml" in cli_help_text
+    assert "--validate-config" in cli_help_text
+
+
+def test_web_help_uses_runtime_prog_and_concrete_home_path(tmp_path: Path) -> None:
+    html = _web_help_html(tmp_path)
+    expected_docs_path = str(Path.home() / "Documents" / "LGPD")
+    assert "python main.py --config config.yaml" in html
+    assert "uv run python main.py" not in html
+    assert expected_docs_path in html
+    assert "~/Documents/LGPD" not in html


### PR DESCRIPTION
## Summary
- make CLI help runtime-aware: `python main.py` on dev runs and `data-boar` when invoked from installed entrypoint
- update `/help` command snippets to use runtime `prog` instead of hardcoded `uv run python main.py`
- replace static Linux docs path in help config example with an OS-aware `Path.home()`-based path and update locale copy accordingly
- extend operator help sync coverage to pin canonical dev invocation and concrete home-path rendering

## Test plan
- [x] `uv run pytest tests/test_operator_help_sync.py -v`
- [x] `uv run python scripts/gate_change_tripwire.py --base origin/main`
- [x] `./scripts/check-all.sh --enforced`

Closes #1130.

Made with [Cursor](https://cursor.com)