### PR TITLE
fix(session): orphan running sessions reaper + interrupt finish (#1251)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1920,11 +1920,15 @@ async def scan_database(config: DatabaseConfig, background_tasks: BackgroundTask
 
     def run_one_target():
         engine._is_running = True
+        status = "completed"
         try:
             engine._run_target(target)
+        except KeyboardInterrupt:
+            status = "interrupted"
+            raise
         finally:
             engine._is_running = False
-            engine.db_manager.finish_session(session_id, "completed")
+            engine.db_manager.finish_session(session_id, status)
             if jh_db:
                 engine.config.setdefault("report", {}).setdefault(
                     "jurisdiction_hints", {}

--- a/core/database.py
+++ b/core/database.py
@@ -1518,6 +1518,9 @@ class LocalDBManager:
         Mark ``running`` sessions as ``interrupted`` when their owner PID is dead or
         unknown (NULL legacy rows). Never reap a live PID on this host (#1251).
 
+        Uses a conditional ``UPDATE … WHERE status='running'`` so a concurrent
+        ``finish_session(..., completed)`` cannot be overwritten (TOCTOU-safe).
+
         Sessions with ``owner_hostname`` set to a *different* host are left alone
         (shared DB / multi-host safe).
         """
@@ -1536,9 +1539,22 @@ class LocalDBManager:
                 pid = getattr(rec, "pid", None)
                 if self.pid_is_alive(pid):
                     continue
-                rec.status = "interrupted"
-                rec.finished_at = now
-                reaped += 1
+                # Atomic terminal write: skip if status already left running.
+                result = session.execute(
+                    text(
+                        "UPDATE scan_sessions SET status = :st, finished_at = :fa "
+                        "WHERE session_id = :sid AND status = 'running'"
+                    ),
+                    {
+                        "st": "interrupted",
+                        # ISO string avoids sqlite3 datetime adapter DeprecationWarning
+                        # on Python 3.12+ when binding via raw text().
+                        "fa": now.isoformat(),
+                        "sid": rec.session_id,
+                    },
+                )
+                if result.rowcount:
+                    reaped += 1
             if reaped:
                 session.commit()
         except Exception:

--- a/core/database.py
+++ b/core/database.py
@@ -5,6 +5,8 @@ Session id comes from core.session (UUID + timestamp); set via set_current_sessi
 """
 
 from datetime import datetime, timezone
+import os
+import socket
 from typing import Any
 
 from sqlalchemy import (
@@ -44,7 +46,10 @@ class ScanSession(Base):
     session_id = Column(String(64), unique=True, nullable=False, index=True)
     started_at = Column(DateTime, default=_utc_now)
     finished_at = Column(DateTime, nullable=True)
-    status = Column(String(20), default="running")  # running, completed, failed
+    status = Column(
+        String(20), default="running"
+    )  # running, completed, failed, interrupted
+
     tenant_name = Column(
         String(255), nullable=True
     )  # optional customer/tenant for this scan
@@ -57,6 +62,9 @@ class ScanSession(Base):
     jurisdiction_hint = Column(
         Integer, default=0
     )  # 1 = operator opted in to heuristic jurisdiction Report info rows for this session
+    # Process liveness for orphan reaper (#1251). NULL = legacy / unknown → reapable.
+    pid = Column(Integer, nullable=True)
+    owner_hostname = Column(String(255), nullable=True)
 
 
 class DatabaseFinding(Base):
@@ -316,6 +324,7 @@ class LocalDBManager:
         self._ensure_technician_column()
         self._ensure_config_scope_hash_column()
         self._ensure_jurisdiction_hint_column()
+        self._ensure_session_pid_columns()
         self._ensure_data_source_inventory_table()
         self._ensure_notification_send_log_table()
         self._ensure_maturity_assessment_answers_table()
@@ -327,6 +336,8 @@ class LocalDBManager:
         self._ensure_content_fingerprint_column()
         self._session_factory = sessionmaker(bind=self.engine, expire_on_commit=False)
         self._current_session_id: str | None = None
+        # Crash-recovery: mark dead-PID / legacy-NULL orphans as interrupted (#1251).
+        self.reap_orphaned_running_sessions()
 
     def _ensure_tenant_column(self) -> None:
         """Add tenant_name column to scan_sessions if missing (migration for existing DBs)."""
@@ -391,6 +402,25 @@ class LocalDBManager:
                     )
                 )
                 conn.commit()
+
+    def _ensure_session_pid_columns(self) -> None:
+        """Add pid / owner_hostname for orphan reaper (#1251)."""
+        with self.engine.connect() as conn:
+            cols = {
+                row[1]
+                for row in conn.execute(
+                    text("PRAGMA table_info(scan_sessions)")
+                ).fetchall()
+            }
+            if "pid" not in cols:
+                conn.execute(text("ALTER TABLE scan_sessions ADD COLUMN pid INTEGER"))
+            if "owner_hostname" not in cols:
+                conn.execute(
+                    text(
+                        "ALTER TABLE scan_sessions ADD COLUMN owner_hostname VARCHAR(255)"
+                    )
+                )
+            conn.commit()
 
     def _ensure_aggregated_table(self) -> None:
         """Create aggregated_identification_risk table if it does not exist."""
@@ -1380,6 +1410,8 @@ class LocalDBManager:
                     technician_name=(technician_name or None),
                     config_scope_hash=(config_scope_hash or None),
                     jurisdiction_hint=1 if jurisdiction_hint else 0,
+                    pid=os.getpid(),
+                    owner_hostname=socket.gethostname() or None,
                 )
             )
             session.commit()
