### PR TITLE
fix(security): Dataverse SSRF guard on org_url/token_url (#1232)

### DIFF
--- a/connectors/dataverse_connector.py
+++ b/connectors/dataverse_connector.py
@@ -16,6 +16,8 @@ from core.suggested_review import (
     augment_low_id_like_for_persist,
 )
 
+from .url_guard import target_allows_private, validate_outbound_url
+
 try:
     import httpx
 
@@ -62,6 +64,15 @@ def _dataverse_token(target: dict[str, Any]) -> str | None:
         auth.get("token_url")
         or f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
     )
+    # SSRF guard (#1232 / #832): custom token_url receives the client_secret via POST —
+    # never let it point at link-local/private hosts without explicit opt-in.
+    err = validate_outbound_url(
+        token_url,
+        allow_private=target_allows_private(target),
+        label="auth.token_url",
+    )
+    if err:
+        raise ValueError(err)
     resp = httpx.post(
         token_url,
         data={
@@ -124,6 +135,16 @@ class DataverseConnector:
         org_url = self.config.get("org_url") or self.config.get("environment_url", "")
         if not org_url:
             raise ValueError("Dataverse requires org_url (or environment_url)")
+        # SSRF guard (#1232): validate the raw org_url from config before any HTTP —
+        # including before token POST. Do not validate `_api_base()` output: it rewrites
+        # hosts (e.g. 169.254.169.254 → 169.api.crm.dynamics.com) and would miss link-local.
+        err = validate_outbound_url(
+            org_url,
+            allow_private=target_allows_private(self.config),
+            label="org_url",
+        )
+        if err:
+            raise ValueError(err)
         self._token = _dataverse_token(self.config)
         if not self._token:
             raise ValueError(

--- a/tests/test_powerbi_dataverse_http_surfaces.py
+++ b/tests/test_powerbi_dataverse_http_surfaces.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 import httpx
+import pytest
 
 from connectors.dataverse_connector import DataverseConnector
 from connectors.powerbi_connector import PowerBIConnector
@@ -79,3 +80,70 @@ def test_powerbi_run_save_failure_on_groups_http_error(mock_post, mock_client_cl
     assert _target == "pbi-test"
     assert kind == "error"
     assert "401" in msg or "Unauthorized" in msg
+
+
+def _dataverse_auth_cfg(**overrides):
+    cfg = {
+        "name": "dv-ssrf",
+        "org_url": "https://org.crm.dynamics.com",
+        "tenant_id": "t",
+        "client_id": "c",
+        "client_secret": "sec",
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+@patch("connectors.dataverse_connector.httpx.Client")
+@patch("connectors.dataverse_connector.httpx.post")
+def test_dataverse_connect_rejects_link_local_org_url_before_token_post(
+    mock_post, mock_client_cls
+):
+    """#1232: raw link-local org_url must raise before any token POST."""
+    cfg = _dataverse_auth_cfg(org_url="http://169.254.169.254")
+    with pytest.raises(ValueError, match="#832|org_url|private|link-local|blocked"):
+        DataverseConnector(cfg, _mk_scanner(), MagicMock()).connect()
+    mock_post.assert_not_called()
+    mock_client_cls.assert_not_called()
+
+
+@patch("connectors.dataverse_connector.httpx.Client")
+@patch("connectors.dataverse_connector.httpx.post")
+def test_dataverse_connect_rejects_rfc1918_org_url_before_token_post(
+    mock_post, mock_client_cls
+):
+    cfg = _dataverse_auth_cfg(org_url="http://10.0.0.5")
+    with pytest.raises(ValueError, match="#832|org_url|private|blocked"):
+        DataverseConnector(cfg, _mk_scanner(), MagicMock()).connect()
+    mock_post.assert_not_called()
+    mock_client_cls.assert_not_called()
+
+
+@patch("connectors.dataverse_connector.httpx.Client")
+@patch("connectors.dataverse_connector.httpx.post")
+def test_dataverse_connect_rejects_private_token_url_before_post(
+    mock_post, mock_client_cls
+):
+    """Public org_url + private auth.token_url must fail before httpx.post."""
+    cfg = _dataverse_auth_cfg(
+        auth={"token_url": "http://169.254.169.254/token"},
+    )
+    with pytest.raises(ValueError, match="#832|token_url|private|link-local|blocked"):
+        DataverseConnector(cfg, _mk_scanner(), MagicMock()).connect()
+    mock_post.assert_not_called()
+    mock_client_cls.assert_not_called()
+
+
+@patch("connectors.dataverse_connector.httpx.Client")
+@patch("connectors.dataverse_connector.httpx.post")
+def test_dataverse_connect_allow_private_networks_opts_in(mock_post, mock_client_cls):
+    """#832 parity: allow_private_networks: true must not reject private org_url."""
+    mock_post.return_value = _oauth_token_response_ok()
+    mock_client_cls.return_value = MagicMock()
+    cfg = _dataverse_auth_cfg(
+        org_url="http://10.0.0.5",
+        allow_private_networks=True,
+    )
+    DataverseConnector(cfg, _mk_scanner(), MagicMock()).connect()
+    mock_post.assert_called_once()
+    mock_client_cls.assert_called_once()

--- a/tests/test_ssrf_guard.py
+++ b/tests/test_ssrf_guard.py
@@ -206,6 +206,7 @@ def test_sharepoint_connector_rejects_private_site_url() -> None:
         "connectors/powerbi_connector.py",
         "connectors/sharepoint_connector.py",
         "connectors/webdav_connector.py",
+        "connectors/dataverse_connector.py",
     ],
 )
 def test_connector_sources_call_url_guard(connector_file: str) -> None:


### PR DESCRIPTION
## Summary
- Wire `validate_outbound_url` / `target_allows_private` into the Dataverse connector (last HTTP connector missing the #832 pattern).
- Validate **raw** `org_url` in `connect()` before `_dataverse_token()` (not `_api_base()` rewrite — link-local would otherwise slip through).
- Validate `auth.token_url` in `_dataverse_token` before `httpx.post`.
- Tests in `tests/test_powerbi_dataverse_http_surfaces.py` + inventory row in `test_ssrf_guard.py`.

Closes #1232

## Test plan
- [x] `./scripts/check-all.sh --enforced`
- [x] link-local / RFC1918 `org_url` → ValueError + `httpx.post` not called
- [x] private `token_url` + public `org_url` → ValueError + no POST
- [x] `allow_private_networks: true` opt-in parity with #832


Made with [Cursor](https://cursor.com)