### PR TITLE
fix(connector): skip Oracle 12c+ system schemas including AUDSYS (#1315)

### DIFF
--- a/connectors/sql_connector.py
+++ b/connectors/sql_connector.py
@@ -65,6 +65,15 @@ ORACLE_SYSTEM_SCHEMAS = frozenset(
         "MDDATA",
         "REMOTE_SCHEDULER_AGENT",
         "DBSFWUSER",
+        # 12c+/19c/23c Oracle-maintained (issue #1315; AUDSYS = unified audit trail noise)
+        "AUDSYS",
+        "SYS$UMF",
+        "GGSYS",
+        "SYSBACKUP",
+        "SYSDG",
+        "SYSKM",
+        "SYSRAC",
+        "PDBADMIN",
     }
 )
 

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -98,6 +98,19 @@ def test_get_skip_schemas_oracle_uses_system_schemas():
     assert "SYSTEM" in skip
 
 
+def test_get_skip_schemas_oracle_includes_12c_plus_system_schemas():
+    """Oracle 12c+/23c maintained schemas skipped (issue #1315 — AUDSYS cascade)."""
+    skip = _get_skip_schemas("oracle")
+    assert "AUDSYS" in skip
+    assert "GGSYS" in skip
+    assert "SYSBACKUP" in skip
+    assert "PDBADMIN" in skip
+    # Already present before #1315 — must not regress
+    assert "DVF" in skip
+    assert "DVSYS" in skip
+    assert "GSMADMIN_INTERNAL" in skip
+
+
 def test_get_skip_schemas_non_oracle_uses_default():
     """_get_skip_schemas for postgresql/mysql returns default skip set."""
     skip = _get_skip_schemas("postgresql")


### PR DESCRIPTION
## Summary
- Extend `ORACLE_SYSTEM_SCHEMAS` in `connectors/sql_connector.py` with Oracle 12c+/23c maintained schemas missing from the static list: **AUDSYS**, **SYS$UMF**, **GGSYS**, **SYSBACKUP**, **SYSDG**, **SYSKM**, **SYSRAC**, **PDBADMIN**.
- Existing entries (**DVF**, **DVSYS**, **GSMADMIN_INTERNAL**, **OJVMSYS**, **DBSFWUSER**, **REMOTE_SCHEDULER_AGENT**) unchanged — no duplicates.
- Unit test asserts `AUDSYS` (and GGSYS, SYSBACKUP, PDBADMIN) in `_get_skip_schemas('oracle')`.

## Context
Closes #1315

Field evidence: DBA scan against `gvenzl/oracle-free:slim` (23c) hit 343× `ORA-00942` on `audsys.aud$unified` because discovery did not skip **AUDSYS**.

## Test plan
- [x] `./scripts/quick-test.sh --path tests/test_sql_connector.py --keyword skip_schemas_oracle`
- [x] `./scripts/check-all.sh` green on `fix/1315-oracle-audsys-skip`
- [ ] Follow-up (separate issue): `DBA_USERS.ORACLE_MAINTAINED = 'Y'` filter instead of static list