@@ -1448,6 +1480,7 @@ class LocalDBManager:
             session.close()
 
     def finish_session(self, session_id: str, status: str = "completed") -> None:
+        """Mark a session terminal. Does not overwrite a session that already left ``running`` (#1251)."""
         session = self._session_factory()
         try:
             rec = (
@@ -1455,7 +1488,7 @@ class LocalDBManager:
                 .filter(ScanSession.session_id == session_id)
                 .first()
             )
-            if rec:
+            if rec and rec.status == "running":
                 rec.finished_at = datetime.now(timezone.utc)
                 rec.status = status
                 session.commit()
@@ -1464,6 +1497,56 @@ class LocalDBManager:
             raise
         finally:
             session.close()
+
+    @staticmethod
+    def pid_is_alive(pid: int | None) -> bool:
+        """True if ``pid`` refers to a live process (PermissionError = alive other-user)."""
+        if pid is None or int(pid) <= 0:
+            return False
+        try:
+            os.kill(int(pid), 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        except OSError:
+            return False
+        return True
+
+    def reap_orphaned_running_sessions(self) -> int:
+        """
+        Mark ``running`` sessions as ``interrupted`` when their owner PID is dead or
+        unknown (NULL legacy rows). Never reap a live PID on this host (#1251).
+
+        Sessions with ``owner_hostname`` set to a *different* host are left alone
+        (shared DB / multi-host safe).
+        """
+        local_host = socket.gethostname() or ""
+        session = self._session_factory()
+        reaped = 0
+        try:
+            rows = (
+                session.query(ScanSession).filter(ScanSession.status == "running").all()
+            )
+            now = datetime.now(timezone.utc)
+            for rec in rows:
+                host = getattr(rec, "owner_hostname", None)
+                if host and local_host and host != local_host:
+                    continue
+                pid = getattr(rec, "pid", None)
+                if self.pid_is_alive(pid):
+                    continue
+                rec.status = "interrupted"
+                rec.finished_at = now
+                reaped += 1
+            if reaped:
+                session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+        return reaped
 
     def get_current_findings_count(self) -> int:
         sid = self._current_session_id

--- a/core/engine.py
+++ b/core/engine.py
@@ -338,12 +338,17 @@ class AuditEngine:
                                 # Best effort: persist failures when possible, but don't break session flow.
                                 _ = str(save_err)
                             final_status = "completed_errors"
+        except KeyboardInterrupt:
+            # Ctrl+C / SIGTERM→KeyboardInterrupt: terminal "interrupted", not orphan running (#1251).
+            final_status = "interrupted"
+            raise
         finally:
             self._is_running = False
             from core.scan_audit_log import build_scan_audit_log
 
             self._scan_audit_log = build_scan_audit_log(self.config)
-            self.db_manager.finish_session(session_id, final_status)
+            if session_id:
+                self.db_manager.finish_session(session_id, final_status)
 
     def _run_target(self, target: dict[str, Any]) -> None:
         """Run one target: resolve connector, instantiate, run()."""

--- a/main.py
+++ b/main.py
@@ -28,6 +28,28 @@ def _cli_public_version_line() -> str:
     return f"Data Boar {_package_version()}"
 
 
+def _install_scan_interrupt_signal_handlers() -> None:
+    """Map SIGTERM to KeyboardInterrupt so engine finally marks ``interrupted`` (#1251)."""
+    import signal
+
+    def _raise_keyboard_interrupt(signum, frame):  # type: ignore[no-untyped-def]
+        raise KeyboardInterrupt()
+
+    if hasattr(signal, "SIGTERM"):
+        try:
+            signal.signal(signal.SIGTERM, _raise_keyboard_interrupt)
+        except (ValueError, OSError):
+            # Not the main thread / platform rejects — best-effort only.
+            pass
+
+
+def _finish_session_interrupted_if_running(engine: AuditEngine) -> None:
+    """Mark current session interrupted when still ``running`` (idempotent vs engine finally)."""
+    sid = engine.db_manager.current_session_id
+    if sid:
+        engine.db_manager.finish_session(sid, "interrupted")
+
+
 def _emit_runtime_trust_info(
     snapshot: dict[str, Any], *, to_stdout: bool = True, to_stderr: bool = True
 ) -> None:
@@ -759,6 +781,7 @@ def main() -> None:
         if demo_mode:
             from core.validation import sanitize_tenant_technician
 
+            _install_scan_interrupt_signal_handlers()
             engine = AuditEngine(config, config_path=args.config)
             try:
                 _emit_runtime_trust_info(runtime_trust, to_stdout=True, to_stderr=True)
@@ -775,6 +798,10 @@ def main() -> None:
                     print(f"[demo] Report written: {report_path}")
                 else:
                     print("[demo] No findings to report.")
+            except KeyboardInterrupt:
+                _finish_session_interrupted_if_running(engine)
+                print("[demo] Scan interrupted.", file=sys.stderr)
+                sys.exit(130)
             finally:
                 engine.db_manager.dispose()
 
@@ -986,6 +1013,7 @@ def main() -> None:
     tenant = sanitize_tenant_technician(args.tenant)
     technician = sanitize_tenant_technician(args.technician)
     # scan_compressed / use_content_type already merged above when CLI flags were passed
+    _install_scan_interrupt_signal_handlers()
     try:
         _emit_runtime_trust_info(runtime_trust, to_stdout=True, to_stderr=True)
         session_id = engine.start_audit(
@@ -1002,6 +1030,10 @@ def main() -> None:
         from utils.notify import notify_scan_complete_background
 
         notify_scan_complete_background(engine.config, engine.db_manager, session_id)
+    except KeyboardInterrupt:
+        _finish_session_interrupted_if_running(engine)
+        print("Scan interrupted.", file=sys.stderr)
+        sys.exit(130)
     except FileNotFoundError as e:
         print(f"Error: {e}")
         print(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -889,6 +889,40 @@ def test_reap_skips_live_pid(tmp_path):
         db.dispose()
 
 
+def test_reap_does_not_overwrite_completed_after_finish(tmp_path, monkeypatch):
+    """TOCTOU: finish_session(completed) mid-reap must not become interrupted (#1251)."""
+    from core.database import LocalDBManager, ScanSession
+
+    db = LocalDBManager(str(tmp_path / "reap_race.db"))
+    try:
+        with db._session_factory() as s:
+            s.add(
+                ScanSession(
+                    session_id="race-sess",
+                    status="running",
+                    pid=2_147_483_647,
+                    owner_hostname=None,
+                )
+            )
+            s.commit()
+
+        def _finish_then_dead(_pid):
+            db.finish_session("race-sess", "completed")
+            return False
+
+        monkeypatch.setattr(
+            LocalDBManager, "pid_is_alive", staticmethod(_finish_then_dead)
+        )
+        n = db.reap_orphaned_running_sessions()
+        assert n == 0
+        with db._session_factory() as s:
+            rec = s.query(ScanSession).filter_by(session_id="race-sess").one()
+            assert rec.status == "completed"
+            assert rec.finished_at is not None
+    finally:
+        db.dispose()
+
+
 def test_session_pid_column_migrates_legacy_db(tmp_path):
     """DBs created without pid still migrate and reap (#1251)."""
     import sqlite3

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -807,3 +807,132 @@ def test_get_object_state_missing_returns_none(tmp_path):
         assert result is None
     finally:
         db.dispose()
+
+
+def test_reap_orphaned_running_null_pid(tmp_path):
+    """Legacy running rows with pid NULL are marked interrupted (#1251)."""
+    from core.database import LocalDBManager, ScanSession
+
+    db = LocalDBManager(str(tmp_path / "reap_null.db"))
+    try:
+        with db._session_factory() as s:
+            s.add(
+                ScanSession(
+                    session_id="orphan-null",
+                    status="running",
+                    pid=None,
+                    owner_hostname=None,
+                )
+            )
+            s.commit()
+        n = db.reap_orphaned_running_sessions()
+        assert n == 1
+        with db._session_factory() as s:
+            rec = s.query(ScanSession).filter_by(session_id="orphan-null").one()
+            assert rec.status == "interrupted"
+            assert rec.finished_at is not None
+    finally:
+        db.dispose()
+
+
+def test_reap_orphaned_running_dead_pid(tmp_path):
+    """running rows whose PID is not alive are reaped (#1251)."""
+    from core.database import LocalDBManager, ScanSession
+
+    db = LocalDBManager(str(tmp_path / "reap_dead.db"))
+    try:
+        with db._session_factory() as s:
+            s.add(
+                ScanSession(
+                    session_id="orphan-dead",
+                    status="running",
+                    pid=2_147_483_647,  # unlikely live PID
+                    owner_hostname=None,
+                )
+            )
+            s.commit()
+        n = db.reap_orphaned_running_sessions()
+        assert n == 1
+        with db._session_factory() as s:
+            rec = s.query(ScanSession).filter_by(session_id="orphan-dead").one()
+            assert rec.status == "interrupted"
+            assert rec.finished_at is not None
+    finally:
+        db.dispose()
+
+
+def test_reap_skips_live_pid(tmp_path):
+    """Concurrency-safe: never reap a session owned by a live PID (#1251)."""
+    import os
+
+    from core.database import LocalDBManager, ScanSession
+
+    db = LocalDBManager(str(tmp_path / "reap_live.db"))
+    try:
+        with db._session_factory() as s:
+            s.add(
+                ScanSession(
+                    session_id="alive-sess",
+                    status="running",
+                    pid=os.getpid(),
+                    owner_hostname=None,
+                )
+            )
+            s.commit()
+        n = db.reap_orphaned_running_sessions()
+        assert n == 0
+        with db._session_factory() as s:
+            rec = s.query(ScanSession).filter_by(session_id="alive-sess").one()
+            assert rec.status == "running"
+            assert rec.finished_at is None
+    finally:
+        db.dispose()
+
+
+def test_session_pid_column_migrates_legacy_db(tmp_path):
+    """DBs created without pid still migrate and reap (#1251)."""
+    import sqlite3
+
+    from sqlalchemy import text
+
+    from core.database import LocalDBManager
+
+    db_path = tmp_path / "legacy_no_pid.db"
+    con = sqlite3.connect(str(db_path))
+    try:
+        con.execute(
+            "CREATE TABLE scan_sessions ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            "session_id VARCHAR(64) NOT NULL UNIQUE,"
+            "started_at DATETIME,"
+            "finished_at DATETIME,"
+            "status VARCHAR(20)"
+            ")"
+        )
+        con.execute(
+            "INSERT INTO scan_sessions (session_id, status) VALUES ('legacy-orphan', 'running')"
+        )
+        con.commit()
+    finally:
+        con.close()
+
+    db = LocalDBManager(str(db_path))
+    try:
+        with db.engine.connect() as conn:
+            cols = {
+                row[1]
+                for row in conn.execute(
+                    text("PRAGMA table_info(scan_sessions)")
+                ).fetchall()
+            }
+        assert "pid" in cols
+        assert "owner_hostname" in cols
+        # Init already reaped NULL-pid legacy running rows
+        with db._session_factory() as s:
+            from core.database import ScanSession
+
+            rec = s.query(ScanSession).filter_by(session_id="legacy-orphan").one()
+            assert rec.status == "interrupted"
+            assert rec.finished_at is not None
+    finally:
+        db.dispose()


### PR DESCRIPTION
## Summary
- **A)** CLI/API interrupt path marks sessions `interrupted` (engine `KeyboardInterrupt` → `finish_session`; SIGTERM→KeyboardInterrupt on scan CLI; `finish_session` refuses to overwrite non-`running`).
- **B)** Concurrency-safe reaper: `pid` + `owner_hostname` on open; migrate via `ALTER`; `reap_orphaned_running_sessions()` at DB init reaps dead/NULL PIDs only — never a live PID.

## Test plan
- [x] `./scripts/check-all.sh --enforced` (green)
- [x] Unit: null PID / dead PID reaped; live `os.getpid()` skipped; legacy DB without `pid` migrates + reaps
- [ ] Manual: Ctrl+C mid-scan → row `interrupted` + `finished_at` set
- [ ] Bugbot review (requested) on reaper concurrency + migration

Closes #1251

Made with [Cursor](https://cursor.com)