### PR TITLE
fix(connector): branch SQL connect timeout kwargs by driver (#1302)

### DIFF
--- a/connectors/sql_connector.py
+++ b/connectors/sql_connector.py
@@ -234,13 +234,28 @@ def _build_url(target: dict[str, Any]) -> str:
 
 def _connect_args_from_target(target: dict[str, Any]) -> dict[str, Any]:
     """
-    Build SQLAlchemy connect_args from target timeouts (config loader merges global + per-target).
-    Uses connect_timeout_seconds for connect; read_timeout_seconds for statement_timeout (PostgreSQL)
-    or SQLite lock timeout, or pymssql ``timeout`` for MSSQL.
+    Build SQLAlchemy ``connect_args`` from target timeouts (config loader merges global + per-target).
+
+    Uses ``connect_timeout_seconds`` for connect; ``read_timeout_seconds`` for statement_timeout
+    (PostgreSQL), SQLite lock wait, or pymssql query ``timeout``.
+
+    Branch on the **resolved SQLAlchemy drivername** from ``_resolve_driver`` (not bare
+    ``base == "mssql"`` alone): ``mssql+pymssql`` and ``mssql+pyodbc`` share base ``mssql``
+    but accept different connect kwargs (#1302).
+
+    Driver → connect_args mapping::
+
+        postgresql[+…]       connect_timeout, options=-c statement_timeout=… (ms)
+        mysql[+…] / mariadb  connect_timeout
+        sqlite               timeout  (lock wait; read_timeout_seconds)
+        mssql+pymssql        login_timeout, timeout  (#1297; bare ``mssql`` maps here)
+        mssql+pyodbc         timeout only  (pyodbc.connect accepts ``timeout``; not login_timeout)
+        oracle+oracledb      tcp_connect_timeout  (oracledb; not connect_timeout)
+        other                connect_timeout  (best-effort)
     """
     connect_s = int(target.get("connect_timeout_seconds", 25))
     read_s = int(target.get("read_timeout_seconds", 90))
-    _, base = _resolve_driver(target.get("driver"))
+    drivername, base = _resolve_driver(target.get("driver"))
     connect_s = max(1, connect_s)
     read_s = max(1, read_s)
     if base == "sqlite":
@@ -254,9 +269,13 @@ def _connect_args_from_target(target: dict[str, Any]) -> dict[str, Any]:
     if base in ("mysql", "mariadb"):
         return {"connect_timeout": connect_s}
     if base == "mssql":
-        # pymssql (default mssql driver) uses login_timeout/timeout, not connect_timeout.
+        if drivername.endswith("+pyodbc"):
+            # pyodbc.connect(..., timeout=seconds) — no login_timeout kwarg
+            return {"timeout": connect_s}
+        # mssql+pymssql (default via DRIVER_MAP) and other mssql+* pymssql-style
         return {"login_timeout": connect_s, "timeout": read_s}
-    # oracle, others: pass connect_timeout when driver supports it
+    if base == "oracle":
+        return {"tcp_connect_timeout": connect_s}
     return {"connect_timeout": connect_s}
 
 

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -276,6 +276,8 @@ def test_connect_args_from_target_postgresql():
     assert args["connect_timeout"] == 15
     assert "options" in args
     assert "statement_timeout=120000" in args["options"]
+    assert "login_timeout" not in args
+    assert "tcp_connect_timeout" not in args
 
 
 def test_connect_args_from_target_mysql():
@@ -288,10 +290,12 @@ def test_connect_args_from_target_mysql():
     args = _connect_args_from_target(target)
     assert args["connect_timeout"] == 10
     assert "options" not in args
+    assert "login_timeout" not in args
+    assert "tcp_connect_timeout" not in args
 
 
-def test_connect_args_from_target_mssql_pymssql():
-    """_connect_args_from_target uses pymssql login_timeout/timeout (not connect_timeout)."""
+def test_connect_args_from_target_mssql_bare_maps_to_pymssql():
+    """Bare mssql resolves to mssql+pymssql → login_timeout/timeout (not connect_timeout)."""
     target = {
         "driver": "mssql",
         "connect_timeout_seconds": 20,
@@ -302,11 +306,66 @@ def test_connect_args_from_target_mssql_pymssql():
     assert "connect_timeout" not in args
 
 
+def test_connect_args_from_target_mssql_pymssql_explicit():
+    """Explicit mssql+pymssql keeps login_timeout/timeout (#1297 / #1302)."""
+    target = {
+        "driver": "mssql+pymssql",
+        "connect_timeout_seconds": 20,
+        "read_timeout_seconds": 80,
+    }
+    args = _connect_args_from_target(target)
+    assert args == {"login_timeout": 20, "timeout": 80}
+    assert "connect_timeout" not in args
+    assert "login_timeout" in args
+
+
+def test_connect_args_from_target_mssql_pyodbc():
+    """mssql+pyodbc uses pyodbc timeout only — never login_timeout (#1302)."""
+    target = {
+        "driver": "mssql+pyodbc",
+        "connect_timeout_seconds": 20,
+        "read_timeout_seconds": 80,
+    }
+    args = _connect_args_from_target(target)
+    assert args == {"timeout": 20}
+    assert "login_timeout" not in args
+    assert "connect_timeout" not in args
+
+
+def test_connect_args_from_target_oracle_oracledb():
+    """oracle+oracledb uses tcp_connect_timeout — never connect_timeout (#1302)."""
+    target = {
+        "driver": "oracle+oracledb",
+        "connect_timeout_seconds": 30,
+        "read_timeout_seconds": 90,
+    }
+    args = _connect_args_from_target(target)
+    assert args == {"tcp_connect_timeout": 30}
+    assert "connect_timeout" not in args
+
+
+def test_connect_args_from_target_oracle_bare():
+    """Bare oracle maps to oracle+oracledb → tcp_connect_timeout."""
+    target = {
+        "driver": "oracle",
+        "connect_timeout_seconds": 12,
+    }
+    args = _connect_args_from_target(target)
+    assert args == {"tcp_connect_timeout": 12}
+    assert "connect_timeout" not in args
+
+
 def test_connect_args_from_target_sqlite():
     """_connect_args_from_target returns timeout (lock wait) for SQLite."""
-    target = {"driver": "sqlite", "read_timeout_seconds": 30}
+    target = {
+        "driver": "sqlite",
+        "connect_timeout_seconds": 25,
+        "read_timeout_seconds": 30,
+    }
     args = _connect_args_from_target(target)
-    assert args["timeout"] == 30
+    assert args == {"timeout": 30}
+    assert "connect_timeout" not in args
+    assert "login_timeout" not in args
 
 
 def test_connect_args_from_target_defaults():


### PR DESCRIPTION
## Summary
- Fix `_connect_args_from_target` in `connectors/sql_connector.py` to branch on the **resolved SQLAlchemy drivername** from `_resolve_driver` (not bare `base == "mssql"` alone).
- **oracle / oracle+oracledb** → `tcp_connect_timeout` (oracledb; **not** `connect_timeout`).
- **mssql+pyodbc** → `timeout` only (pyodbc.connect accepts `timeout`; **not** `login_timeout`).
- **mssql+pymssql** (default bare `mssql`) → keep `login_timeout` / `timeout` (#1297).
- Document driver→kwarg table in the function docstring.
- Unit tests cover mssql+pymssql, mssql+pyodbc, oracle+oracledb, postgresql, mysql, sqlite — including absence of forbidden kwargs.

## Context
Refs #1302

**Not closing** the issue: Podman / real-engine validation (MSSQL + `gvenzl/oracle-free`) remains a **follow-up**. This PR is the code + unit-test slice only.

## Test plan
- [x] `./scripts/quick-test.sh --path tests/test_sql_connector.py --keyword connect_args_from_target`
- [x] `./scripts/check-all.sh` green on `fix/1302-connector-timeout-kwargs`
- [ ] Follow-up: Podman smoke against MSSQL + Oracle Free (ingest > 0) per #1302 / PLAN_DATABASE_COMPAT_MATRIX


Made with [Cursor](https://cursor.com)