### PR TITLE
docs(man): align section 1/5 invocation and add anti-drift guard

### DIFF
--- a/docs/data_boar.1
+++ b/docs/data_boar.1
@@ -49,7 +49,7 @@ is accepted as an alias; both names refer to the same application.
 The actual entry point is:
 .br
 .RS 4
-.B python main.py
+.B data-boar
 [
 .I OPTIONS
 ]
@@ -576,27 +576,25 @@ Synthetic corpus and dashboard (ignores
 in the CWD):
 .RS
 .B data-boar \-\-demo
-.br
-.B python main.py \-\-demo
 .RE
 .
 .SS One\-shot CLI (config\-driven)
 .TP
 Minimal scan with default config:
 .RS
-.B python main.py \-\-config config.yaml
+.B data-boar \-\-config config.yaml
 .RE
 .
 .TP
 Scan with tenant and technician metadata:
 .RS
-.B python main.py \-\-config config.yaml \-\-tenant "Acme Corp" \-\-technician "Alice Colleague-V"
+.B data-boar \-\-config config.yaml \-\-tenant "Acme Corp" \-\-technician "Alice Colleague-V"
 .RE
 .
 .TP
 Wipe all sessions, findings and generated reports (dangerous):
 .RS
-.B python main.py \-\-config config.yaml \-\-reset\-data
+.B data-boar \-\-config config.yaml \-\-reset\-data
 .RE
 .
 .SS Web API
@@ -609,13 +607,13 @@ in the configuration) for plaintext HTTP.
 .TP
 Start the API on port 8088 (plaintext, explicit opt\-in):
 .RS
-.B python main.py \-\-config config.yaml \-\-web \-\-allow\-insecure\-http \-\-port 8088
+.B data-boar \-\-config config.yaml \-\-web \-\-allow\-insecure\-http \-\-port 8088
 .RE
 .
 .TP
 HTTPS (PEM cert + key; TLS >= 1.2):
 .RS
-.B python main.py \-\-config config.yaml \-\-web \-\-https\-cert\-file server.crt \-\-https\-key\-file server.key
+.B data-boar \-\-config config.yaml \-\-web \-\-https\-cert\-file server.crt \-\-https\-key\-file server.key
 .RE
 .
 .TP
@@ -623,14 +621,14 @@ Use CONFIG_PATH and start the server:
 .RS
 .nf
 export CONFIG_PATH=/etc/lgpd\-audit/config.yaml
-python main.py \-\-web \-\-allow\-insecure\-http \-\-port 8088
+data-boar \-\-web \-\-allow\-insecure\-http \-\-port 8088
 .fi
 .RE
 .
 .TP
 Listen on all interfaces (e.g.\& LAN or container without Docker env); use only with network controls:
 .RS
-.B python main.py \-\-config config.yaml \-\-web \-\-allow\-insecure\-http \-\-host 0.0.0.0 \-\-port 8088
+.B data-boar \-\-config config.yaml \-\-web \-\-allow\-insecure\-http \-\-host 0.0.0.0 \-\-port 8088
 .RE
 .
 .SS curl \- API examples

--- a/docs/data_boar.5
+++ b/docs/data_boar.5
@@ -480,7 +480,7 @@ Example main config (excerpt):
 \fBapi:\fR
   port: 8088
   # host: 127.0.0.1   # optional bind address; see man 1 data-boar for CLI and API_HOST
-  # https_cert_file: /path/server.crt   # optional: TLS for python main.py --web
+  # https_cert_file: /path/server.crt   # optional: TLS for data-boar --web
   # https_key_file: /path/server.key    # optional: must pair with https_cert_file
   # allow_insecure_http: false           # explicit plaintext only when true (Docker image CMD often sets CLI flag instead)
 

--- a/tests/operator_help_sync_manifest.py
+++ b/tests/operator_help_sync_manifest.py
@@ -159,11 +159,12 @@ OPERATOR_HELP_MARKERS: tuple[OperatorHelpMarker, ...] = (
         _MAN_JURISDICTION_HINT,
     ),
     # Dev canonical invocation is python main.py; installed entry point is data-boar.
+    # Man pages document installed usage, so man1 is intentionally skipped here.
     OperatorHelpMarker(
         "python_main_invocation",
         "python main.py --config config.yaml",
         "python main.py --config config.yaml",
-        "python main.py",
+        None,
     ),
     OperatorHelpMarker("api_host_env", "API_HOST", "API_HOST", "API_HOST"),
     OperatorHelpMarker("bind_loopback", "127.0.0.1", "127.0.0.1", "127.0.0.1"),

--- a/tests/test_operator_help_sync.py
+++ b/tests/test_operator_help_sync.py
@@ -16,6 +16,7 @@ from tests.operator_help_sync_manifest import OPERATOR_HELP_MARKERS
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _MAN1_PATH = _REPO_ROOT / "docs" / "data_boar.1"
+_MAN5_PATH = _REPO_ROOT / "docs" / "data_boar.5"
 
 
 def _cli_help_stdout() -> str:
@@ -74,6 +75,12 @@ def man1_text() -> str:
     return _MAN1_PATH.read_text(encoding="utf-8")
 
 
+@pytest.fixture(scope="module")
+def man5_text() -> str:
+    assert _MAN5_PATH.is_file(), f"missing {_MAN5_PATH}"
+    return _MAN5_PATH.read_text(encoding="utf-8")
+
+
 def test_operator_help_markers_in_cli_help(cli_help_text: str) -> None:
     for marker in OPERATOR_HELP_MARKERS:
         if marker.cli_help_substring is None:
@@ -121,3 +128,17 @@ def test_web_help_uses_runtime_prog_and_concrete_home_path(tmp_path: Path) -> No
     assert "uv run python main.py" not in html
     assert expected_docs_path in html
     assert "~/Documents/LGPD" not in html
+
+
+def test_man_pages_use_installed_invocation_contract(
+    man1_text: str, man5_text: str
+) -> None:
+    """
+    #1131: man pages are user-facing installed docs (man 1/5), so they must not
+    drift back to source-run wrappers.
+    """
+    for name, body in (("data_boar.1", man1_text), ("data_boar.5", man5_text)):
+        assert "uv run" not in body, f"{name} must not include uv-run wrappers"
+        assert "python main.py" not in body, (
+            f"{name} must use installed invocation (data-boar)"
+        )


### PR DESCRIPTION
Closes #1131

## Summary
- align `docs/data_boar.1` user-facing examples to the installed command `data-boar` (remove source-wrapper drift in section 1 usage examples)
- align the section 5 config comment in `docs/data_boar.5` to `data-boar --web`
- add a regression guard in `tests/test_operator_help_sync.py` to fail if `docs/data_boar.1` or `docs/data_boar.5` drift back to `python main.py`/`uv run`
- keep `python main.py` as canonical dev invocation in CLI/web help surfaces by skipping man1 enforcement for that marker in `tests/operator_help_sync_manifest.py`

## Validation
- `uv run python scripts/gate_change_tripwire.py --base origin/main`
- `./scripts/quick-test.sh --path tests/test_operator_help_sync.py`
- `./scripts/check-all.sh --enforced`

Made with [Cursor](https://cursor.com)