### PR TITLE
fix(connectors): pymssql login_timeout/timeout for MSSQL connect_args

### DIFF
--- a/connectors/sql_connector.py
+++ b/connectors/sql_connector.py
@@ -236,7 +236,7 @@ def _connect_args_from_target(target: dict[str, Any]) -> dict[str, Any]:
     """
     Build SQLAlchemy connect_args from target timeouts (config loader merges global + per-target).
     Uses connect_timeout_seconds for connect; read_timeout_seconds for statement_timeout (PostgreSQL)
-    or SQLite lock timeout.
+    or SQLite lock timeout, or pymssql ``timeout`` for MSSQL.
     """
     connect_s = int(target.get("connect_timeout_seconds", 25))
     read_s = int(target.get("read_timeout_seconds", 90))
@@ -253,7 +253,10 @@ def _connect_args_from_target(target: dict[str, Any]) -> dict[str, Any]:
         }
     if base in ("mysql", "mariadb"):
         return {"connect_timeout": connect_s}
-    # mssql, oracle, others: pass connect_timeout when driver supports it
+    if base == "mssql":
+        # pymssql (default mssql driver) uses login_timeout/timeout, not connect_timeout.
+        return {"login_timeout": connect_s, "timeout": read_s}
+    # oracle, others: pass connect_timeout when driver supports it
     return {"connect_timeout": connect_s}
 
 

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -290,6 +290,18 @@ def test_connect_args_from_target_mysql():
     assert "options" not in args
 
 
+def test_connect_args_from_target_mssql_pymssql():
+    """_connect_args_from_target uses pymssql login_timeout/timeout (not connect_timeout)."""
+    target = {
+        "driver": "mssql",
+        "connect_timeout_seconds": 20,
+        "read_timeout_seconds": 80,
+    }
+    args = _connect_args_from_target(target)
+    assert args == {"login_timeout": 20, "timeout": 80}
+    assert "connect_timeout" not in args
+
+
 def test_connect_args_from_target_sqlite():
     """_connect_args_from_target returns timeout (lock wait) for SQLite."""
     target = {"driver": "sqlite", "read_timeout_seconds": 30}


### PR DESCRIPTION
## Summary

Field bug on first native MSSQL connector run: `_connect_args_from_target` passed `connect_timeout` to pymssql, which expects `login_timeout` and `timeout` — connections failed with `connect() got an unexpected keyword argument connect_timeout` and zero rows ingested.

- MSSQL branch returns `{"login_timeout": connect_s, "timeout": read_s}` before the generic `connect_timeout` fallback
- Oracle and other drivers unchanged

## Test plan

- [x] `test_connect_args_from_target_mssql_pymssql` — asserts `login_timeout`/`timeout`, no `connect_timeout`
- [x] `./scripts/check-all.sh` green locally

Made with [Cursor](https://cursor.com)