### PR TITLE
chore(release): 1.7.4.post7 PyPI publish counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ Human-readable summary of user-facing changes. **Detailed release notes:** [docs
 
 ---
 
+## 1.7.4.post7 (pending PyPI dispatch)
+
+> Post-release on the **`1.7.4`** public line. **`[project] version = 1.7.4.post7`** and **`[tool.databoar] maturity_build = 245`** (`N=4` discrete fixes since post6 baseline `6dc54642`, ADR-0073). **PyPI-only** — no Git tag, no GitHub Release, no container.
+
+### Fixed / hardened (post7)
+
+- **Archives (.7z):** batch-extract and post-extract read failures route through `clean_error()` instead of raw `str(e)` (#1257).
+- **API / WebAuthn:** valid WebAuthn session cookie satisfies `require_api_key` on JSON routes (#1258).
+- **learned_patterns:** skip bare filesystem filenames; anchor relative `output_file` under `report.output_dir` (#1259, #1260).
+- **SQL / MSSQL:** honor explicit `dialect+driver`; default `mssql` to `mssql+pymssql` (hardcoded ODBC was the defect) + `sql-community` extra for free-tier drivers (#1289, #1290 — operator reclassified from `feat(` as defect-fix).
+
+### Notes (post7)
+
+- **Accounting (#1261):** post5 `maturity_build` baseline documentation only — does **not** advance `maturity_build`.
+- Full `N=4` fix set and `postN` ↔ `maturity_build` map: [docs/releases/1.7.4.post7.md](docs/releases/1.7.4.post7.md).
+
+---
+
 ## 1.7.4.post6 (pending PyPI dispatch)
 
 > Post-release on the **`1.7.4`** public line. **`[project] version = 1.7.4.post6`** and **`[tool.databoar] maturity_build = 241`** (`N=1` `fix(` commit since post5 `b7de32ba`, ADR-0073). **PyPI-only** — no Git tag, no GitHub Release, no container.

--- a/core/about.py
+++ b/core/about.py
@@ -11,7 +11,7 @@ def _package_version() -> str:
 
         return version("data-boar")
     except Exception:
-        return "1.7.4.post6"
+        return "1.7.4.post7"
 
 
 def get_http_user_agent() -> str:

--- a/docs/releases/1.7.4.post7.md
+++ b/docs/releases/1.7.4.post7.md
@@ -1,10 +1,10 @@
-# Release 1.7.4.post6 (PyPI publish counter)
+# Release 1.7.4.post7 (PyPI publish counter)
 
 **Status:** Pending PyPI upload after merge (operator **`publish-pypi`** `workflow_dispatch`: build → TestPyPI → PyPI).
 
 **Public line (marketing):** **`1.7.4`** — README, man pages, stakeholder copy unchanged.
 
-**Build / PyPI / About:** **`1.7.4.post6`** — PEP 440 post-release (publish counter per [ADR-0073](../adr/ADR-0073-version-scheme-octet-maturity-and-roadmap.md) § *PyPI dual counters*).
+**Build / PyPI / About:** **`1.7.4.post7`** — PEP 440 post-release (publish counter per [ADR-0073](../adr/ADR-0073-version-scheme-octet-maturity-and-roadmap.md) § *PyPI dual counters*).
 
 **Not in this drop:** Git tag · GitHub Release · Docker / container image (PyPI-only `.postN`).
 
@@ -56,38 +56,54 @@ Per ADR-0073: **`postN`** counts **PyPI uploads**; **`maturity_build`** counts *
 | *(fix, unpublished on PyPI)* | **`.238`** | Extract pre-budget `.7z` members on budget stop (#1250, #1248). |
 | *(fix, unpublished on PyPI)* | **`.239`** | Orphan session reaper (PID liveness) + interrupt → `interrupted` (#1251). |
 | **`1.7.4.post5`** | **`.240`** | Post5 wave (archives/sessions/security/integrity train); baseline post4 + `N=14` `fix(` — see [1.7.4.post5.md](1.7.4.post5.md). |
-| **`1.7.4.post6`** | **`.241`** | Integrity anchor re-baselines on legitimate release upgrade (#1262 / #1263); baseline `1.7.4.post5` + `N=1` `fix(` commit. |
+| **`1.7.4.post6`** | **`.241`** | Integrity anchor re-baselines on legitimate release upgrade (#1262 / #1263); baseline `1.7.4.post5` + `N=1` `fix(` — see [1.7.4.post6.md](1.7.4.post6.md). |
+| *(fix, unpublished on PyPI)* | **`.242`** | `.7z` batch-extract / post-extract failures sanitized via `clean_error()` (#1257). |
+| *(fix, unpublished on PyPI)* | **`.243`** | WebAuthn session satisfies `require_api_key` on JSON routes (#1258). |
+| *(fix, unpublished on PyPI)* | **`.244`** | `learned_patterns`: skip bare filenames + anchor `output_file` to `report.output_dir` (#1259, #1260). |
+| **`1.7.4.post7`** | **`.245`** | **This upload** — post6 baseline `6dc54642` + `N=4` discrete fixes (incl. MSSQL defect-fix #1290/#1289); see appendix. |
 
 ---
 
-## Appendix — Fix set used for `N` (`N=1`) (git-literal)
+## Appendix — Fix set used for `N` (`N=4`) (git-literal + operator reclassification)
 
-**Boundary:** `chore(release): 1.7.4.post5` → `b7de32ba`.
+**Boundary:** post6 integrity fix `6dc54642` (`fix(integrity): re-baseline anchor on release upgrade`).
 
 ```bash
-git log b7de32ba..HEAD --format='%h %s' | rg '^[0-9a-f]+ fix\('
-# COUNT=1  →  maturity_build = 240 + 1 = 241
+git log 6dc54642..HEAD --format='%h %s' | rg '^[0-9a-f]+ fix\('
+# COUNT=3 git-literal fix( commits
+
+git log 6dc54642..HEAD --format='%h %s' | rg '^[0-9a-f]+ feat\(connectors\)'
+# +1 operator-reclassified defect-fix (see below)
+
+# N=4  →  maturity_build = 241 + 4 = 245
 ```
 
-Commits counted:
+Commits counted toward **`N=4`**:
 
-1. `6dc54642` — `fix(integrity): re-baseline anchor on release upgrade`
+1. `26c24e27` — `fix(archives): sanitize .7z batch-extract failure details via clean_error` (#1257)
+2. `9376ddc5` — `fix(api): WebAuthn session satisfies require_api_key on JSON routes` (#1258)
+3. `55431157` — `fix(learned_patterns): skip bare filenames + anchor output to report dir` (#1259, #1260)
+4. `c04e53ce` — `feat(connectors): honor explicit SQL driver + no-ODBC mssql via pymssql` ([#1290](https://github.com/DataBoar/data-boar/pull/1290) / [#1289](https://github.com/DataBoar/data-boar/issues/1289)) — **operator reclassification:** hardcoded ODBC was the **defect**; generalizing driver selection is the **correction**. Git subject says `feat(` by mistake; counted as a discrete fix per ADR-0073.
 
-**Not counted toward `N` (not `fix(`):** `test(integrity): assert -alpha watermark on upgrade vs tamper` (`1384061a`); docs under `docs/ops/INTEGRITY_CHECK_ALPHA_LOGIC*` that landed in the same PR train; merge commit of #1263.
+**Not counted toward `N`:**
+
+- `c9956f56` — `docs(release): clarify post5 maturity_build accounting` ([#1261](https://github.com/DataBoar/data-boar/pull/1295)) — accounting documentation only; does not advance `maturity_build`.
+- `2dc8293d` — `build(extras): add sql-community extra` — packaging extra shipped with #1290; not a standalone runtime behavioral fix.
+- Merge commits and test-only commits on the fix PRs.
 
 ---
 
-## Highlights (why post6)
+## Highlights (why post7)
 
-- Demo-critical upgrade UX: `pip install -U` / `pipx upgrade` reusing the same SQLite DB no longer false-tints as `-alpha` / `integrity_tampered` when only the package version (and shipped `CRITICAL_MODULES`) changed.
-- Same-version hash drift still tampers (detection not softened); append-only `re-baseline` event keeps the E.6 tamper-evident trail.
+- Security/UX hardening wave: sanitized `.7z` failure surfaces, WebAuthn + `require_api_key` compose for browser dashboards, tighter `learned_patterns` hygiene.
+- MSSQL on lean installs: no implicit ODBC dependency; explicit `dialect+driver` honored; `sql-community` extra for free-tier SQL drivers.
 
 ---
 
 ## Install
 
 ```bash
-pip install 'data-boar==1.7.4.post6'
+pip install 'data-boar==1.7.4.post7'
 ```
 
 See [USAGE.md](../USAGE.md), [QUICKSTART.md](../QUICKSTART.md), and [TROUBLESHOOTING.md](../TROUBLESHOOTING.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-boar"
-version = "1.7.4.post6"
+version = "1.7.4.post7"
 description = "Data Boar — compliance-aware discovery and mapping of personal and sensitive data across databases, files, and APIs (LGPD, GDPR, CCPA, and configurable frameworks)."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -309,6 +309,6 @@ dev = [
 ]
 
 # Operator-only maturity octet (ADR-0073). Never copy into [project].version.
-# postN <-> maturity_build map: docs/releases/1.7.4.post6.md (canonical; includes post1–post5 rows).
+# postN <-> maturity_build map: docs/releases/1.7.4.post7.md (canonical; includes post1–post6 rows).
 [tool.databoar]
-maturity_build = 241
+maturity_build = 245

--- a/tests/test_maturity_build_accounting.py
+++ b/tests/test_maturity_build_accounting.py
@@ -13,6 +13,8 @@ POST4_PUBLISHED_MATURITY_BUILD = 226
 POST5_FIX_COUNT = 14
 POST5_MATURITY_BUILD = 240
 POST6_MATURITY_BUILD = 241
+POST7_FIX_COUNT = 4
+POST7_MATURITY_BUILD = 245
 
 
 def _load_pyproject() -> dict:
@@ -28,8 +30,8 @@ def test_post5_maturity_build_accounting_uses_post4_publish_row_not_225() -> Non
     assert (POST5_MATURITY_BUILD - 225) != POST5_FIX_COUNT
 
 
-def test_pyproject_maturity_build_matches_post6_canonical_map() -> None:
+def test_pyproject_maturity_build_matches_post7_canonical_map() -> None:
     data = _load_pyproject()
     maturity = data.get("tool", {}).get("databoar", {}).get("maturity_build")
-    assert maturity == POST6_MATURITY_BUILD
-    assert POST5_MATURITY_BUILD + 1 == POST6_MATURITY_BUILD
+    assert maturity == POST7_MATURITY_BUILD
+    assert POST6_MATURITY_BUILD + POST7_FIX_COUNT == POST7_MATURITY_BUILD

--- a/tests/test_pyproject_sql_extras.py
+++ b/tests/test_pyproject_sql_extras.py
@@ -64,11 +64,11 @@ def test_sql_optional_extras_present() -> None:
 def test_maturity_build_bumped_for_packaging_fix() -> None:
     data = _load_pyproject()
     maturity = data.get("tool", {}).get("databoar", {}).get("maturity_build")
-    assert maturity == 241
+    assert maturity == 245
 
 
 def test_version_is_174_post_release_not_semver_bump() -> None:
     version = _load_pyproject().get("project", {}).get("version")
-    assert version == "1.7.4.post6"
+    assert version == "1.7.4.post7"
     assert not str(version).startswith("1.7.5")
     assert not str(version).startswith("1.8.")

--- a/uv.lock
+++ b/uv.lock
@@ -800,7 +800,7 @@ validation = [
 
 [[package]]
 name = "data-boar"
-version = "1.7.4.post6"
+version = "1.7.4.post7"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-doc" },


### PR DESCRIPTION
## Summary

Release-prep for **`1.7.4.post7`** (PEP 440 post-release, ADR-0073):

- **`[project] version`:** `1.7.4.post6` → `1.7.4.post7`
- **`[tool.databoar] maturity_build`:** `241` → `245` (`N=4` since post6 baseline `6dc54642`)
- Fix set: #1257 (.7z `clean_error`), #1258 (WebAuthn + `require_api_key`), #1259+#1260 (`learned_patterns`), #1290/#1289 MSSQL defect-fix (operator reclassified from `feat(` — hardcoded ODBC was the bug)
- #1261 accounting docs only — does not bump maturity
- Full map + git-literal appendix: `docs/releases/1.7.4.post7.md`

**Operator action after merge:** `publish-pypi` workflow_dispatch only — no tag, no GitHub Release, no container.

## Test plan

- [x] `./scripts/check-all.sh` green locally

Made with [Cursor](https://cursor.com)