### PR TITLE
chore(release): 1.7.4.post6 (PyPI publish counter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ Human-readable summary of user-facing changes. **Detailed release notes:** [docs
 
 ---
 
+## 1.7.4.post6 (pending PyPI dispatch)
+
+> Post-release on the **`1.7.4`** public line. **`[project] version = 1.7.4.post6`** and **`[tool.databoar] maturity_build = 241`** (`N=1` `fix(` commit since post5 `b7de32ba`, ADR-0073). **PyPI-only** — no Git tag, no GitHub Release, no container.
+
+### Fixed / hardened (post6)
+
+- **Integrity:** re-baseline the SQLite integrity anchor on a **legitimate** release upgrade — `pip install -U` / `pipx upgrade` reusing the same SQLite DB no longer false-tints as tampered/`-alpha`; same `release_label` + hash drift still = `tampered` (real detection preserved) (#1262, #1263).
+
+### Notes (post6)
+
+- Full `N=1` fix set and `postN` ↔ `maturity_build` map: [docs/releases/1.7.4.post6.md](docs/releases/1.7.4.post6.md).
+
+---
+
 ## 1.7.4.post5 (pending PyPI dispatch)
 
 > Post-release on the **`1.7.4`** public line. **`[project] version = 1.7.4.post5`** and **`[tool.databoar] maturity_build = 240`** (`N=14` `fix(` commits since post4 merge `656fdc3d`, ADR-0073). **PyPI-only** — no Git tag, no GitHub Release, no container.

--- a/core/about.py
+++ b/core/about.py
@@ -11,7 +11,7 @@ def _package_version() -> str:
 
         return version("data-boar")
     except Exception:
-        return "1.7.4.post5"
+        return "1.7.4.post6"
 
 
 def get_http_user_agent() -> str:

--- a/docs/releases/1.7.4.post6.md
+++ b/docs/releases/1.7.4.post6.md
@@ -1,0 +1,93 @@
+# Release 1.7.4.post6 (PyPI publish counter)
+
+**Status:** Pending PyPI upload after merge (operator **`publish-pypi`** `workflow_dispatch`: build → TestPyPI → PyPI).
+
+**Public line (marketing):** **`1.7.4`** — README, man pages, stakeholder copy unchanged.
+
+**Build / PyPI / About:** **`1.7.4.post6`** — PEP 440 post-release (publish counter per [ADR-0073](../adr/ADR-0073-version-scheme-octet-maturity-and-roadmap.md) § *PyPI dual counters*).
+
+**Not in this drop:** Git tag · GitHub Release · Docker / container image (PyPI-only `.postN`).
+
+---
+
+## Mandatory map: `postN` ↔ `maturity_build`
+
+Per ADR-0073: **`postN`** counts **PyPI uploads**; **`maturity_build`** counts **discrete fixes** and may run ahead. This map is the mandatory audit trail.
+
+| PyPI / `[project] version` | `maturity_build` (octet) | Notes |
+| --- | --- | --- |
+| **`1.7.4`** | **`.201`** | GA on PyPI (immutable); release PR **#1024** |
+| **`1.7.4.post1`** | **`.202`** | SQL drivers → optional extras ([#1047](https://github.com/DataBoar/data-boar/issues/1047)) — published |
+| *(fix, unpublished on PyPI)* | **`.203`** | [#1026](https://github.com/DataBoar/data-boar/pull/1026) |
+| *(fix, unpublished on PyPI)* | **`.204`** | [#1028](https://github.com/DataBoar/data-boar/pull/1028) |
+| *(fix, unpublished on PyPI)* | **`.205`** | Deploy / packaging fix train |
+| *(fix, unpublished on PyPI)* | **`.206`** | `main.py --version` without config |
+| *(fix, unpublished on PyPI)* | **`.207`** | `fix(connectors)` symlink / reparse-point loop guard ([#1080](https://github.com/DataBoar/data-boar/pull/1080)) |
+| **`1.7.4.post2`** | **`.208`** | Prior upload on this line |
+| *(fix, unpublished on PyPI)* | **`.209`** | SQL sampling failures now surface in `scan_failures` ([#1140](https://github.com/DataBoar/data-boar/issues/1140), [#1144](https://github.com/DataBoar/data-boar/pull/1144)) |
+| *(fix, unpublished on PyPI)* | **`.210`** | Encrypted/corrupt archive members now surface in `scan_failures` (open-core slice of [#828](https://github.com/DataBoar/data-boar/issues/828), [#1146](https://github.com/DataBoar/data-boar/pull/1146)) |
+| **`1.7.4.post3`** | **`.211`** | Published with `soupsieve` CVE fix ([#1177](https://github.com/DataBoar/data-boar/pull/1177)) |
+| *(fix, unpublished on PyPI)* | **`.212`** | RBAC now defaults to deny on the full route map (#1133). |
+| *(fix, unpublished on PyPI)* | **`.213`** | API key comparison now uses UTF-8 byte-safe `compare_digest` (#1150). |
+| *(fix, unpublished on PyPI)* | **`.214`** | Operator-gated reopen workflow pins were restored to keep governance automation stable. |
+| *(fix, unpublished on PyPI)* | **`.215`** | SQL sampling transaction scope is now isolated per connection (#1194). |
+| *(fix, unpublished on PyPI)* | **`.216`** | One-class compliance profiles now preserve declared-term detections (#1195). |
+| *(fix, unpublished on PyPI)* | **`.217`** | XLSX exports now neutralize formula-leading cells to prevent spreadsheet injection (#1201). |
+| *(fix, unpublished on PyPI)* | **`.218`** | Web exposure defaults now enforce a safe-by-default posture for remote surface (#1202). |
+| *(fix, unpublished on PyPI)* | **`.219`** | Follow-up CodeQL logging and import-cycle hardening landed on the web-exposure path (#1202). |
+| *(fix, unpublished on PyPI)* | **`.220`** | Remaining routes-context import cycle was removed to stabilize route wiring. |
+| *(fix, unpublished on PyPI)* | **`.221`** | Config redaction now masks DSN/URL embedded credentials in `/config` (#1137). |
+| *(fix, unpublished on PyPI)* | **`.222`** | Prefilter now preserves recall parity with active profile terms/regexes (#1198). |
+| *(fix, unpublished on PyPI)* | **`.223`** | Help output now aligns dev invocation and installed command contract (#1130). |
+| *(fix, unpublished on PyPI)* | **`.224`** | Demo sessions now resolve audit trail correctly via `/logs/{session_id}` (#1218). |
+| *(fix, unpublished on PyPI)* | **`.225`** | Logs fallback hardening removed the CodeQL path-injection sink in demo retrieval (#1218, `4bd3e5bc`). |
+| **`1.7.4.post4`** | **`.226`** | Pillow `12.2.0` → `12.3.0` (PYSEC-2026-2253..2257); baseline post3 + `N=15`. |
+| *(fix, unpublished on PyPI)* | **`.227`** | Align ATS import footer skill path to private (#1191). |
+| *(fix, unpublished on PyPI)* | **`.228`** | Standalone HTML form CSRF without WebAuthn (#1231). |
+| *(fix, unpublished on PyPI)* | **`.229`** | Dataverse `org_url` / `token_url` SSRF guards (#1232). |
+| *(fix, unpublished on PyPI)* | **`.230`** | Aggregate archive decompression budgets (#1233). |
+| *(fix, unpublished on PyPI)* | **`.231`** | Reject non-finite `max_expansion_ratio` (nan/inf). |
+| *(fix, unpublished on PyPI)* | **`.232`** | Secret-by-identity lock + reachable JWT GRACE (#1210, #1212). |
+| *(fix, unpublished on PyPI)* | **`.233`** | Fail-closed on non-numeric license `exp` claim. |
+| *(fix, unpublished on PyPI)* | **`.234`** | Honest `build_digest_matched` (no `signature_ok` overclaim) (#1211). |
+| *(fix, unpublished on PyPI)* | **`.235`** | Zero legacy `build_digest_matched` bit on migrate (#1211). |
+| *(fix, unpublished on PyPI)* | **`.236`** | Drop `Invoke-Expression` from `external-review-pack.ps1` (#1192). |
+| *(fix, unpublished on PyPI)* | **`.237`** | Read `.7z` members via py7zr `BytesIOFactory` (#1250, #1248). |
+| *(fix, unpublished on PyPI)* | **`.238`** | Extract pre-budget `.7z` members on budget stop (#1250, #1248). |
+| *(fix, unpublished on PyPI)* | **`.239`** | Orphan session reaper (PID liveness) + interrupt → `interrupted` (#1251). |
+| **`1.7.4.post5`** | **`.240`** | Post5 wave (archives/sessions/security/integrity train); baseline post4 + `N=14` `fix(` — see [1.7.4.post5.md](1.7.4.post5.md). |
+| **`1.7.4.post6`** | **`.241`** | **This upload** — integrity anchor re-baselines on legitimate release upgrade (#1262 / #1263); baseline `1.7.4.post5` + `N=1` `fix(` commit. |
+
+---
+
+## Appendix — Fix set used for `N` (`N=1`) (git-literal)
+
+**Boundary:** `chore(release): 1.7.4.post5` → `b7de32ba`.
+
+```bash
+git log b7de32ba..HEAD --format='%h %s' | rg '^[0-9a-f]+ fix\('
+# COUNT=1  →  maturity_build = 240 + 1 = 241
+```
+
+Commits counted:
+
+1. `6dc54642` — `fix(integrity): re-baseline anchor on release upgrade`
+
+**Not counted toward `N` (not `fix(`):** `test(integrity): assert -alpha watermark on upgrade vs tamper` (`1384061a`); docs under `docs/ops/INTEGRITY_CHECK_ALPHA_LOGIC*` that landed in the same PR train; merge commit of #1263.
+
+---
+
+## Highlights (why post6)
+
+- Demo-critical upgrade UX: `pip install -U` / `pipx upgrade` reusing the same SQLite DB no longer false-tints as `-alpha` / `integrity_tampered` when only the package version (and shipped `CRITICAL_MODULES`) changed.
+- Same-version hash drift still tampers (detection not softened); append-only `re-baseline` event keeps the E.6 tamper-evident trail.
+
+---
+
+## Install
+
+```bash
+pip install 'data-boar==1.7.4.post6'
+```
+
+See [USAGE.md](../USAGE.md), [QUICKSTART.md](../QUICKSTART.md), and [TROUBLESHOOTING.md](../TROUBLESHOOTING.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-boar"
-version = "1.7.4.post5"
+version = "1.7.4.post6"
 description = "Data Boar — compliance-aware discovery and mapping of personal and sensitive data across databases, files, and APIs (LGPD, GDPR, CCPA, and configurable frameworks)."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -302,6 +302,6 @@ dev = [
 ]
 
 # Operator-only maturity octet (ADR-0073). Never copy into [project].version.
-# postN <-> maturity_build map: docs/releases/1.7.4.post5.md (canonical; includes post1–post4 rows).
+# postN <-> maturity_build map: docs/releases/1.7.4.post6.md (canonical; includes post1–post5 rows).
 [tool.databoar]
-maturity_build = 240
+maturity_build = 241

--- a/tests/test_pyproject_sql_extras.py
+++ b/tests/test_pyproject_sql_extras.py
@@ -64,11 +64,11 @@ def test_sql_optional_extras_present() -> None:
 def test_maturity_build_bumped_for_packaging_fix() -> None:
     data = _load_pyproject()
     maturity = data.get("tool", {}).get("databoar", {}).get("maturity_build")
-    assert maturity == 240
+    assert maturity == 241
 
 
 def test_version_is_174_post_release_not_semver_bump() -> None:
     version = _load_pyproject().get("project", {}).get("version")
-    assert version == "1.7.4.post5"
+    assert version == "1.7.4.post6"
     assert not str(version).startswith("1.7.5")
     assert not str(version).startswith("1.8.")

--- a/uv.lock
+++ b/uv.lock
@@ -800,7 +800,7 @@ validation = [
 
 [[package]]
 name = "data-boar"
-version = "1.7.4.post5"
+version = "1.7.4.post6"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-doc" },


### PR DESCRIPTION
## Summary
Release-prep bump for **`1.7.4.post6`** (PEP 440 post-release / ADR-0073). **PyPI-only** — operator runs build → TestPyPI → PyPI. **No** Git tag, **no** GitHub Release, **no** container.

| Field | Value |
| --- | --- |
| `[project] version` | `1.7.4.post5` → **`1.7.4.post6`** |
| `maturity_build` | `240` → **`241`** |
| GATE_FILE | none touched |

## `maturity_build` calculation (ADR-0073)

**Boundary:** `chore(release): 1.7.4.post5` → `b7de32ba`.

```bash
git log b7de32ba..HEAD --format='%h %s' | rg '^[0-9a-f]+ fix\('
# COUNT = 1
# maturity_build = 240 + 1 = 241
```

Counted: `6dc54642` — `fix(integrity): re-baseline anchor on release upgrade` (#1263).

**Not in N:** `test(integrity)…` (`1384061a`); docs in the same PR train.

Full map: [`docs/releases/1.7.4.post6.md`](docs/releases/1.7.4.post6.md).

## Wave packaged

- fix(integrity): legitimate release-upgrade re-baseline; same-version drift still tampers (#1262 / #1263)

## Test plan
- [x] `./scripts/check-all.sh --enforced`
- [ ] Operator: merge → `publish-pypi` (TestPyPI → PyPI)

**Does not close issues** — bump-only release-prep.

Made with [Cursor](https://cursor.com)