### PR TITLE
fix(api): WebAuthn session satisfies require_api_key (#1258)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -92,6 +92,7 @@ from api.webauthn_html_gate import (
     safe_next_path,
     verify_html_form_csrf_or_raise,
     webauthn_html_session_middleware as webauthn_html_session_gate,
+    webauthn_session_satisfies_require_api_key,
 )
 from api.webauthn_routes import register_webauthn_routes
 
@@ -1103,7 +1104,8 @@ async def optional_api_key_middleware(request: Request, call_next):
     """
     When ``api.require_api_key`` is true and a key is available (literal or resolved from
     ``api_key_from_env`` at config load), require **X-API-Key** or **Authorization: Bearer**
-    for every path except **GET /health** (liveness: must stay unauthenticated).
+    for every path except **GET /health** (liveness: must stay unauthenticated). A valid
+    **WebAuthn session cookie** also satisfies this gate when WebAuthn is enabled (#1258).
 
     Responses: **401** if the key is missing or wrong; **503** if the operator enabled
     ``require_api_key`` but no key could be resolved (misconfiguration).
@@ -1136,6 +1138,8 @@ async def optional_api_key_middleware(request: Request, call_next):
         if auth.lower().startswith("bearer "):
             provided = auth[7:].strip()
     if not provided or not hmac.compare_digest(provided, expected):
+        if webauthn_session_satisfies_require_api_key(cfg, request):
+            return await call_next(request)
         return JSONResponse(
             status_code=401, content={"detail": "Missing or invalid API key"}
         )

--- a/api/webauthn_html_gate.py
+++ b/api/webauthn_html_gate.py
@@ -69,6 +69,22 @@ def request_has_webauthn_session(request: Request, token_secret: str) -> bool:
     return session_cookie.verify_session_cookie(token_secret, raw) is not None
 
 
+def webauthn_session_satisfies_require_api_key(cfg: dict, request: Request) -> bool:
+    """
+    True when WebAuthn is enabled and the request carries a valid signed session cookie.
+
+    Lets browser dashboard JSON calls (e.g. ``/status``, ``/scan``) coexist with
+    ``api.require_api_key`` without turning off API-key protection for automation (#1258).
+    """
+    wa = webauthn_block(cfg)
+    if wa is None:
+        return False
+    secret = resolve_token_secret(wa)
+    if not secret:
+        return False
+    return request_has_webauthn_session(request, secret)
+
+
 def is_locale_html_public_unauthenticated(method: str, rest: list[str]) -> bool:
     """Pages reachable without WebAuthn session when gate is on (GET only)."""
     return method == "GET" and len(rest) == 1 and rest[0] in ("help", "about", "login")

--- a/tests/test_webauthn_html_gate.py
+++ b/tests/test_webauthn_html_gate.py
@@ -224,3 +224,84 @@ def test_config_post_rejects_forged_csrf_when_gate_off(html_csrf_gate_off_client
         follow_redirects=False,
     )
     assert r.status_code == 403
+
+
+def test_require_api_key_satisfied_by_webauthn_session_on_json_route(
+    webauthn_gate_client,
+):
+    """#1258: valid WebAuthn session cookie must satisfy api.require_api_key on /status."""
+    client, routes_mod = webauthn_gate_client
+    cfg_path = Path(routes_mod._config_path)
+    cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    cfg.setdefault("api", {})["require_api_key"] = True
+    cfg["api"]["api_key"] = "automation-secret"
+    cfg_path.write_text(yaml.dump(cfg, sort_keys=False), encoding="utf-8")
+    routes_mod._config = None
+
+    wa = webauthn_block(cfg)
+    assert wa is not None
+    uid = user_id_bytes(wa)
+    secret = "unit-test-webauthn-secret-min-16"
+    dbm = routes_mod._get_engine().db_manager
+    dbm.webauthn_save_credential(
+        user_id=uid,
+        credential_id=b"unit-test-credential-id-32bytes!!",
+        public_key=b"k" * 64,
+        sign_count=0,
+    )
+    client.cookies.set(COOKIE_NAME, sign_session(secret, uid))
+
+    resp = client.get("/status")
+    assert resp.status_code == 200
+
+
+def test_require_api_key_still_rejects_without_session_when_webauthn_on(
+    webauthn_gate_client,
+):
+    """#1258: api-key gate stays enforced for JSON when no session and no key."""
+    client, routes_mod = webauthn_gate_client
+    cfg_path = Path(routes_mod._config_path)
+    cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    cfg.setdefault("api", {})["require_api_key"] = True
+    cfg["api"]["api_key"] = "automation-secret"
+    cfg_path.write_text(yaml.dump(cfg, sort_keys=False), encoding="utf-8")
+    routes_mod._config = None
+
+    wa = webauthn_block(cfg)
+    uid = user_id_bytes(wa)
+    dbm = routes_mod._get_engine().db_manager
+    dbm.webauthn_save_credential(
+        user_id=uid,
+        credential_id=b"unit-test-credential-id-32bytes!!",
+        public_key=b"k" * 64,
+        sign_count=0,
+    )
+
+    resp = client.get("/status")
+    assert resp.status_code == 401
+
+
+def test_require_api_key_accepts_session_over_wrong_api_key(webauthn_gate_client):
+    """#1258: wrong X-API-Key must not block a valid WebAuthn browser session."""
+    client, routes_mod = webauthn_gate_client
+    cfg_path = Path(routes_mod._config_path)
+    cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    cfg.setdefault("api", {})["require_api_key"] = True
+    cfg["api"]["api_key"] = "automation-secret"
+    cfg_path.write_text(yaml.dump(cfg, sort_keys=False), encoding="utf-8")
+    routes_mod._config = None
+
+    wa = webauthn_block(cfg)
+    uid = user_id_bytes(wa)
+    secret = "unit-test-webauthn-secret-min-16"
+    dbm = routes_mod._get_engine().db_manager
+    dbm.webauthn_save_credential(
+        user_id=uid,
+        credential_id=b"unit-test-credential-id-32bytes!!",
+        public_key=b"k" * 64,
+        sign_count=0,
+    )
+    client.cookies.set(COOKIE_NAME, sign_session(secret, uid))
+
+    resp = client.get("/status", headers={"X-API-Key": "wrong-key"})
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary

- Valid WebAuthn session cookie now satisfies `api.require_api_key` on JSON routes (`/status`, `/scan`, etc.)
- Automation clients still require `X-API-Key` / `Authorization: Bearer` when no session is present
- Enables `require_api_key: true` + `webauthn.enabled: true` to coexist without opening JSON surfaces

Closes #1258

## Test plan

- [x] `./scripts/check-all.sh` green (ADR-0080)
- [x] `test_require_api_key_satisfied_by_webauthn_session_on_json_route`
- [x] `test_require_api_key_still_rejects_without_session_when_webauthn_on`
- [x] `test_require_api_key_accepts_session_over_wrong_api_key`
- [ ] HITL merge


Made with [Cursor](https://cursor.com)