### PR TITLE
docs(versioning): CVE/real-bug vs planned post-GA cadence (#1228)

### DIFF
--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -99,6 +99,18 @@ When **`1.7.4`** is already on PyPI and a packaging fix must ship without a new 
 For every **new** `X.Y.Z.postN` note, make the unpublished interval explicit: add one row per intermediate `maturity_build` as `*(fix, unpublished on PyPI)*` between `post(N-1)` and `postN`. Do not compress that interval into a single “N fixes” summary.
 In that map, keep **Notes** as short effect prose (with `#issue` when known), not raw commit subjects. Keep git-literal proof (`fix(...)` subjects + hashes) only in an **Appendix — Fix set (N=...)** section.
 
+### Post-GA tag / GitHub Release / Docker cadence (CVE vs planned deferral)
+
+After a line reaches **GA** (release gate closed — see [ADR-0072](adr/ADR-0072-commit-gate-vs-release-gate-distinct-criteria.md)), the operator may run a **deliberate pause** on **Git tag**, **GitHub Release**, and **Docker Hub** while the **PyPI `.postN` fix-line** stabilizes on `main`. That pause is a **publish rhythm** choice; it is **not** the same question as commit gate vs release gate. ADR-0072 names those gates; this subsection records **when to break or hold** the post-GA tag/Release/container pace.
+
+| Situation | Tag + GitHub Release + Docker Hub | PyPI `.postN` / `maturity_build` on `main` |
+| --- | --- | --- |
+| **CVE or real bug** (exploitable risk, user-visible incorrect behavior, dependency CVE with an actionable **fixed** upstream) | **Break the pause immediately** — run **release-ritual** for the fix-line upload and refresh Hub/tags as needed | Advance per the dual-counter table above and [ADR-0073](adr/ADR-0073-version-scheme-octet-maturity-and-roadmap.md) |
+| **Planned rigor** (operator-perceived hardening still in flight) or a fix **intentionally deferred** before rc→GA | **Hold the agreed pace** — do not accelerate tag/Release/container for perception or backlog grooming alone | Land fixes on `main`; octet / `.postN` only when runnable substance warrants |
+| **Docs / ADR / plans / chore / ci / test-only** | No automatic tag/Release/Docker bump | **Does not** increment `maturity_build` |
+
+**Roster doctrine (origin):** [data-boar-shared#14](https://github.com/DataBoar/data-boar-shared/issues/14) (2026-07-13). **Related gate taxonomy:** [ADR-0072](adr/ADR-0072-commit-gate-vs-release-gate-distinct-criteria.md) — commit gate ≠ release gate; it does **not** subsume this CVE-vs-planned distinction.
+
 ---
 
 ## Pre-release flow (`-beta` / `-rc`) before final publish

--- a/docs/VERSIONING.pt_BR.md
+++ b/docs/VERSIONING.pt_BR.md
@@ -99,6 +99,18 @@ Quando **`1.7.4`** já está no PyPI e um fix de empacotamento precisa sair sem 
 Para cada nota nova `X.Y.Z.postN`, deixe o intervalo unpublished explícito: inclua uma linha por `maturity_build` intermediário como `*(fix, unpublished on PyPI)*` entre `post(N-1)` e `postN`. Não comprima esse intervalo em uma linha única de “N fixes”.
 Nesse mapa, mantenha a coluna **Notes** em prosa curta de efeito (com `#issue` quando houver), não em subject cru de commit. A prova git-literal (`fix(...)` + hash) fica apenas no **Appendix — Fix set (N=...)**.
 
+### Cadência pós-GA de tag / GitHub Release / Docker (CVE vs adiado de propósito)
+
+Depois que uma linha atinge **GA** (release gate fechado — ver [ADR-0072](adr/ADR-0072-commit-gate-vs-release-gate-distinct-criteria.md)), o operador pode adotar uma **pausa deliberada** em **tag Git**, **GitHub Release** e **Docker Hub** enquanto a **fix-line `.postN` no PyPI** estabiliza em `main`. Essa pausa é escolha de **ritmo de publicação**; **não** é a mesma pergunta que commit gate vs release gate. A ADR-0072 nomeia esses gates; esta subseção registra **quando quebrar ou manter** o compasso pós-GA de tag/Release/container.
+
+| Situação | Tag + GitHub Release + Docker Hub | PyPI `.postN` / `maturity_build` em `main` |
+| --- | --- | --- |
+| **CVE ou bug real** (risco explorável, comportamento incorreto visível ao usuário, CVE de dependência com correção **acionável** no upstream) | **Quebra a pausa imediatamente** — executar **release-ritual** para o upload da fix-line e atualizar Hub/tags conforme necessário | Avançar conforme a tabela de dois contadores acima e a [ADR-0073](adr/ADR-0073-version-scheme-octet-maturity-and-roadmap.md) |
+| **Rigor planejado** (endurecimento percebido pelo operador ainda em curso) ou fix **adiado de propósito** antes de rc→GA | **Mantém o compasso combinado** — não acelerar tag/Release/container por percepção ou higiene de backlog sozinha | Fixes em `main`; octeto / `.postN` só quando houver substância executável |
+| **Docs / ADR / plans / chore / ci / só teste** | Sem bump automático de tag/Release/Docker | **Não** incrementa `maturity_build` |
+
+**Doutrina de roster (origem):** [data-boar-shared#14](https://github.com/DataBoar/data-boar-shared/issues/14) (2026-07-13). **Taxonomia de gate relacionada:** [ADR-0072](adr/ADR-0072-commit-gate-vs-release-gate-distinct-criteria.md) — commit gate ≠ release gate; **não** cobre esta distinção CVE-vs-planejado.
+
 ---
 
 ## Fluxo de pré-release (`-beta` / `-rc`) antes do publish final


### PR DESCRIPTION
## Summary

- Add post-GA tag / GitHub Release / Docker cadence guidance to `docs/VERSIONING.md` and `docs/VERSIONING.pt_BR.md`.
- **CVE or real bug** breaks the deliberate post-GA publish pause immediately; **planned rigor** or **intentionally deferred** fixes keep the agreed pace.
- Cross-reference [ADR-0072](docs/adr/ADR-0072-commit-gate-vs-release-gate-distinct-criteria.md) and [data-boar-shared#14](https://github.com/DataBoar/data-boar-shared/issues/14).

**Supersedes #1306** — tip was amended clean locally (`d3cfc6c1`, no `Co-authored-by`), but `git push --force-with-lease` was blocked (`GH013: Cannot force-push to this branch`). This PR uses a fresh branch with clean history (`4eaefe31`).

Closes #1228

## Test plan

- [x] `uv run pytest tests/test_commit_no_tool_coauthorship.py -q`
- [ ] CI green on clean tip