### PR TITLE
fix(security): lock secret-by-identity and reachable JWT GRACE (#1210 #1212)

### DIFF
--- a/core/licensing/guard.py
+++ b/core/licensing/guard.py
@@ -340,7 +340,20 @@ class LicenseGuard:
             return
 
         now = utc_now_ts()
-        exp = float(claims.get("exp", 0))
+        try:
+            exp = float(claims.get("exp", 0))
+        except (TypeError, ValueError):
+            # verify_exp is False in decode_license_jwt (#1212); require[] only
+            # checks presence. Non-numeric exp must fail CLOSED — never crash.
+            self._context = LicenseContext(
+                state="INVALID",
+                mode="enforced",
+                license_id=lic_id,
+                machine_fingerprint=mfp,
+                detail="malformed_exp_claim",
+                watermark="INVALID_TOKEN",
+            )
+            return
         grace_until = claims.get("dbgrace")
         try:
             grace_ts = float(grace_until) if grace_until is not None else 0.0

--- a/core/licensing/verify.py
+++ b/core/licensing/verify.py
@@ -33,6 +33,10 @@ def load_public_key_from_path(path: str) -> Any:
 def decode_license_jwt(token: str, public_key: Any) -> dict[str, Any]:
     """
     Verify signature and return claims. Raises jwt.PyJWTError on failure.
+
+    ``exp`` / ``dbgrace`` time windows are evaluated in ``LicenseGuard`` (VALID →
+    GRACE → EXPIRED). PyJWT must not reject an expired signature before that
+    chain runs — otherwise GRACE is unreachable (#1212).
     """
     return jwt.decode(
         token,
@@ -40,6 +44,7 @@ def decode_license_jwt(token: str, public_key: Any) -> dict[str, Any]:
         algorithms=["EdDSA"],
         options={
             "verify_aud": False,
+            "verify_exp": False,
             "require": ["exp", "sub"],
         },
     )

--- a/tests/test_licensing.py
+++ b/tests/test_licensing.py
@@ -106,6 +106,49 @@ def test_enforced_valid_token(ed25519_priv, tmp_path):
     assert g.context.customer_name == "Test Customer"
 
 
+def test_enforced_grace_when_past_exp_before_dbgrace(ed25519_priv, tmp_path):
+    """#1212 — GRACE is reachable when exp < now <= dbgrace (PyJWT must not block on exp)."""
+    pem = _pem_public(ed25519_priv)
+    now = datetime.now(timezone.utc)
+    grace_ts = int((now + timedelta(days=7)).timestamp())
+    lic = tmp_path / "grace.lic"
+    lic.write_text(
+        _make_token(
+            ed25519_priv,
+            exp_delta_days=-1,
+            extra={"dbgrace": grace_ts},
+        ),
+        encoding="utf-8",
+    )
+    cfg = {"licensing": {"mode": "enforced", "license_path": str(lic)}}
+    os.environ["DATA_BOAR_LICENSE_PUBLIC_KEY_PEM"] = pem
+    g = LicenseGuard(cfg)
+    assert g.context.state == "GRACE"
+    assert g.allows_scan() is True
+    assert g.context.state in ("OPEN", "VALID", "GRACE")
+
+
+def test_enforced_expired_when_past_dbgrace(ed25519_priv, tmp_path):
+    """#1212 — past both exp and dbgrace → EXPIRED (grace boundary)."""
+    pem = _pem_public(ed25519_priv)
+    now = datetime.now(timezone.utc)
+    past_grace = int((now - timedelta(days=1)).timestamp())
+    lic = tmp_path / "expired.lic"
+    lic.write_text(
+        _make_token(
+            ed25519_priv,
+            exp_delta_days=-3,
+            extra={"dbgrace": past_grace},
+        ),
+        encoding="utf-8",
+    )
+    cfg = {"licensing": {"mode": "enforced", "license_path": str(lic)}}
+    os.environ["DATA_BOAR_LICENSE_PUBLIC_KEY_PEM"] = pem
+    g = LicenseGuard(cfg)
+    assert g.context.state == "EXPIRED"
+    assert g.allows_scan() is False
+
+
 def test_enforced_token_dbtier_claim_exposed(ed25519_priv, tmp_path):
     """JWT ``dbtier`` is stored for feature gates (e.g. maturity POC) — see LICENSING_SPEC.md."""
     pem = _pem_public(ed25519_priv)

--- a/tests/test_licensing.py
+++ b/tests/test_licensing.py
@@ -149,6 +149,46 @@ def test_enforced_expired_when_past_dbgrace(ed25519_priv, tmp_path):
     assert g.allows_scan() is False
 
 
+def test_enforced_expired_when_past_exp_without_dbgrace(ed25519_priv, tmp_path):
+    """#1212 — past exp and no dbgrace (grace_ts=0) → EXPIRED, never allowed."""
+    pem = _pem_public(ed25519_priv)
+    lic = tmp_path / "expired-no-grace.lic"
+    lic.write_text(
+        _make_token(ed25519_priv, exp_delta_days=-1),
+        encoding="utf-8",
+    )
+    cfg = {"licensing": {"mode": "enforced", "license_path": str(lic)}}
+    os.environ["DATA_BOAR_LICENSE_PUBLIC_KEY_PEM"] = pem
+    g = LicenseGuard(cfg)
+    assert g.context.state == "EXPIRED"
+    assert g.allows_scan() is False
+
+
+def test_enforced_malformed_exp_claim_fail_closed(ed25519_priv, tmp_path):
+    """Non-numeric exp (verify_exp=False) → INVALID, no crash on LicenseGuard init."""
+    pem = _pem_public(ed25519_priv)
+    now = datetime.now(timezone.utc)
+    payload = {
+        "sub": "lic-bad-exp",
+        "iat": int(now.timestamp()),
+        "exp": "not-a-number",
+        "dbcid": "cust-1",
+        "dbcname": "Test Customer",
+        "dbenv": "qa",
+        "dbissuer": "test-issuer",
+        "dbkid": "k1",
+    }
+    tok = jwt.encode(payload, ed25519_priv, algorithm="EdDSA")
+    lic = tmp_path / "bad-exp.lic"
+    lic.write_text(tok, encoding="utf-8")
+    cfg = {"licensing": {"mode": "enforced", "license_path": str(lic)}}
+    os.environ["DATA_BOAR_LICENSE_PUBLIC_KEY_PEM"] = pem
+    g = LicenseGuard(cfg)
+    assert g.context.state == "INVALID"
+    assert g.context.detail == "malformed_exp_claim"
+    assert g.allows_scan() is False
+
+
 def test_enforced_token_dbtier_claim_exposed(ed25519_priv, tmp_path):
     """JWT ``dbtier`` is stored for feature gates (e.g. maturity POC) — see LICENSING_SPEC.md."""
     pem = _pem_public(ed25519_priv)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -585,6 +585,65 @@ def test_normalize_config_resolves_pass_from_env_and_user_from_env(monkeypatch):
     assert out["targets"][1]["user"] == "env-user"
 
 
+def test_normalize_config_secret_binding_is_by_identity_not_position(monkeypatch):
+    """#1210 — credential-from-env binds to the same target dict (identity), never list index.
+
+    Reordering targets must not swap secrets. Distinct env vars → distinct values per name.
+    """
+    from config.loader import normalize_config
+
+    monkeypatch.setenv("SECRET_ALPHA", "alpha-secret-value")
+    monkeypatch.setenv("SECRET_BETA", "beta-secret-value")
+    monkeypatch.setenv("PASS_ALPHA", "alpha-pass")
+    monkeypatch.setenv("PASS_BETA", "beta-pass")
+
+    def _by_name(targets: list) -> dict:
+        return {t["name"]: t for t in targets}
+
+    data = {
+        "targets": [
+            {
+                "name": "alpha",
+                "type": "rest_api",
+                "client_secret_from_env": "SECRET_ALPHA",
+                "pass_from_env": "PASS_ALPHA",
+            },
+            {
+                "name": "beta",
+                "type": "rest_api",
+                "client_secret_from_env": "SECRET_BETA",
+                "pass_from_env": "PASS_BETA",
+            },
+        ],
+        "api": {},
+        "report": {"output_dir": "."},
+    }
+    out = normalize_config(data)
+    named = _by_name(out["targets"])
+    assert named["alpha"]["client_secret"] == "alpha-secret-value"
+    assert named["beta"]["client_secret"] == "beta-secret-value"
+    assert named["alpha"]["pass"] == "alpha-pass"
+    assert named["beta"]["pass"] == "beta-pass"
+
+    reordered = {
+        "targets": [
+            dict(data["targets"][1]),
+            dict(data["targets"][0]),
+        ],
+        "api": {},
+        "report": {"output_dir": "."},
+    }
+    out2 = normalize_config(reordered)
+    named2 = _by_name(out2["targets"])
+    assert named2["alpha"]["client_secret"] == "alpha-secret-value"
+    assert named2["beta"]["client_secret"] == "beta-secret-value"
+    assert named2["alpha"]["pass"] == "alpha-pass"
+    assert named2["beta"]["pass"] == "beta-pass"
+    # Position 0 after reorder is beta — must carry beta's secret, not alpha's.
+    assert out2["targets"][0]["name"] == "beta"
+    assert out2["targets"][0]["client_secret"] == "beta-secret-value"
+
+
 def test_normalize_config_warns_when_pass_from_env_unset_then_falls_back(monkeypatch):
     """Issue #508: missing env for pass_from_env emits UserWarning; inline pass still applies."""
     import warnings


### PR DESCRIPTION
## Summary
- **#1210 (verify-lock, test-only):** `normalize_config` resolves `*_from_env` onto the same target dict; regression asserts distinct env secrets stay bound **by name** after reordering the targets list.
- **#1212:** Auditor assumed the `elif grace_ts` chain alone made GRACE reachable. **Repro:** PyJWT `jwt.decode` defaults to `verify_exp=True`, so a past-`exp` token became `INVALID` (`Signature has expired`) before the guard. Fix: `verify_exp: False` in `decode_license_jwt` so VALID/GRACE/EXPIRED are decided in `LicenseGuard`. Tests lock GRACE (`exp` past + `dbgrace` future, allowed) and EXPIRED (both past).

Closes #1210
Closes #1212

## Test plan
- [x] `uv run pytest` identity + GRACE + EXPIRED cases
- [x] `./scripts/check-all.sh --enforced` green
- [ ] Operator: confirm intentional `verify_exp: False` (time windows owned by guard)


Made with [Cursor](https://cursor.com)