### PR TITLE
fix(integrity): re-baseline anchor on legitimate release upgrade

### DIFF
--- a/core/integrity_anchor.py
+++ b/core/integrity_anchor.py
@@ -17,13 +17,16 @@ Flow (E.1–E.5):
    ``build_digest_matched`` is a **digest compare** flag (not a cryptographic
    signature): True only when ``DATA_BOAR_EXPECTED_BUILD_DIGEST`` was set and
    matched the embedded digest (#1211).
-2. Every later startup (ANY mode, including ``open``): recompute hashes,
-   compare to the anchor. Mismatch → ``integrity_state=tampered`` /
+2. Every later startup (ANY mode, including ``open``): recompute hashes.
+   If ``release_label`` changed (legitimate package upgrade) → **re-baseline**
+   the anchor row and append a ``re-baseline`` event (#1262) — do **not** tint.
+   Same label + hash mismatch → ``integrity_state=tampered`` /
    ``trust_level=adulterated`` and every user-visible surface (report Info
    sheet, dashboard footer, GET /about, GET /status, /health, startup logs)
    shows the ``-alpha`` label ("development / not CI-validated").
-3. ``integrity_events`` is append-only (validation / re-verify / tamper) for
-   forensics and is also preserved by ``wipe_all_data()``.
+3. ``integrity_events`` is append-only
+   (validation / re-verify / re-baseline / tamper) for forensics and is also
+   preserved by ``wipe_all_data()``.
 
 The open-mode worker clamp (OPEN_MODE_WORKER_CAP, enforced in core/engine.py)
 is part of the hashed allowlist: removing the clamp changes ``core/engine.py``
@@ -244,37 +247,71 @@ def ensure_integrity_anchor(config: dict[str, Any] | None = None) -> dict[str, A
             else:
                 # E.3 — startup re-verify against the stored anchor.
                 label, _stored_manifest, stored_json, validated_at, digest_flag = row
-                stored: dict[str, str] = json.loads(stored_json)
-                mismatched = sorted(
-                    set(stored) | set(current),
-                )
-                mismatched = [
-                    rel for rel in mismatched if stored.get(rel) != current.get(rel)
-                ]
-                if mismatched:
+                current_label = _release_label()
+                if label != current_label:
+                    # Release upgrade (#1262): new signed/released bits are the
+                    # new baseline. Same-label hash drift still = tamper below.
+                    # Tamper-EVIDENT (E.6): append-only ``re-baseline`` event.
+                    digest_matched = _build_digest_matched()
+                    conn.execute(
+                        "UPDATE build_integrity_anchor SET release_label=?, "
+                        "manifest_content_hash=?, file_hashes_json=?, "
+                        "validated_at=?, build_digest_matched=? "
+                        "WHERE anchor_version=?",
+                        (
+                            current_label,
+                            _manifest_content_hash(current),
+                            json.dumps(current, sort_keys=True),
+                            now_iso,
+                            1 if digest_matched else 0,
+                            ANCHOR_VERSION,
+                        ),
+                    )
                     _record_event(
                         conn,
-                        "tamper",
-                        "startup re-verify mismatch: " + ", ".join(mismatched),
+                        "re-baseline",
+                        f"release upgrade {label} -> {current_label}: "
+                        f"re-baselined anchor ({len(current)} files, "
+                        f"build_digest_matched={digest_matched})",
                     )
-                    snapshot = {
-                        "integrity_state": "tampered",
-                        "trust_level": "adulterated",
-                        "release_label": label,
-                        "validated_at": validated_at,
-                        "build_digest_matched": bool(digest_flag),
-                        "mismatched_files": mismatched,
-                    }
-                else:
-                    _record_event(conn, "re-verify", "startup re-verify ok")
                     snapshot = {
                         "integrity_state": "validated",
                         "trust_level": "expected",
-                        "release_label": label,
-                        "validated_at": validated_at,
-                        "build_digest_matched": bool(digest_flag),
+                        "release_label": current_label,
+                        "validated_at": now_iso,
+                        "build_digest_matched": digest_matched,
                         "mismatched_files": [],
                     }
+                else:
+                    stored: dict[str, str] = json.loads(stored_json)
+                    mismatched = sorted(set(stored) | set(current))
+                    mismatched = [
+                        rel for rel in mismatched if stored.get(rel) != current.get(rel)
+                    ]
+                    if mismatched:
+                        _record_event(
+                            conn,
+                            "tamper",
+                            "startup re-verify mismatch: " + ", ".join(mismatched),
+                        )
+                        snapshot = {
+                            "integrity_state": "tampered",
+                            "trust_level": "adulterated",
+                            "release_label": label,
+                            "validated_at": validated_at,
+                            "build_digest_matched": bool(digest_flag),
+                            "mismatched_files": mismatched,
+                        }
+                    else:
+                        _record_event(conn, "re-verify", "startup re-verify ok")
+                        snapshot = {
+                            "integrity_state": "validated",
+                            "trust_level": "expected",
+                            "release_label": label,
+                            "validated_at": validated_at,
+                            "build_digest_matched": bool(digest_flag),
+                            "mismatched_files": [],
+                        }
             conn.commit()
     except (sqlite3.Error, OSError, json.JSONDecodeError) as e:
         logger.warning("Integrity anchor unavailable (state=unknown): %s", e)

--- a/docs/ops/INTEGRITY_CHECK_ALPHA_LOGIC.md
+++ b/docs/ops/INTEGRITY_CHECK_ALPHA_LOGIC.md
@@ -70,7 +70,13 @@ Append a structured record to `security_alert.log` (or SIEM sink):
    scan tables only.
 2. **Startup re-verify (E.3):** every start (CLI and web, **any** licensing
    mode including `open`) recomputes the hashes and compares to the anchor.
-   Mismatch → `integrity_state=tampered` / `trust_level=adulterated`.
+   - **Same `release_label` + hash mismatch** → `integrity_state=tampered` /
+     `trust_level=adulterated` (unchanged; do not soften).
+   - **`release_label` changed (legitimate package upgrade)** → **re-baseline**
+     the single anchor row to the new hashes / label, append a `re-baseline`
+     event, and stay `validated` / `expected` ([#1262](https://github.com/DataBoar/data-boar/issues/1262)).
+     A PyPI/wheel upgrade that changes `CRITICAL_MODULES` is expected; treating
+     it as tamper breaks every `pip install -U` that reuses the SQLite DB.
 3. **TINTED / `-alpha` (E.4):** the adulterated state forces the
    `-alpha (development / not CI-validated)` label on the report Info sheet
    (`Build trust` / `Integrity state` rows), dashboard footer, `GET /about`,
@@ -81,18 +87,20 @@ Append a structured record to `security_alert.log` (or SIEM sink):
    `OPEN_MODE_WORKER_CAP = 2` in open mode. The clamp lives inside the hashed
    allowlist — removing it changes `core/engine.py` and tints the build.
 5. **Forensics (E.5):** `integrity_events` is an append-only table
-   (validation / re-verify / tamper) preserved across data wipes.
+   (validation / re-verify / re-baseline / tamper) preserved across data wipes.
 
 ### Honest threat model (E.6)
 
 This is **tamper-EVIDENT, not tamper-PROOF.** An attacker with write access to
 both the code tree **and** the SQLite anchor file can delete or re-baseline the
-anchor (the app then re-runs first validation or shows `unknown`). Mitigations:
-file permissions, read-only DB mounts in high-assurance deploys, and the
-**signed manifest** (Sigstore / CI OIDC — Phase C.4 of
-`PLAN_BUILD_IDENTITY_RELEASE_INTEGRITY`) as the next hardening layer. The local
-anchor reliably catches casual edits, forks with gates removed, and silent
-deploy drift — which is the Alpha-detection goal.
+anchor (the app then re-runs first validation or shows `unknown`). The
+**release-upgrade re-baseline** path only runs when `release_label` changes;
+same-version hash drift still tints. Unexpected upgrades remain visible in the
+append-only `re-baseline` event trail. Mitigations: file permissions, read-only
+DB mounts in high-assurance deploys, and the **signed manifest** (Sigstore /
+CI OIDC — Phase C.4 of `PLAN_BUILD_IDENTITY_RELEASE_INTEGRITY`) as the next
+hardening layer. The local anchor reliably catches casual edits, forks with
+gates removed, and silent deploy drift — which is the Alpha-detection goal.
 
 ## Related
 

--- a/docs/ops/INTEGRITY_CHECK_ALPHA_LOGIC.pt_BR.md
+++ b/docs/ops/INTEGRITY_CHECK_ALPHA_LOGIC.pt_BR.md
@@ -72,8 +72,15 @@ Anexar registro estruturado a `security_alert.log` (ou destino SIEM):
    de scan.
 2. **Re-verificação no startup (E.3):** todo start (CLI e web, **qualquer**
    modo de licenciamento, incluindo `open`) recomputa os hashes e compara com
-   a âncora. Divergência → `integrity_state=tampered` /
-   `trust_level=adulterated`.
+   a âncora.
+   - **Mesmo `release_label` + hash divergente** → `integrity_state=tampered` /
+     `trust_level=adulterated` (não afrouxar).
+   - **`release_label` mudou (upgrade legítimo do pacote)** → **re-baseline**
+     da única linha da âncora (novos hashes / label), evento append-only
+     `re-baseline`, e permanece `validated` / `expected`
+     ([#1262](https://github.com/DataBoar/data-boar/issues/1262)). Um upgrade
+     PyPI/wheel que altera `CRITICAL_MODULES` é esperado; tratá-lo como
+     tamper quebra todo `pip install -U` que reusa o SQLite.
 3. **TINTED / `-alpha` (E.4):** o estado adulterado força o rótulo
    `-alpha (development / not CI-validated)` na aba Info do report (linhas
    `Build trust` / `Integrity state`), no rodapé do dashboard, em
@@ -85,18 +92,22 @@ Anexar registro estruturado a `security_alert.log` (ou destino SIEM):
    dentro da allowlist hasheada — remover o clamp altera `core/engine.py` e
    tinge o build.
 5. **Forense (E.5):** `integrity_events` é uma tabela append-only
-   (validation / re-verify / tamper) preservada em wipes de dados.
+   (validation / re-verify / re-baseline / tamper) preservada em wipes de
+   dados.
 
 ### Modelo de ameaça honesto (E.6)
 
 Isto é **evidência de adulteração, não prova de inviolabilidade.** Um atacante
 com acesso de escrita ao código **e** ao arquivo SQLite da âncora pode apagar
 ou re-basear a âncora (o app então re-executa a primeira validação ou mostra
-`unknown`). Mitigações: permissões de arquivo, montagem somente leitura do DB
-em deploys de alta garantia, e o **manifest assinado** (Sigstore / CI OIDC —
-Fase C.4 do `PLAN_BUILD_IDENTITY_RELEASE_INTEGRITY`) como próxima camada. A
-âncora local captura com confiabilidade edições casuais, forks com gates
-removidos e drift silencioso de deploy — que é o objetivo da detecção Alpha.
+`unknown`). O caminho de **re-baseline no upgrade de release** só dispara
+quando `release_label` muda; drift de hash na mesma versão ainda tingido.
+Upgrades inesperados ficam no rastro append-only do evento `re-baseline`.
+Mitigações: permissões de arquivo, montagem somente leitura do DB em deploys
+de alta garantia, e o **manifest assinado** (Sigstore / CI OIDC — Fase C.4 do
+`PLAN_BUILD_IDENTITY_RELEASE_INTEGRITY`) como próxima camada. A âncora local
+captura com confiabilidade edições casuais, forks com gates removidos e drift
+silencioso de deploy — que é o objetivo da detecção Alpha.
 
 ## Relacionados
 

--- a/tests/test_integrity_anchor.py
+++ b/tests/test_integrity_anchor.py
@@ -41,9 +41,11 @@ from core.integrity_anchor import (
     OPEN_MODE_WORKER_CAP,
     VALIDATOR_VERSION,
     _manifest_content_hash,
+    alpha_version_suffix,
     compute_module_hashes,
     ensure_integrity_anchor,
     get_integrity_snapshot,
+    is_tampered,
     list_integrity_events,
     reset_integrity_anchor_for_tests,
 )
@@ -166,11 +168,15 @@ def test_release_upgrade_rebaselines_without_tamper(tmp_path, monkeypatch):
     drifted["core/engine.py"] = "a" * 64
     monkeypatch.setattr("core.integrity_anchor.compute_module_hashes", lambda: drifted)
     monkeypatch.setattr("core.integrity_anchor._release_label", lambda: "1.7.4.post5")
+    reset_integrity_anchor_for_tests()
     snap = ensure_integrity_anchor(cfg)
     assert snap["integrity_state"] == "validated"
     assert snap["trust_level"] == "expected"
     assert snap["release_label"] == "1.7.4.post5"
     assert snap["mismatched_files"] == []
+    # User-visible watermark must stay clean after legitimate upgrade.
+    assert is_tampered() is False
+    assert alpha_version_suffix() == ""
 
     with contextlib.closing(sqlite3.connect(cfg["sqlite_path"])) as conn:
         rows = conn.execute(
@@ -195,10 +201,14 @@ def test_same_release_label_still_detects_tamper(tmp_path, monkeypatch):
     ensure_integrity_anchor(cfg)
     _tamper(monkeypatch)
     monkeypatch.setattr("core.integrity_anchor._release_label", lambda: "1.7.4.post5")
+    reset_integrity_anchor_for_tests()
     snap = ensure_integrity_anchor(cfg)
     assert snap["integrity_state"] == "tampered"
     assert snap["trust_level"] == "adulterated"
     assert "core/engine.py" in snap["mismatched_files"]
+    # User-visible watermark must still tint on real same-version tamper.
+    assert is_tampered() is True
+    assert alpha_version_suffix() == "-alpha"
     assert any(e["event_type"] == "tamper" for e in list_integrity_events(cfg))
     assert not any(e["event_type"] == "re-baseline" for e in list_integrity_events(cfg))
 

--- a/tests/test_integrity_anchor.py
+++ b/tests/test_integrity_anchor.py
@@ -22,6 +22,8 @@ Contract under test:
 8. ``build_digest_matched`` (#1211): True only when expected digest set and
    matches; unset env → False (no signature overclaim).
 9. Legacy DB column ``signature_ok`` migrates to ``build_digest_matched``.
+10. Release upgrade (#1262): ``release_label`` change re-baselines; same-label
+    hash drift still tampers.
 """
 
 from __future__ import annotations
@@ -152,6 +154,53 @@ def test_tamper_detected_in_open_mode_without_licensing_config(tmp_path, monkeyp
     ensure_integrity_anchor(cfg)
     _tamper(monkeypatch)
     assert ensure_integrity_anchor(cfg)["integrity_state"] == "tampered"
+
+
+def test_release_upgrade_rebaselines_without_tamper(tmp_path, monkeypatch):
+    """#1262: release_label change + new hashes → re-baseline, not tampered."""
+    cfg = _cfg(tmp_path)
+    monkeypatch.setattr("core.integrity_anchor._release_label", lambda: "1.7.4.post4")
+    ensure_integrity_anchor(cfg)
+
+    drifted = compute_module_hashes()
+    drifted["core/engine.py"] = "a" * 64
+    monkeypatch.setattr("core.integrity_anchor.compute_module_hashes", lambda: drifted)
+    monkeypatch.setattr("core.integrity_anchor._release_label", lambda: "1.7.4.post5")
+    snap = ensure_integrity_anchor(cfg)
+    assert snap["integrity_state"] == "validated"
+    assert snap["trust_level"] == "expected"
+    assert snap["release_label"] == "1.7.4.post5"
+    assert snap["mismatched_files"] == []
+
+    with contextlib.closing(sqlite3.connect(cfg["sqlite_path"])) as conn:
+        rows = conn.execute(
+            "SELECT release_label, file_hashes_json FROM build_integrity_anchor"
+        ).fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == "1.7.4.post5"
+    stored = json.loads(rows[0][1])
+    assert stored["core/engine.py"] == "a" * 64
+
+    events = list_integrity_events(cfg)
+    assert any(e["event_type"] == "re-baseline" for e in events)
+    re_bl = next(e for e in events if e["event_type"] == "re-baseline")
+    assert "1.7.4.post4 -> 1.7.4.post5" in re_bl["detail"]
+    assert not any(e["event_type"] == "tamper" for e in events)
+
+
+def test_same_release_label_still_detects_tamper(tmp_path, monkeypatch):
+    """#1262 regression: same label + hash drift remains tampered (not softened)."""
+    cfg = _cfg(tmp_path)
+    monkeypatch.setattr("core.integrity_anchor._release_label", lambda: "1.7.4.post5")
+    ensure_integrity_anchor(cfg)
+    _tamper(monkeypatch)
+    monkeypatch.setattr("core.integrity_anchor._release_label", lambda: "1.7.4.post5")
+    snap = ensure_integrity_anchor(cfg)
+    assert snap["integrity_state"] == "tampered"
+    assert snap["trust_level"] == "adulterated"
+    assert "core/engine.py" in snap["mismatched_files"]
+    assert any(e["event_type"] == "tamper" for e in list_integrity_events(cfg))
+    assert not any(e["event_type"] == "re-baseline" for e in list_integrity_events(cfg))
 
 
 # --- 4. survives wipe_all_data (--reset-data) ------------------------------------


### PR DESCRIPTION
## Summary
Fixes false `integrity_state=tampered` / `-alpha` after a legitimate package upgrade that reuses the same SQLite DB (reproduced: `pipx upgrade` post4→post5 + shared `audit_demo.db`).

**Cause:** E.3 re-verify compared module hashes without checking whether `release_label` changed.

**Fix:** when stored `release_label` ≠ current `_release_label()`, UPDATE the single anchor row to the new baseline and append a `re-baseline` event. **Same label + hash drift still tampers** (not softened). Aligns with E.6 (tamper-evident, not proof).

Related: **#1262** (issue exists; **no auto-close** — link only).

## Test plan
- [x] `./scripts/check-all.sh --enforced`
- [x] Upgrade path → `validated` + `re-baseline` event + one row
- [x] Same label + drift → still `tampered`
- [ ] Bugbot on concurrency / soften risk

## Security note
Re-baseline **only** on `release_label` change. GATE_FILE untouched.

Made with [Cursor](https://cursor.com)