### PR TITLE
fix(learned_patterns): bare filename skip + output_dir anchor (#1259, #1260)

### DIFF
--- a/core/learned_patterns.py
+++ b/core/learned_patterns.py
@@ -45,12 +45,12 @@ def _extract_term(row: dict, source: str) -> str | None:
     if source == "database":
         term = (row.get("column_name") or "").strip()
     else:
-        # Filesystem: file_name can be "path.db | table.column" or a path
+        # Filesystem: only learn structured db-like locations ("path | table.column").
+        # Bare filenames (e.g. main.yml) do not generalize across projects (#1259).
         fn = (row.get("file_name") or "").strip()
-        if " | " in fn:
-            term = fn.split(" | ")[-1].strip()  # e.g. table.column
-        else:
-            term = Path(fn).name if fn else ""
+        if " | " not in fn:
+            return None
+        term = fn.split(" | ")[-1].strip()  # e.g. table.column
     return term if term else None
 
 
@@ -147,6 +147,17 @@ def _load_existing_ml_texts(path: str | Path | None) -> set[str]:
     return out
 
 
+def _resolve_learned_patterns_output_path(lp: dict, config: dict[str, Any]) -> Path:
+    """Resolve learned_patterns.output_file; relative paths anchor to report.output_dir (#1260)."""
+    out_path = Path(lp.get("output_file", "learned_patterns.yaml"))
+    if out_path.is_absolute():
+        return out_path
+    output_dir = str((config.get("report") or {}).get("output_dir") or "").strip()
+    if output_dir:
+        return Path(output_dir) / out_path
+    return out_path
+
+
 def write_learned_patterns(
     db_manager: Any,
     session_id: str | None,
@@ -157,7 +168,7 @@ def write_learned_patterns(
     write YAML. Returns path to written file or None if disabled / no entries.
     Config under config["learned_patterns"]:
       enabled: bool (default True if key present)
-      output_file: str (default "learned_patterns.yaml")
+      output_file: str (default "learned_patterns.yaml"; relative paths resolve under report.output_dir)
       min_sensitivity: "HIGH" | "MEDIUM" (default "HIGH")
       min_confidence: int (default 70)
       min_term_length: int (default 3)
@@ -168,7 +179,7 @@ def write_learned_patterns(
     lp = config.get("learned_patterns") or {}
     if not lp.get("enabled", False):
         return None
-    out_path = Path(lp.get("output_file", "learned_patterns.yaml"))
+    out_path = _resolve_learned_patterns_output_path(lp, config)
     min_sensitivity = lp.get("min_sensitivity", "HIGH")
     min_confidence = int(lp.get("min_confidence", 70))
     min_term_length = int(lp.get("min_term_length", 3))

--- a/tests/test_learned_patterns.py
+++ b/tests/test_learned_patterns.py
@@ -103,6 +103,28 @@ def test_collect_filesystem_extracts_table_column():
     assert entries[0]["text"] == "users.cpf"
 
 
+def test_collect_filesystem_skips_bare_filename():
+    """#1259: generic filenames must not become learned ML terms."""
+    fs = [
+        {
+            "file_name": "/repo/main.yml",
+            "sensitivity_level": "HIGH",
+            "pattern_detected": "DOB_POSSIBLE_MINOR",
+            "norm_tag": "Minor",
+            "ml_confidence": 82,
+        },
+        {
+            "file_name": "CONTRIBUTORS.txt",
+            "sensitivity_level": "HIGH",
+            "pattern_detected": "ML_POTENTIAL_ENTERTAINMENT",
+            "norm_tag": "",
+            "ml_confidence": 90,
+        },
+    ]
+    entries = collect_learned_entries([], fs, min_sensitivity="HIGH")
+    assert entries == []
+
+
 def test_write_learned_patterns_disabled_returns_none(tmp_path):
     class MockDB:
         def get_findings(self, session_id):
@@ -157,3 +179,73 @@ def test_write_learned_patterns_writes_yaml(tmp_path):
     content = out_file.read_text(encoding="utf-8")
     assert "cpf_cliente" in content
     assert "sensitive" in content
+
+
+def test_write_learned_patterns_resolves_relative_output_against_report_dir(tmp_path):
+    """#1260: relative output_file lands under report.output_dir, not cwd."""
+
+    class MockDB:
+        def get_findings(self, session_id):
+            return (
+                [
+                    {
+                        "column_name": "cpf_cliente",
+                        "sensitivity_level": "HIGH",
+                        "pattern_detected": "LGPD_CPF",
+                        "norm_tag": "LGPD",
+                        "ml_confidence": 88,
+                    }
+                ],
+                [],
+                [],
+            )
+
+    report_dir = tmp_path / "reports" / "demo"
+    report_dir.mkdir(parents=True)
+    config = {
+        "report": {"output_dir": str(report_dir)},
+        "learned_patterns": {
+            "enabled": True,
+            "output_file": "learned_patterns.yaml",
+            "append": False,
+        },
+        "ml_patterns_file": "",
+    }
+    out = write_learned_patterns(MockDB(), "s1", config)
+    expected = report_dir / "learned_patterns.yaml"
+    assert out == str(expected)
+    assert expected.exists()
+
+
+def test_write_learned_patterns_keeps_absolute_output_path(tmp_path):
+    """#1260: explicit absolute output_file is not rewritten under report.output_dir."""
+
+    class MockDB:
+        def get_findings(self, session_id):
+            return (
+                [
+                    {
+                        "column_name": "cpf_cliente",
+                        "sensitivity_level": "HIGH",
+                        "pattern_detected": "LGPD_CPF",
+                        "norm_tag": "LGPD",
+                        "ml_confidence": 88,
+                    }
+                ],
+                [],
+                [],
+            )
+
+    absolute_out = tmp_path / "custom" / "learned.yaml"
+    config = {
+        "report": {"output_dir": str(tmp_path / "reports")},
+        "learned_patterns": {
+            "enabled": True,
+            "output_file": str(absolute_out),
+            "append": False,
+        },
+        "ml_patterns_file": "",
+    }
+    out = write_learned_patterns(MockDB(), "s1", config)
+    assert out == str(absolute_out)
+    assert absolute_out.exists()


### PR DESCRIPTION
## Summary

- **#1259:** stop learning bare filesystem filenames as ML terms; only structured `path | table.column` locations generalize
- **#1260:** resolve relative `learned_patterns.output_file` under `report.output_dir` (absolute paths unchanged)

Closes #1259
Closes #1260

## Test plan

- [x] `./scripts/check-all.sh` green (ADR-0080)
- [x] `test_collect_filesystem_skips_bare_filename`
- [x] `test_write_learned_patterns_resolves_relative_output_against_report_dir`
- [x] `test_write_learned_patterns_keeps_absolute_output_path`
- [ ] HITL merge


Made with [Cursor](https://cursor.com)