### PR TITLE
chore(release): 1.7.4.post8 PyPI publish counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ Human-readable summary of user-facing changes. **Detailed release notes:** [docs
 
 ---
 
+## 1.7.4.post8 (pending PyPI dispatch)
+
+> Post-release on the **`1.7.4`** public line. **`[project] version = 1.7.4.post8`** and **`[tool.databoar] maturity_build = 247`** (`N=2` `fix(` commits since post7 baseline `b5054d55`, ADR-0073). **PyPI-only** — no Git tag, no GitHub Release, no container.
+>
+> **Field-caught on-site (2026-07-21):** both fixes in this drop were discovered during the same customer engagement — native MSSQL connector first run (#1297) and integrity anchor false-negative (#1298).
+
+### Fixed / hardened (post8)
+
+- **SQL / MSSQL (native pymssql):** map `connect_timeout_seconds` / `read_timeout_seconds` to pymssql `login_timeout` / `timeout` instead of unsupported `connect_timeout` — first field run ingested zero rows before this fix ([#1297](https://github.com/DataBoar/data-boar/pull/1297)).
+- **Integrity anchor:** expand behaviour-critical allowlist via `connectors/*.py` + `core/licensing/*.py` globs (42 modules, was 6); `--version` and `--validate-config` surface `-alpha` / `runtime-trust` before scan ([#1298](https://github.com/DataBoar/data-boar/pull/1298)).
+
+### Notes (post8)
+
+- Full `N=2` fix set and `postN` ↔ `maturity_build` map: [docs/releases/1.7.4.post8.md](docs/releases/1.7.4.post8.md).
+
+---
+
 ## 1.7.4.post7 (pending PyPI dispatch)
 
 > Post-release on the **`1.7.4`** public line. **`[project] version = 1.7.4.post7`** and **`[tool.databoar] maturity_build = 245`** (`N=4` discrete fixes since post6 baseline `6dc54642`, ADR-0073). **PyPI-only** — no Git tag, no GitHub Release, no container.

--- a/core/about.py
+++ b/core/about.py
@@ -11,7 +11,7 @@ def _package_version() -> str:
 
         return version("data-boar")
     except Exception:
-        return "1.7.4.post7"
+        return "1.7.4.post8"
 
 
 def get_http_user_agent() -> str:

--- a/docs/releases/1.7.4.post8.md
+++ b/docs/releases/1.7.4.post8.md
@@ -1,12 +1,14 @@
-# Release 1.7.4.post7 (PyPI publish counter)
+# Release 1.7.4.post8 (PyPI publish counter)
 
 **Status:** Pending PyPI upload after merge (operator **`publish-pypi`** `workflow_dispatch`: build → TestPyPI → PyPI).
 
 **Public line (marketing):** **`1.7.4`** — README, man pages, stakeholder copy unchanged.
 
-**Build / PyPI / About:** **`1.7.4.post7`** — PEP 440 post-release (publish counter per [ADR-0073](../adr/ADR-0073-version-scheme-octet-maturity-and-roadmap.md) § *PyPI dual counters*).
+**Build / PyPI / About:** **`1.7.4.post8`** — PEP 440 post-release (publish counter per [ADR-0073](../adr/ADR-0073-version-scheme-octet-maturity-and-roadmap.md) § *PyPI dual counters*).
 
 **Not in this drop:** Git tag · GitHub Release · Docker / container image (PyPI-only `.postN`).
+
+**Field context (2026-07-21):** Both fixes were **field-caught on-site** during the same customer engagement — native MSSQL connector first execution (#1297) and integrity anchor false-negative (#1298).
 
 ---
 
@@ -60,50 +62,41 @@ Per ADR-0073: **`postN`** counts **PyPI uploads**; **`maturity_build`** counts *
 | *(fix, unpublished on PyPI)* | **`.242`** | `.7z` batch-extract / post-extract failures sanitized via `clean_error()` (#1257). |
 | *(fix, unpublished on PyPI)* | **`.243`** | WebAuthn session satisfies `require_api_key` on JSON routes (#1258). |
 | *(fix, unpublished on PyPI)* | **`.244`** | `learned_patterns`: skip bare filenames + anchor `output_file` to `report.output_dir` (#1259, #1260). |
-| **`1.7.4.post7`** | **`.245`** | Post6 baseline `6dc54642` + `N=4` discrete fixes (incl. MSSQL defect-fix #1290/#1289); see [1.7.4.post7.md](1.7.4.post7.md). |
+| **`1.7.4.post7`** | **`.245`** | Post6 baseline `6dc54642` + `N=4` discrete fixes (incl. MSSQL defect-fix #1290/#1289) — see [1.7.4.post7.md](1.7.4.post7.md). |
+| *(fix, unpublished on PyPI)* | **`.246`** | MSSQL pymssql `login_timeout` / `timeout` connect args (#1297, field-caught 2026-07-21). |
+| **`1.7.4.post8`** | **`.247`** | **This upload** — post7 baseline `b5054d55` + `N=2` `fix(` commits (#1297, #1298); see appendix. |
 
 ---
 
-## Appendix — Fix set used for `N` (`N=4`) (git-literal + operator reclassification)
+## Appendix — Fix set used for `N` (`N=2`) (git-literal)
 
-**Boundary:** post6 integrity fix `6dc54642` (`fix(integrity): re-baseline anchor on release upgrade`).
+**Boundary:** post7 release commit `b5054d55` (`chore(release): 1.7.4.post7 PyPI publish counter`).
 
 ```bash
-git log 6dc54642..HEAD --format='%h %s' | rg '^[0-9a-f]+ fix\('
-# COUNT=3 git-literal fix( commits
-
-git log 6dc54642..HEAD --format='%h %s' | rg '^[0-9a-f]+ feat\(connectors\)'
-# +1 operator-reclassified defect-fix (see below)
-
-# N=4  →  maturity_build = 241 + 4 = 245
+git log b5054d55..HEAD --format='%h %s' | rg '^[0-9a-f]+ fix\('
+# COUNT=2  →  maturity_build = 245 + 2 = 247
 ```
 
-Commits counted toward **`N=4`**:
+Commits counted toward **`N=2`**:
 
-1. `26c24e27` — `fix(archives): sanitize .7z batch-extract failure details via clean_error` (#1257)
-2. `9376ddc5` — `fix(api): WebAuthn session satisfies require_api_key on JSON routes` (#1258)
-3. `55431157` — `fix(learned_patterns): skip bare filenames + anchor output to report dir` (#1259, #1260)
-4. `c04e53ce` — `feat(connectors): honor explicit SQL driver + no-ODBC mssql via pymssql` ([#1290](https://github.com/DataBoar/data-boar/pull/1290) / [#1289](https://github.com/DataBoar/data-boar/issues/1289)) — **operator reclassification:** hardcoded ODBC was the **defect**; generalizing driver selection is the **correction**. Git subject says `feat(` by mistake; counted as a discrete fix per ADR-0073.
+1. `6dd14dfd` — `fix(connectors): pymssql login_timeout/timeout for MSSQL connect_args` ([#1297](https://github.com/DataBoar/data-boar/pull/1297)) — field-caught: first native MSSQL run failed with `connect() got an unexpected keyword argument 'connect_timeout'`; zero rows ingested across five databases.
+2. `ad2440a3` — `fix(integrity): expand CRITICAL_MODULES globs + CLI trust surfacing` ([#1298](https://github.com/DataBoar/data-boar/issues/1298) / [#1300](https://github.com/DataBoar/data-boar/pull/1300)) — field-caught: connector tamper did not tint; glob allowlist (`connectors/*.py`, `core/licensing/*.py`) + `--version` / `--validate-config` surfacing.
 
-**Not counted toward `N`:**
-
-- `c9956f56` — `docs(release): clarify post5 maturity_build accounting` ([#1261](https://github.com/DataBoar/data-boar/pull/1295)) — accounting documentation only; does not advance `maturity_build`.
-- `2dc8293d` — `build(extras): add sql-community extra` — packaging extra shipped with #1290; not a standalone runtime behavioral fix.
-- Merge commits and test-only commits on the fix PRs.
+**Not counted toward `N`:** merge commits of #1297 / #1300; release-prep commits for post8.
 
 ---
 
-## Highlights (why post7)
+## Highlights (why post8)
 
-- Security/UX hardening wave: sanitized `.7z` failure surfaces, WebAuthn + `require_api_key` compose for browser dashboards, tighter `learned_patterns` hygiene.
-- MSSQL on lean installs: no implicit ODBC dependency; explicit `dialect+driver` honored; `sql-community` extra for free-tier SQL drivers.
+- **On-site reliability:** native MSSQL connector works on first field execution (pymssql timeout kwargs).
+- **On-site trust:** integrity anchor now covers the full connector and licensing trees; cheapest tamper signal is `data-boar --version` showing `-alpha`.
 
 ---
 
 ## Install
 
 ```bash
-pip install 'data-boar==1.7.4.post7'
+pip install 'data-boar==1.7.4.post8'
 ```
 
 See [USAGE.md](../USAGE.md), [QUICKSTART.md](../QUICKSTART.md), and [TROUBLESHOOTING.md](../TROUBLESHOOTING.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-boar"
-version = "1.7.4.post7"
+version = "1.7.4.post8"
 description = "Data Boar — compliance-aware discovery and mapping of personal and sensitive data across databases, files, and APIs (LGPD, GDPR, CCPA, and configurable frameworks)."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -309,6 +309,6 @@ dev = [
 ]
 
 # Operator-only maturity octet (ADR-0073). Never copy into [project].version.
-# postN <-> maturity_build map: docs/releases/1.7.4.post7.md (canonical; includes post1–post6 rows).
+# postN <-> maturity_build map: docs/releases/1.7.4.post8.md (canonical; includes post1–post7 rows).
 [tool.databoar]
-maturity_build = 245
+maturity_build = 247

--- a/tests/test_maturity_build_accounting.py
+++ b/tests/test_maturity_build_accounting.py
@@ -13,8 +13,9 @@ POST4_PUBLISHED_MATURITY_BUILD = 226
 POST5_FIX_COUNT = 14
 POST5_MATURITY_BUILD = 240
 POST6_MATURITY_BUILD = 241
-POST7_FIX_COUNT = 4
 POST7_MATURITY_BUILD = 245
+POST8_FIX_COUNT = 2
+POST8_MATURITY_BUILD = 247
 
 
 def _load_pyproject() -> dict:
@@ -30,8 +31,8 @@ def test_post5_maturity_build_accounting_uses_post4_publish_row_not_225() -> Non
     assert (POST5_MATURITY_BUILD - 225) != POST5_FIX_COUNT
 
 
-def test_pyproject_maturity_build_matches_post7_canonical_map() -> None:
+def test_pyproject_maturity_build_matches_post8_canonical_map() -> None:
     data = _load_pyproject()
     maturity = data.get("tool", {}).get("databoar", {}).get("maturity_build")
-    assert maturity == POST7_MATURITY_BUILD
-    assert POST6_MATURITY_BUILD + POST7_FIX_COUNT == POST7_MATURITY_BUILD
+    assert maturity == POST8_MATURITY_BUILD
+    assert POST7_MATURITY_BUILD + POST8_FIX_COUNT == POST8_MATURITY_BUILD

--- a/tests/test_pyproject_sql_extras.py
+++ b/tests/test_pyproject_sql_extras.py
@@ -64,11 +64,11 @@ def test_sql_optional_extras_present() -> None:
 def test_maturity_build_bumped_for_packaging_fix() -> None:
     data = _load_pyproject()
     maturity = data.get("tool", {}).get("databoar", {}).get("maturity_build")
-    assert maturity == 245
+    assert maturity == 247
 
 
 def test_version_is_174_post_release_not_semver_bump() -> None:
     version = _load_pyproject().get("project", {}).get("version")
-    assert version == "1.7.4.post7"
+    assert version == "1.7.4.post8"
     assert not str(version).startswith("1.7.5")
     assert not str(version).startswith("1.8.")

--- a/uv.lock
+++ b/uv.lock
@@ -800,7 +800,7 @@ validation = [
 
 [[package]]
 name = "data-boar"
-version = "1.7.4.post7"
+version = "1.7.4.post8"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-doc" },


### PR DESCRIPTION
## Summary

Release-prep for **`1.7.4.post8`** (PEP 440 post-release, ADR-0073):

- **`[project] version`:** `1.7.4.post7` → `1.7.4.post8`
- **`[tool.databoar] maturity_build`:** `245` → `247` (`N=2` `fix(` since post7 baseline `b5054d55`)
- Fix set (field-caught on-site **2026-07-21**):
  - **#1297** — MSSQL pymssql `login_timeout`/`timeout` (first native connector field run)
  - **#1298** — integrity glob allowlist + `--version`/`--validate-config` trust surfacing
- Full map + git-literal appendix: `docs/releases/1.7.4.post8.md`

**Operator action after merge:** `publish-pypi` workflow_dispatch only — no tag, no GitHub Release, no container.

## Test plan

- [x] `./scripts/check-all.sh` green locally

Made with [Cursor](https://cursor.com)