### PR TITLE
fix(deps): bump pyasn1 to 0.6.4 (PYSEC-2026-3455/3456/3457)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,9 @@ dependencies = [
     "packaging>=26.1",
     "pandas>=3.0.3",
     "pillow>=12.3.0",
+    # pyasn1 is transitive (pyopenssl/crypto); direct floor so uv resolves the
+    # security fix for PYSEC-2026-3455, PYSEC-2026-3456, PYSEC-2026-3457.
+    "pyasn1>=0.6.4",
     "pycparser>=3.0 ; implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'",
     "pydantic>=2.13.2",
     "pydantic-core>=2.46.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1260,10 +1260,12 @@ py-serializable==2.1.0 \
     --hash=sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103 \
     --hash=sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304
     # via cyclonedx-python-lib
-pyasn1==0.6.3 \
-    --hash=sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf \
-    --hash=sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde
-    # via webauthn
+pyasn1==0.6.4 \
+    --hash=sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81 \
+    --hash=sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b
+    # via
+    #   data-boar
+    #   webauthn
 pycparser==3.0 ; implementation_name != 'PyPy' and platform_python_implementation != 'PyPy' \
     --hash=sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29 \
     --hash=sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992

--- a/uv.lock
+++ b/uv.lock
@@ -841,6 +841,7 @@ dependencies = [
     { name = "packaging" },
     { name = "pandas" },
     { name = "pillow" },
+    { name = "pyasn1" },
     { name = "pycparser", marker = "implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'" },
     { name = "pydantic" },
     { name = "pydantic-core" },
@@ -1016,6 +1017,7 @@ requires-dist = [
     { name = "psycopg2-binary", marker = "extra == 'sql-community'", specifier = ">=2.9.11" },
     { name = "py7zr", marker = "extra == 'compressed'", specifier = ">=1.1.3" },
     { name = "pyarrow", marker = "extra == 'dataformats'", specifier = ">=14.0.0" },
+    { name = "pyasn1", specifier = ">=0.6.4" },
     { name = "pycparser", marker = "implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'", specifier = ">=3.0" },
     { name = "pydantic", specifier = ">=2.13.2" },
     { name = "pydantic-core", specifier = ">=2.46.2" },
@@ -3011,11 +3013,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes the red **Dependency audit** gate on `main` after #1303 by bumping transitive **pyasn1** to a fixed release:

- Direct floor `pyasn1>=0.6.4` in `pyproject.toml` (same pattern as beautifulsoup4/ebcdic transitive pins)
- `uv.lock` / `requirements.txt` resolve **pyasn1==0.6.4**
- Advisories cleared: **PYSEC-2026-3455**, **PYSEC-2026-3456**, **PYSEC-2026-3457**
- **Not** added to `--ignore-vuln` — doctrine is bump, not mask

## Test plan

- [x] `uv run pip-audit` (CI ignores only) → **No known vulnerabilities found**; no PYSEC-2026-345x
- [x] `./scripts/check-all.sh` green locally

Made with [Cursor](https://cursor.com)