### PR TITLE
chore(post7): project.urls org, post4 octet backfill, integrity comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Human-readable summary of user-facing changes. **Detailed release notes:** [docs
 
 ## 1.7.4.post4 (pending PyPI dispatch)
 
-> Post-release on the **`1.7.4`** public line. **`[project] version = 1.7.4.post4`** and **`[tool.databoar] maturity_build = 225`** (`N=14` fixes since post3 baseline, ADR-0073 dual counter policy).
+> Post-release on the **`1.7.4`** public line. **`[project] version = 1.7.4.post4`** and **`[tool.databoar] maturity_build = 226`** (`N=15` fixes since post3 baseline, ADR-0073 dual counter policy).
 
 ### Fixed (post4)
 

--- a/core/integrity_anchor.py
+++ b/core/integrity_anchor.py
@@ -249,7 +249,7 @@ def ensure_integrity_anchor(config: dict[str, Any] | None = None) -> dict[str, A
                 label, _stored_manifest, stored_json, validated_at, digest_flag = row
                 current_label = _release_label()
                 if label != current_label:
-                    # Release upgrade (#1262): new signed/released bits are the
+                    # Release upgrade (#1262): new released bits are the
                     # new baseline. Same-label hash drift still = tamper below.
                     # Tamper-EVIDENT (E.6): append-only ``re-baseline`` event.
                     digest_matched = _build_digest_matched()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,10 +117,10 @@ data-boar = "main:main"
 data-boar-report = "cli.reporter:main"
 
 [project.urls]
-Homepage = "https://github.com/FabioLeitao/data-boar"
-Repository = "https://github.com/FabioLeitao/data-boar"
-Issues = "https://github.com/FabioLeitao/data-boar/issues"
-Changelog = "https://github.com/FabioLeitao/data-boar/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/DataBoar/data-boar"
+Repository = "https://github.com/DataBoar/data-boar"
+Issues = "https://github.com/DataBoar/data-boar/issues"
+Changelog = "https://github.com/DataBoar/data-boar/blob/main/CHANGELOG.md"
 "Docker Hub" = "https://hub.docker.com/r/fabioleitao/data_boar"
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
Housekeeping-only (docs/metadata/comment) — **no functional change**. GATE_FILE untouched. No tag / Release / container.

1. **`[project.urls]`** — `FabioLeitao` → `DataBoar` on Homepage / Repository / Issues / Changelog. Docker Hub `fabioleitao/data_boar` left as-is (personal namespace).
2. **CHANGELOG post4 header** — `maturity_build` **225→226**, **N=14→N=15** (align with authoritative map / pyproject at post4 merge).
3. **`integrity_anchor` comment** — drop overclaim “signed”; baseline is local SHA-256 (Sigstore = future layer).

Closes #1227

## Test plan
- [x] `./scripts/check-all.sh --enforced`

Made with [Cursor](https://cursor.com)