### PR TITLE
docs(compliance-samples): enrich LGPD sample with field-validated categories (#1288)

### DIFF
--- a/docs/compliance-samples/README.md
+++ b/docs/compliance-samples/README.md
@@ -10,7 +10,7 @@ For operational governance (scope, minimization, retention, traceability), use [
 
 | File                                           | Purpose                                                                                                                                                             |
 | ------                                         | ---------                                                                                                                                                           |
-| **compliance-sample-lgpd.yaml**                | LGPD (Brazil): bilingual PT-BR + EN terms (e.g. documento oficial / official document, RG, CNH / Driver License); RG/CEP regex; **precise geolocation** regex (same geometry as VCDPA / EU GDPR sample); for Brazilian deployments.          |
+| **compliance-sample-lgpd.yaml**                | LGPD (Brazil): bilingual PT-BR + EN terms; RG/CEP regex; **precise geolocation**; field-validated column patterns (#1288) for criminal records (Art. 11), CNH/RG, bank account/branch, geolocation columns, emergency contact.          |
 | **compliance-sample-br_insurance_lgpd_anchor.yaml** | Brazil insurance sector: **skeleton** EN-header sample with generic insurance terms and LGPD-inventory **`norm_tag`** strings; **not** SUSEP/CNSP certification — see [COMPLIANCE_FRAMEWORKS.md](../COMPLIANCE_FRAMEWORKS.md#brazil-insurance-sector-lgpd-anchoring-prudential-references). |
 | **compliance-sample-brazil_felca.yaml**        | Brazil FELCA (Lei 15.211/2025 — Estatuto Digital da Criança e do Adolescente, in force 17 March 2026): inventory signals for minor-related fields on digital platforms; **pair with** full LGPD sample; **not** age verification or legal conclusion — see [COMPLIANCE_FRAMEWORKS.md](../COMPLIANCE_FRAMEWORKS.md). |
 | **compliance-sample-brazil_saude.yaml**        | Brazil health sector (LGPD Art. 5/11 sensitive health data): CRM, CRF, CRO, COREN, CNS, ANVISA RMS, ANS, prescription and record-number patterns; PT-BR + EN terms; **pair with** [compliance-sample-lgpd.yaml](compliance-sample-lgpd.yaml). |
@@ -69,7 +69,7 @@ When choosing or authoring a sample, consider the **language(s)** of the target 
 
 | Regulation / region               | Recommended language(s) for terms and labels                                                                   |
 | -------------------               | ---------------------------------------------                                                                  |
-| **LGPD (Brazil)**                 | Portuguese (BR) and English (e.g. "documento oficial" and "official document", "CNH" and "Driver License").    |
+| **LGPD (Brazil)**                 | Portuguese (BR) and English (e.g. documento oficial / official document, CNH / Driver License, antecedentes criminais / criminal record, conta bancária / bank account, contato de emergência / emergency contact).    |
 | **Brazil (insurance — LGPD skeleton)** | Portuguese (BR) and English for policy/claims/brokerage column names; merge with full LGPD sample for national IDs. |
 | **PIPEDA (Canada)**               | English and French (e.g. "personal information" and "renseignements personnels") where scanning Canadian data. |
 | **Quebec (Law 25)**               | English and French (Quebec private sector; complements PIPEDA for operational wording in Quebec).               |

--- a/docs/compliance-samples/README.pt_BR.md
+++ b/docs/compliance-samples/README.pt_BR.md
@@ -10,7 +10,7 @@ Para governança operacional (escopo, minimização, retenção e rastreabilidad
 
 | Arquivo                                        | Finalidade                                                                                                                                                                                          |
 | ---------                                      | ------------                                                                                                                                                                                        |
-| **compliance-sample-lgpd.yaml**                | LGPD (Brasil): termos bilíngues PT-BR + EN (ex.: documento oficial / official document, RG, CNH / Driver License); regex RG/CEP; regex de **geolocalização precisa** (mesma geometria das amostras VCDPA / RGPD UE); para implantações brasileiras.                                     |
+| **compliance-sample-lgpd.yaml**                | LGPD (Brasil): termos bilíngues PT-BR + EN; regex RG/CEP; **geolocalização precisa**; padrões de coluna validados em campo (#1288): antecedentes criminais (Art. 11), CNH/RG, conta/agência bancária, geolocalização, contato de emergência.                                     |
 | **compliance-sample-br_insurance_lgpd_anchor.yaml** | Setor segurador (Brasil): amostra **esqueleto** (cabeçalho EN) com termos genéricos e **`norm_tag`** de inventário ancorada na LGPD; **não** certifica SUSEP/CNSP — ver [COMPLIANCE_FRAMEWORKS.pt_BR.md](../COMPLIANCE_FRAMEWORKS.pt_BR.md#setor-segurador-brasil-lgpd-referencias-prudenciais). |
 | **compliance-sample-brazil_felca.yaml**        | Brasil FELCA (Lei 15.211/2025 — Estatuto Digital da Criança e do Adolescente, vigência 17 mar 2026): sinais de inventário para campos ligados a menores em plataformas digitais; **mescle** com a amostra LGPD completa; **não** é verificação de idade nem conclusão jurídica — ver [COMPLIANCE_FRAMEWORKS.pt_BR.md](../COMPLIANCE_FRAMEWORKS.pt_BR.md). |
 | **compliance-sample-brazil_saude.yaml**        | Brasil setor saúde (LGPD Art. 5/11 — dados sensíveis de saúde): CRM, CRF, CRO, COREN, CNS, RMS ANVISA, ANS, receituário e prontuário (heurísticas); termos PT-BR + EN; **mescle** com [compliance-sample-lgpd.yaml](compliance-sample-lgpd.yaml). |
@@ -59,7 +59,7 @@ Ao escolher ou criar uma amostra, considere o(s) **idioma(s)** da região alvo p
 
 | Regulamento / região             | Idioma(s) recomendado(s) para termos e rótulos                                                             |
 | --------------------             | ------------------------------------------------                                                           |
-| **LGPD (Brasil)**                | Português (BR) e inglês (ex.: "documento oficial" e "official document", "CNH" e "Driver License").        |
+| **LGPD (Brasil)**                | Português (BR) e inglês (ex.: documento oficial / official document, antecedentes criminais / criminal record, conta bancária / bank account, contato de emergência / emergency contact, CNH / Driver License).        |
 | **Brasil (seguros — esqueleto LGPD)** | Português (BR) e inglês para nomes de colunas de apólice/sinistro/corretagem; mescle com a amostra LGPD completa para identificadores nacionais. |
 | **PIPEDA (Canadá)**              | Inglês e francês (ex.: "personal information" e "renseignements personnels") ao varrer dados canadenses.   |
 | **Québec (Lei 25)**              | Inglês e francês (setor privado de QC; complementa PIPEDA para vocabulário operacional).                  |

--- a/docs/compliance-samples/compliance-sample-lgpd.yaml
+++ b/docs/compliance-samples/compliance-sample-lgpd.yaml
@@ -1,9 +1,12 @@
 # LGPD – sample compliance profile (Brazil; Lei Geral de Proteção de Dados)
 #
-# Target audience: Brazilian deployments and LGPD compliance. This sample includes
+# Target audience: Brazilian deployments and LGPD compliance. Bilingual PT-BR + EN
+# terms (see .cursor/rules/compliance-samples-language.mdc). This sample includes
 # the same regex and ML terms as the app's built-in defaults (so using this file
 # as regex_overrides_file and ml_patterns_file does not reduce coverage), plus
-# extra Brazilian regex (RG, CEP, PIS/PASEP) and bilingual (PT-BR + EN) terms.
+# extra Brazilian regex (RG, CEP, PIS/PASEP), precise geolocation, and field-
+# validated column-header patterns (#1288): criminal records (Art. 11), CNH/RG,
+# bank account/branch, geolocation columns, emergency contact.
 #
 # How to use:
 #   1. Set in your main config:
@@ -82,6 +85,28 @@ regex:
   - name: "LGPD_QUERYSTRING_LAT_LONG"
     pattern: "(?i)latitude=[-+]?(?:[1-8]?\\d|90)\\.\\d{4,}\\s*&\\s*longitude=[-+]?(?:180|1[0-7]\\d|[1-9]?\\d)\\.\\d{4,}"
     norm_tag: "LGPD Art. 5"
+  # Field-validated column-header patterns (#1288).
+  # - No trailing \\b after stems that may take underscore suffixes (\\b fails before '_').
+  # - Leading (?:^|_) anchors at start-or-underscore so prefixed columns match
+  #   (user_latitude, titular_cnh) without mid-word hits (platitude).
+  - name: "LGPD_CRIMINAL_RECORDS"
+    pattern: "(?i)(?:criminal_records?\\w*|antecedentes?_?criminal\\w*|certidao_?negativa(?:_?criminal)?\\w*|criminal_?background\\w*)"
+    norm_tag: "dado SENSIVEL - antecedentes criminais (Art. 11)"
+  - name: "LGPD_CNH"
+    pattern: "(?i)(?:^|_)(?:cnh\\w*|carteira_?de_?habilitacao\\w*|driver_?licen[cs]e\\w*|driving_?licen[cs]e\\w*)"
+    norm_tag: "LGPD Art. 5 (documento — CNH)"
+  - name: "LGPD_RG_IDENTITY"
+    pattern: "(?i)(?:^|_)(?:rg_?(?:number|numero)?\\w*|numero_?rg\\w*|registro_?geral\\w*|carteira_?de_?identidade\\w*|identity_?(?:card|doc(?:ument)?)\\w*)"
+    norm_tag: "LGPD Art. 5 (documento — RG/identidade)"
+  - name: "LGPD_BANK_ACCOUNT"
+    pattern: "(?i)(?:^|_)(?:bank_?account\\w*|conta_?(?:bancaria|corrente)\\w*|numero_?(?:da_?)?conta\\w*|agencia_?(?:bancaria)?\\w*|codigo_?agencia\\w*|account_?(?:number|no)\\w*|branch_?(?:number|code)\\w*)"
+    norm_tag: "LGPD Art. 5 (dado financeiro — conta/agência bancária)"
+  - name: "LGPD_GEOLOCATION"
+    pattern: "(?i)(?:^|_)(?:latitude\\w*|longitude\\w*|geo_?loc(?:ation)?\\w*|coordenadas?_?(?:gps|geograficas)\\w*|precise_?location\\w*)"
+    norm_tag: "LGPD Art. 5 (geolocalização precisa — re-ID)"
+  - name: "LGPD_EMERGENCY_CONTACT"
+    pattern: "(?i)(?:^|_)(?:emergency_?contact\\w*|contato_?(?:de_?)?emergencia\\w*|next_?of_?kin\\w*)"
+    norm_tag: "LGPD Art. 5 (dado de terceiro — contato de emergência)"
 
 # ML/DL terms: full set matching app defaults (core/detector.py DEFAULT_ML_TERMS) plus
 # LGPD-specific extras. When this file is used as ml_patterns_file, coverage is at least
@@ -532,8 +557,84 @@ terms:
     label: sensitive
   - text: "identity"
     label: sensitive
+  - text: "antecedentes criminais"
+    label: sensitive
+  - text: "criminal record"
+    label: sensitive
+  - text: "criminal background"
+    label: sensitive
+  - text: "certidão negativa"
+    label: sensitive
+  - text: "certidao negativa"
+    label: sensitive
+  - text: "negative criminal certificate"
+    label: sensitive
+  - text: "conta bancária"
+    label: sensitive
+  - text: "conta bancaria"
+    label: sensitive
+  - text: "bank account"
+    label: sensitive
+  - text: "bank account number"
+    label: sensitive
+  - text: "agência bancária"
+    label: sensitive
+  - text: "agencia bancaria"
+    label: sensitive
+  - text: "bank branch"
+    label: sensitive
+  - text: "branch number"
+    label: sensitive
+  - text: "contato de emergência"
+    label: sensitive
+  - text: "contato de emergencia"
+    label: sensitive
+  - text: "emergency contact"
+    label: sensitive
+  - text: "next of kin"
+    label: sensitive
+  - text: "numero rg"
+    label: sensitive
+  - text: "rg number"
+    label: sensitive
 
 recommendation_overrides:
+  - norm_tag_pattern: "antecedentes criminais (Art. 11)"
+    base_legal: "LGPD Art. 11 — dado pessoal sensível (antecedentes criminais)"
+    risk: "Antecedentes criminais são dado sensível; tratamento exige base legal específica do Art. 11 e controles reforçados. Exposição indevida pode gerar discriminação e violação de sigilo."
+    recommendation: "Confirmar base legal do Art. 11 (ex.: consentimento específico, tutela da saúde, procedimento legal). Restringir acesso, criptografar, minimizar retenção e registrar finalidade. Consultar DPO e jurídico — não é conclusão legal."
+    priority: "ALTA"
+    relevant_for: "DPO, Encarregado LGPD, Jurídico, Segurança da Informação"
+  - norm_tag_pattern: "documento — CNH"
+    base_legal: "LGPD Art. 5 — documento de identificação (CNH)"
+    risk: "CNH identifica o titular e pode ser usada para fraude documental ou acesso indevido a serviços."
+    recommendation: "Aplicar minimização, controle de acesso e bases legais da LGPD; mascarar em relatórios quando possível."
+    priority: "ALTA"
+    relevant_for: "DPO, Operador, Segurança da Informação"
+  - norm_tag_pattern: "documento — RG/identidade"
+    base_legal: "LGPD Art. 5 — documento de identidade"
+    risk: "RG ou equivalente identifica pessoa natural; exposição facilita fraude e reidentificação."
+    recommendation: "Restringir acesso, criptografar em repouso/trânsito e documentar finalidade e base legal."
+    priority: "ALTA"
+    relevant_for: "DPO, Operador, Segurança da Informação"
+  - norm_tag_pattern: "conta/agência bancária"
+    base_legal: "LGPD Art. 5 — dado financeiro (conta/agência)"
+    risk: "Conta e agência bancária permitem vincular titular a instituição financeira; risco de fraude e vazamento financeiro."
+    recommendation: "Mascarar em relatórios, restringir acesso e alinhar com políticas de segurança financeira e LGPD."
+    priority: "ALTA"
+    relevant_for: "DPO, CISO, Operador financeiro"
+  - norm_tag_pattern: "geolocalização precisa"
+    base_legal: "LGPD Art. 5 — localização precisa (vetor de reidentificação)"
+    risk: "Coordenadas ou colunas de latitude/longitude precisas permitem rastrear ou reidentificar titulares."
+    recommendation: "Avaliar necessidade de precisão; agregar ou anonimizar quando possível; restringir acesso e retenção."
+    priority: "ALTA"
+    relevant_for: "DPO, Arquitetura de dados, Segurança da Informação"
+  - norm_tag_pattern: "contato de emergência"
+    base_legal: "LGPD Art. 5 — dado pessoal de terceiro (contato de emergência)"
+    risk: "Contato de emergência é dado de terceiro sem relação direta com o titular principal; exige transparência e base legal adequada."
+    recommendation: "Informar finalidade ao titular; obter consentimento quando aplicável; restringir uso à finalidade declarada."
+    priority: "MÉDIA"
+    relevant_for: "DPO, RH, Operador"
   - norm_tag_pattern: "PII_AMBIGUOUS"
     base_legal: "Identificador genérico – confirmar manualmente"
     risk: "Nome de coluna genérico (doc_id, document_id, id_number, etc.). Pode ser PII ou ID interno."

--- a/tests/test_compliance_samples.py
+++ b/tests/test_compliance_samples.py
@@ -246,3 +246,62 @@ def test_ml_patterns_file_is_merged_with_default_terms():
         assert ("email", 1) in terms
     finally:
         path.unlink(missing_ok=True)
+
+
+LGPD_SAMPLE = COMPLIANCE_SAMPLES_DIR / "compliance-sample-lgpd.yaml"
+
+
+@pytest.fixture
+def lgpd_scanner():
+    """Detector loaded with the LGPD compliance sample (#1288)."""
+    from core.scanner import DataScanner
+
+    path = str(LGPD_SAMPLE.resolve())
+    return DataScanner(regex_overrides_path=path, ml_patterns_path=path)
+
+
+def test_lgpd_criminal_records_regex_matches_underscore_column_suffix(lgpd_scanner):
+    """
+    Regression #1288: trailing \\b after criminal_records fails on underscore suffixes.
+
+    ``\\bcriminal_records\\b`` does not match ``criminal_records_consulted_at`` because
+    underscore is a word character. The sample uses ``criminal_records?\\w*`` instead.
+    """
+    import re
+
+    column = "criminal_records_consulted_at"
+    assert not re.search(r"\bcriminal_records\b", column)
+    result = lgpd_scanner.scan_column(column, "")
+    assert result["sensitivity_level"] == "HIGH"
+    assert "LGPD_CRIMINAL_RECORDS" in result["pattern_detected"]
+    assert "Art. 11" in result["norm_tag"]
+
+
+@pytest.mark.parametrize(
+    "column_name,expected_pattern",
+    [
+        ("cnh_expiry_date", "LGPD_CNH"),
+        ("numero_rg_emitido_em", "LGPD_RG_IDENTITY"),
+        ("agencia_bancaria_codigo", "LGPD_BANK_ACCOUNT"),
+        ("latitude_last_seen", "LGPD_GEOLOCATION"),
+        ("emergency_contact_phone", "LGPD_EMERGENCY_CONTACT"),
+        # Prefix recall: leading \\b misses these; (?:^|_) matches after underscore.
+        ("titular_cnh", "LGPD_CNH"),
+        ("cliente_conta_bancaria", "LGPD_BANK_ACCOUNT"),
+        ("user_latitude", "LGPD_GEOLOCATION"),
+        ("func_contato_emergencia", "LGPD_EMERGENCY_CONTACT"),
+    ],
+)
+def test_lgpd_field_validated_column_headers_detect_high(
+    lgpd_scanner, column_name: str, expected_pattern: str
+):
+    """#1288 field-caught categories fire on representative column headers."""
+    result = lgpd_scanner.scan_column(column_name, "")
+    assert result["sensitivity_level"] == "HIGH"
+    assert expected_pattern in result["pattern_detected"]
+
+
+def test_lgpd_geolocation_does_not_match_platitude_midword(lgpd_scanner):
+    """(?:^|_) avoids mid-word false positives (platitude ≠ latitude)."""
+    result = lgpd_scanner.scan_column("platitude", "")
+    assert "LGPD_GEOLOCATION" not in result["pattern_detected"]


### PR DESCRIPTION
## Summary

Field-validated enrichment of `compliance-sample-lgpd.yaml` (#1288):

- **Regex + terms + recommendation_overrides** for criminal records (Art. 11, priority ALTA), CNH, RG/identity, bank account/branch, precise geolocation, emergency contact
- Bilingual PT-BR + EN terms; double-quoted YAML regex with escaped backslashes
- **Recall nits:** no trailing `\b` on underscore stems (`criminal_records_consulted_at`); leading `(?:^|_)` instead of `\b` so prefixed columns match (`user_latitude`, `titular_cnh`, `cliente_conta_bancaria`, `func_contato_emergencia`) without mid-word hits (`platitude`)
- README EN/pt-BR language + sample table updated
- Regression tests for suffix and prefix column headers

No PLAN — enrichment of existing sample only. Synthetic patterns only (zero real PII).

## Test plan

- [x] `uv run pytest tests/test_compliance_samples.py` — 103 passed
- [x] Prefix cases: `user_latitude`, `titular_cnh`, `cliente_conta_bancaria`, `func_contato_emergencia`
- [x] Suffix case: `criminal_records_consulted_at` → Art. 11
- [x] Mid-word negative: `platitude` does not fire `LGPD_GEOLOCATION`

Closes #1288

Made with [Cursor](https://cursor.com)