### PR TITLE
feat(scan): adaptive rate limiting in production engine + docs (#1320, #1321)

### DIFF
--- a/config/loader.py
+++ b/config/loader.py
@@ -1016,6 +1016,14 @@ def normalize_config(
     if mw > 32:
         mw = 32
     out["scan"]["max_workers"] = mw
+    out["scan"]["adaptive_rate_limit"] = bool(
+        out["scan"].get("adaptive_rate_limit", False)
+    )
+    try:
+        tlm = float(out["scan"].get("target_latency_ms", 200.0))
+    except (TypeError, ValueError):
+        tlm = 200.0
+    out["scan"]["target_latency_ms"] = max(1.0, min(tlm, 60_000.0))
 
     # SQLite path for audit results
     out["sqlite_path"] = data.get("sqlite_path", "audit_results.db")

--- a/core/engine.py
+++ b/core/engine.py
@@ -7,7 +7,9 @@ Exposes db_manager, is_running, get_current_findings_count() for API.
 """
 
 import hashlib
-from concurrent.futures import ThreadPoolExecutor, as_completed
+import logging
+import time
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, as_completed, wait
 from pathlib import Path
 from typing import Any
 
@@ -90,6 +92,7 @@ from core.database import LocalDBManager
 from core.sampling import SamplingPolicy
 from core.scanner import DataScanner
 from core.session import new_session_id
+from core.throttler import BoarThrottler
 from utils.logger import configure_audit_log_directory
 
 _CONNECTOR_SAMPLING_POLICY_BASES: tuple[type, ...] = (SQLConnector,)
@@ -143,7 +146,14 @@ class AuditEngine:
         )
         self._is_running = False
         self._last_report_path: str | None = None
-        self._max_workers = int(config.get("scan", {}).get("max_workers", 1))
+        scan_cfg = config.get("scan") if isinstance(config.get("scan"), dict) else {}
+        self._max_workers = int(scan_cfg.get("max_workers", 1))
+        self._adaptive_rate_limit = bool(scan_cfg.get("adaptive_rate_limit", False))
+        try:
+            self._target_latency_ms = float(scan_cfg.get("target_latency_ms", 200.0))
+        except (TypeError, ValueError):
+            self._target_latency_ms = 200.0
+        self._target_latency_ms = max(1.0, self._target_latency_ms)
         self._extensions = config.get("file_scan", {}).get("extensions", [])
         # Internal: best-effort strong-crypto signals collected per-target during this run.
         # Phase 1: populated for database-style targets only; not yet persisted or exposed.
@@ -237,7 +247,6 @@ class AuditEngine:
         # Enforced mode only (open mode returns None = no cap). Fail-soft: a cap
         # resolution error must never abort a scan the license gate already
         # allowed — warn and run uncapped instead.
-        import logging
 
         try:
             cap = guard.worker_cap()
@@ -295,6 +304,86 @@ class AuditEngine:
         self._run_audit_targets()
         return session_id
 
+    def _record_parallel_worker_failure(
+        self,
+        *,
+        target: dict[str, Any],
+        exc: BaseException,
+        session_id: str | None,
+    ) -> None:
+        """Log and persist uncaught worker failures (parallel target runs)."""
+        tname = target.get("name", "unknown") if isinstance(target, dict) else "unknown"
+        try:
+            from utils.logger import get_logger
+
+            get_logger().exception(
+                "Parallel target worker failed: session=%s",
+                session_id,
+            )
+        except Exception as log_err:
+            _ = str(log_err)
+        try:
+            from core.validation import clean_error
+
+            self.db_manager.save_failure(
+                tname,
+                "error",
+                f"Uncaught worker error: {clean_error(exc)}",
+            )
+        except Exception as save_err:
+            _ = str(save_err)
+
+    def _run_audit_targets_adaptive(self, targets: list[dict[str, Any]]) -> str:
+        """
+        Run targets with BoarThrottler feedback (#1320).
+
+        Effective concurrency is ``throttler.current_workers`` (1 .. scan.max_workers),
+        already clamped to licensing tier in ``start_audit``.
+        """
+        final_status = "completed"
+        throttler = BoarThrottler(
+            target_latency_ms=self._target_latency_ms,
+            max_workers=max(1, self._max_workers),
+        )
+        session_id = self.db_manager.current_session_id
+
+        def _timed_run(target: dict[str, Any]) -> float:
+            started = time.perf_counter()
+            self._run_target(target)
+            return time.perf_counter() - started
+
+        pending = list(targets)
+        in_flight: dict[Any, dict[str, Any]] = {}
+        pool_cap = max(1, self._max_workers)
+
+        with ThreadPoolExecutor(max_workers=pool_cap) as ex:
+            while pending or in_flight:
+                limit = max(1, int(throttler.current_workers))
+                while pending and len(in_flight) < limit:
+                    tgt = pending.pop(0)
+                    fut = ex.submit(_timed_run, tgt)
+                    in_flight[fut] = tgt
+
+                if not in_flight:
+                    break
+
+                done, _ = wait(tuple(in_flight.keys()), return_when=FIRST_COMPLETED)
+                for fut in done:
+                    tgt = in_flight.pop(fut)
+                    try:
+                        elapsed = float(fut.result())
+                    except Exception as e:
+                        self._record_parallel_worker_failure(
+                            target=tgt, exc=e, session_id=session_id
+                        )
+                        final_status = "completed_errors"
+                        elapsed = 0.0
+                    throttler.record_latency(elapsed)
+                    cool = throttler.get_sleep_time()
+                    if cool > 0:
+                        time.sleep(cool)
+        return final_status
+
     def _run_audit_targets(self) -> None:
         """Run all targets; caller must set session_id and create_session_record before."""
         self._is_running = True
@@ -302,7 +391,9 @@ class AuditEngine:
         targets = self.config.get("targets", [])
         final_status = "completed"
         try:
-            if self._max_workers <= 1:
+            if self._adaptive_rate_limit:
+                final_status = self._run_audit_targets_adaptive(targets)
+            elif self._max_workers <= 1:
                 for target in targets:
                     self._run_target(target)
             else:
@@ -314,36 +405,12 @@ class AuditEngine:
                         try:
                             fut.result()
                         except Exception as e:
-                            # Target-level errors are usually caught inside _run_target; this
-                            # path handles unexpected worker failures so sessions are not
-                            # silently marked completed without trace.
                             tgt = futures.get(fut) or {}
-                            tname = (
-                                tgt.get("name", "unknown")
-                                if isinstance(tgt, dict)
-                                else "unknown"
+                            self._record_parallel_worker_failure(
+                                target=tgt if isinstance(tgt, dict) else {},
+                                exc=e,
+                                session_id=session_id,
                             )
-                            try:
-                                from utils.logger import get_logger
-
-                                get_logger().exception(
-                                    "Parallel target worker failed: session=%s",
-                                    session_id,
-                                )
-                            except Exception as log_err:
-                                # Best effort: logging failures must not interrupt worker cleanup.
-                                _ = str(log_err)
-                            try:
-                                from core.validation import clean_error
-
-                                self.db_manager.save_failure(
-                                    tname,
-                                    "error",
-                                    f"Uncaught worker error: {clean_error(e)}",
-                                )
-                            except Exception as save_err:
-                                # Best effort: persist failures when possible, but don't break session flow.
-                                _ = str(save_err)
                             final_status = "completed_errors"
         except KeyboardInterrupt:
             # Ctrl+C / SIGTERM→KeyboardInterrupt: terminal "interrupted", not orphan running (#1251).

--- a/docs/TECH_GUIDE.md
+++ b/docs/TECH_GUIDE.md
@@ -184,6 +184,8 @@ api:
 sqlite_path: audit_results.db
 scan:
   max_workers: 1   # 1 = sequential; >1 = parallel
+  # adaptive_rate_limit: true   # optional ARL — see USAGE.md §Adaptive rate limiting
+  # target_latency_ms: 200
 
 # Optional: external pattern files (no code change)
 ml_patterns_file: ml_patterns.yaml
@@ -250,6 +252,8 @@ rate_limit:
   min_interval_seconds: 0
   grace_for_running_status: 0
 ```
+
+**Adaptive rate limiting (ARL):** optional `scan.adaptive_rate_limit: true` tunes effective `max_workers` from per-target latency in the production engine path (`core/engine.py`). Default is **off** (fixed pool). See [USAGE.md](USAGE.md) § *Adaptive rate limiting (ARL)* for mechanics, defaults, and interaction with licensing worker caps (#551).
 
 When `enabled` is true, API endpoints that start scans (`POST /scan`, `/start`, `/scan_database`) may respond with **HTTP 429** and a JSON payload describing the reason (e.g. too many running scans or minimum interval not elapsed). The CLI only prints warnings using the same logic, so existing scripts keep working. See [USAGE.md](USAGE.md) and [data_boar.5](data_boar.5) for full configuration details and examples.
 

--- a/docs/TECH_GUIDE.pt_BR.md
+++ b/docs/TECH_GUIDE.pt_BR.md
@@ -184,6 +184,8 @@ api:
 sqlite_path: audit_results.db
 scan:
   max_workers: 1   # 1 = sequential; >1 = parallel
+  # adaptive_rate_limit: true   # ARL opcional — veja USAGE.pt_BR.md §Limitação de taxa adaptativa
+  # target_latency_ms: 200
 
 # Optional: external pattern files (no code change)
 ml_patterns_file: ml_patterns.yaml
@@ -250,6 +252,8 @@ rate_limit:
   min_interval_seconds: 0
   grace_for_running_status: 0
 ```
+
+**Limitação de taxa adaptativa (ARL):** `scan.adaptive_rate_limit: true` (padrão **false**) ajusta workers efetivos a partir da latência por alvo no engine de produção. Veja [USAGE.pt_BR.md](USAGE.pt_BR.md) § *Limitação de taxa adaptativa (ARL)* e interação com o teto de licença (#551).
 
 Quando `enabled` é true, os endpoints da API que iniciam varreduras (`POST /scan`, `/start`, `/scan_database`) podem responder com **HTTP 429** e um payload JSON descrevendo o motivo (ex.: muitas varreduras em execução ou intervalo mínimo não decorrido). A CLI apenas imprime avisos com a mesma lógica, então scripts existentes continuam funcionando. Veja [USAGE.md](USAGE.md) e [data_boar.5](data_boar.5) para detalhes e exemplos completos de configuração.
 

--- a/docs/TROUBLESHOOTING_CONNECTIVITY.md
+++ b/docs/TROUBLESHOOTING_CONNECTIVITY.md
@@ -46,6 +46,7 @@ This document helps you diagnose and fix **unreachable**, **timeout**, and **per
 1. **Timeout too low in config:** REST/API targets support a `timeout` (seconds). Default is often 30; increase if the target is slow (e.g. `timeout: 60` or 120).
 1. **Network latency:** Cross-region or congested path; increase timeout or run the scanner closer to the target.
 1. **Large discovery:** Some connectors (e.g. Power BI, Dataverse) do many API calls; total time can exceed a single-request timeout. Increase timeout and/or reduce scope if possible.
+1. **Fragile production database under parallel scan:** If the host has little memory or no swap, high `scan.max_workers` can amplify latency or look like DoS. Try `scan.adaptive_rate_limit: true` with a realistic `target_latency_ms` (default 200) so the engine throttles target concurrency from observed latency — see [USAGE.md](USAGE.md) § *Adaptive rate limiting (ARL)*. Fixed `max_workers: 1` remains the manual alternative.
 
 ### 3.2 Steps to fix
 

--- a/docs/TROUBLESHOOTING_CONNECTIVITY.pt_BR.md
+++ b/docs/TROUBLESHOOTING_CONNECTIVITY.pt_BR.md
@@ -42,6 +42,7 @@ Corrija DNS (use IP ou servidor DNS correto); abra firewall para a porta necess�
 1. **Alvo lento ou sobrecarregado:** Alta latência ou carga no DB/API; tente em horário de menor uso.
 1. **Timeout baixo no config:** Alvos REST/API aceitam `timeout` (segundos). Aumente (ex.: 60 ou 120) se o alvo for lento.
 1. **Latência de rede:** Caminho entre regiões ou congestionado; aumente timeout ou rode o scanner mais perto do alvo.
+1. **Banco de produção frágil com scan paralelo:** Pouca memória ou sem swap — `scan.max_workers` alto pode amplificar latência ou parecer DoS. Tente `scan.adaptive_rate_limit: true` com `target_latency_ms` realista (padrão 200); veja [USAGE.pt_BR.md](USAGE.pt_BR.md) § *Limitação de taxa adaptativa (ARL)*. `max_workers: 1` fixo continua sendo a alternativa manual.
 
 ### 3.2 Passos para corrigir
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -639,9 +639,40 @@ Recommendations so scans stay robust without overloading targets or waiting fore
 
 1. **Don’t wait forever:** Set connect and read timeouts so one stuck target does not block the whole scan. Use report failure hints to spot timeout failures and which target failed.
 1. **Don’t be too aggressive:** Too-low timeouts cause false timeouts on busy or slow networks (e.g. during backup). If you see many timeouts, **increase** `connect_seconds` and `read_seconds` (or per-target `connect_timeout` / `read_timeout`) and consider re-running during off-peak.
-1. **Avoid DoS and "too much, too fast":** Use **rate_limit** (e.g. `max_concurrent_scans: 1`, `min_interval_seconds: 5`) and **scan.max_workers: 1** (or 2) so the scanner does not open many connections at once. This reduces load on targets and avoids amplifying slowness or causing DoS.
+1. **Avoid DoS and "too much, too fast":** Use **rate_limit** (e.g. `max_concurrent_scans: 1`, `min_interval_seconds: 5`) and **scan.max_workers: 1** (or 2) so the scanner does not open many connections at once. This reduces load on targets and avoids amplifying slowness or causing DoS. For fragile production databases where fixed workers are either too aggressive or too slow, prefer **adaptive rate limiting (ARL)** — see [Adaptive rate limiting (ARL)](#adaptive-rate-limiting-arl) below instead of guessing a static `max_workers`.
 1. **Backup or maintenance windows:** If scans run during backup or maintenance, increase timeouts and keep parallelism low; or schedule scans outside those windows.
 1. **Per-target overrides:** For one slow database or API, set `connect_timeout` / `read_timeout` (or `timeout`) on that target instead of raising global defaults for everyone.
+
+### Adaptive rate limiting (ARL)
+
+**Default:** `scan.adaptive_rate_limit: false` — the engine uses a fixed `scan.max_workers` pool (unchanged behaviour).
+
+When **enabled**, the production `--config` scan path (`core/engine.py`) uses `BoarThrottler` to adjust **effective** parallel target workers from observed per-target latency:
+
+| Signal | Action |
+| ------ | ------ |
+| Moving average latency **&lt; 80%** of `target_latency_ms` | Increase workers by 1 (up to `scan.max_workers`) |
+| Average **&gt;** `target_latency_ms` | Decrease workers by 1 (minimum 1) |
+| Average **&gt; 2×** `target_latency_ms` | Halve workers (minimum 1) + optional cool-off sleep |
+
+**Config (under `scan:`):**
+
+```yaml
+scan:
+  max_workers: 4              # ceiling for ARL and fixed mode
+  adaptive_rate_limit: true   # default false — opt-in
+  target_latency_ms: 200      # default 200; feedback target in milliseconds
+```
+
+**Interactions:**
+
+- **Licensing worker cap (#551):** `guard.worker_cap()` still clamps `scan.max_workers` before the scan starts; ARL never exceeds that hard ceiling.
+- **`rate_limit`:** API/dashboard scan-start throttling is orthogonal — it limits how many **scan sessions** start; ARL limits how many **targets** run in parallel inside one session.
+- **Manual freio:** Fixed `max_workers: 1` (or 2) remains valid when you want a static cap; ARL is for when latency feedback should tune concurrency automatically.
+
+**When to use:** Production SQL Server / RDS / other fragile hosts without swap, where `max_workers: 8` risks overload but `max_workers: 1` wastes wall-clock on healthy latency.
+
+See also [TECH_GUIDE.md](TECH_GUIDE.md) (detection / performance) and [TROUBLESHOOTING_CONNECTIVITY.md](TROUBLESHOOTING_CONNECTIVITY.md) (timeouts and load).
 
 ### API and security (CSP, headers)
 

--- a/docs/USAGE.pt_BR.md
+++ b/docs/USAGE.pt_BR.md
@@ -580,9 +580,40 @@ Recomendações para que as varreduras permaneçam estáveis sem sobrecarregar o
 
 1. **Não espere para sempre:** Defina timeouts de conexão e de leitura para que um alvo travado não bloqueie toda a varredura. Use as dicas de falha no relatório para identificar falhas por timeout e qual alvo falhou.
 1. **Não seja agressivo demais:** Timeouts muito baixos geram falsos timeouts em redes ocupadas ou lentas (ex.: durante backup). Se aparecerem muitos timeouts, **aumente** `connect_seconds` e `read_seconds` (ou por alvo `connect_timeout` / `read_timeout`) e considere reexecutar em horário de menor uso.
-1. **Evite DoS e “muito rápido demais”:** Use **rate_limit** (ex.: `max_concurrent_scans: 1`, `min_interval_seconds: 5`) e **scan.max_workers: 1** (ou 2) para que o scanner não abra muitas conexões ao mesmo tempo. Isso reduz carga nos alvos e evita amplificar lentidão ou causar DoS.
+1. **Evite DoS e “muito rápido demais”:** Use **rate_limit** (ex.: `max_concurrent_scans: 1`, `min_interval_seconds: 5`) e **scan.max_workers: 1** (ou 2) para que o scanner não abra muitas conexões ao mesmo tempo. Isso reduz carga nos alvos e evita amplificar lentidão ou causar DoS. Em bancos de produção frágeis, prefira **limitação de taxa adaptativa (ARL)** — veja [Limitação de taxa adaptativa (ARL)](#limitação-de-taxa-adaptativa-arl) abaixo em vez de chutar um `max_workers` fixo.
 1. **Janelas de backup ou manutenção:** Se as varreduras rodarem durante backup ou manutenção, aumente os timeouts e mantenha o paralelismo baixo; ou agende varreduras fora dessas janelas.
 1. **Sobrescrita por alvo:** Para um banco ou API lento, defina `connect_timeout` / `read_timeout` (ou `timeout`) nesse alvo em vez de aumentar os padrões globais para todos.
+
+### Limitação de taxa adaptativa (ARL)
+
+**Padrão:** `scan.adaptive_rate_limit: false` — o engine usa pool fixo de `scan.max_workers` (comportamento atual).
+
+Com **ARL ligado**, o caminho de produção `--config` (`core/engine.py`) usa `BoarThrottler` para ajustar workers **efetivos** por alvo a partir da latência observada:
+
+| Sinal | Ação |
+| ----- | ---- |
+| Média móvel **&lt; 80%** de `target_latency_ms` | Aumenta workers em 1 (até `scan.max_workers`) |
+| Média **&gt;** `target_latency_ms` | Reduz workers em 1 (mínimo 1) |
+| Média **&gt; 2×** `target_latency_ms` | Divide workers pela metade (mín. 1) + cool-off opcional |
+
+**Config (em `scan:`):**
+
+```yaml
+scan:
+  max_workers: 4
+  adaptive_rate_limit: true   # padrão false — opt-in
+  target_latency_ms: 200
+```
+
+**Interações:**
+
+- **Teto de licença (#551):** `guard.worker_cap()` ainda limita `scan.max_workers` antes do scan; ARL não ultrapassa esse teto.
+- **`rate_limit`:** limita **sessões** de scan na API; ARL limita **alvos** em paralelo dentro de uma sessão.
+- **Freio manual:** `max_workers: 1` (ou 2) fixo continua válido; ARL é para quando o feedback de latência deve ajustar a concorrência.
+
+**Quando usar:** SQL Server / RDS em produção frágil, sem swap — `max_workers: 8` arrisca sobrecarga; `max_workers: 1` desperdiça tempo quando a latência está boa.
+
+Veja também [TECH_GUIDE.pt_BR.md](TECH_GUIDE.pt_BR.md) e [TROUBLESHOOTING_CONNECTIVITY.pt_BR.md](TROUBLESHOOTING_CONNECTIVITY.pt_BR.md).
 
 ### API e segurança (CSP, cabeçalhos)
 

--- a/tests/test_engine_adaptive_rate_limit.py
+++ b/tests/test_engine_adaptive_rate_limit.py
@@ -1,0 +1,138 @@
+"""AuditEngine adaptive rate limiting (#1320) — production path wiring."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.engine import AuditEngine
+
+
+def _filesystem_targets(n: int) -> list[dict[str, Any]]:
+    return [
+        {"name": f"target-{i}", "type": "filesystem", "path": "/tmp"} for i in range(n)
+    ]
+
+
+def _engine(
+    tmp_path, config: dict[str, Any], *, monkeypatch: pytest.MonkeyPatch
+) -> AuditEngine:
+    eng = AuditEngine(config, db_path=str(tmp_path / "audit.db"))
+    monkeypatch.setattr(eng.db_manager, "finish_session", MagicMock())
+    eng.db_manager.set_current_session_id("sess-test")
+    return eng
+
+
+def test_engine_adaptive_rate_limit_defaults_off(tmp_path, monkeypatch) -> None:
+    eng = _engine(
+        tmp_path,
+        {"targets": [], "scan": {}, "file_scan": {}, "detection": {}},
+        monkeypatch=monkeypatch,
+    )
+    assert eng._adaptive_rate_limit is False
+    assert eng._target_latency_ms == 200.0
+
+
+def test_engine_fixed_parallel_uses_thread_pool_concurrency(
+    tmp_path, monkeypatch
+) -> None:
+    """Without ARL, max_workers>1 may run multiple targets concurrently."""
+    config: dict[str, Any] = {
+        "targets": _filesystem_targets(8),
+        "scan": {"max_workers": 4, "adaptive_rate_limit": False},
+        "file_scan": {},
+        "detection": {},
+    }
+    eng = _engine(tmp_path, config, monkeypatch=monkeypatch)
+    active = 0
+    max_active = 0
+    lock = threading.Lock()
+
+    def _slow_run(_target: dict[str, Any]) -> None:
+        nonlocal active, max_active
+        with lock:
+            active += 1
+            max_active = max(max_active, active)
+        time.sleep(0.06)
+        with lock:
+            active -= 1
+
+    monkeypatch.setattr(eng, "_run_target", _slow_run)
+    eng._run_audit_targets()
+    assert max_active >= 3
+
+
+def test_engine_adaptive_reduces_concurrency_under_induced_latency(
+    tmp_path, monkeypatch
+) -> None:
+    """ARL on the engine path: slow targets + low target_latency_ms cap in-flight work."""
+    config: dict[str, Any] = {
+        "targets": _filesystem_targets(10),
+        "scan": {
+            "max_workers": 8,
+            "adaptive_rate_limit": True,
+            "target_latency_ms": 1.0,
+        },
+        "file_scan": {},
+        "detection": {},
+    }
+    eng = _engine(tmp_path, config, monkeypatch=monkeypatch)
+    active = 0
+    max_active = 0
+    lock = threading.Lock()
+
+    def _slow_run(_target: dict[str, Any]) -> None:
+        nonlocal active, max_active
+        with lock:
+            active += 1
+            max_active = max(max_active, active)
+        time.sleep(0.05)
+        with lock:
+            active -= 1
+
+    monkeypatch.setattr(eng, "_run_target", _slow_run)
+    eng._run_audit_targets()
+    assert max_active == 1
+
+
+def test_engine_adaptive_throttler_ceiling_uses_clamped_max_workers(
+    tmp_path, monkeypatch
+) -> None:
+    """Tier/licensing cap on _max_workers is the hard ceiling passed to BoarThrottler."""
+    config: dict[str, Any] = {
+        "targets": _filesystem_targets(2),
+        "scan": {
+            "max_workers": 8,
+            "adaptive_rate_limit": True,
+            "target_latency_ms": 200.0,
+        },
+        "file_scan": {},
+        "detection": {},
+    }
+    eng = _engine(tmp_path, config, monkeypatch=monkeypatch)
+    eng._max_workers = 2
+    monkeypatch.setattr(eng, "_run_target", lambda _t: None)
+
+    captured: list[int] = []
+
+    real_init = None
+
+    def _spy_init(self, *, target_latency_ms=200.0, max_workers=10, **kwargs):
+        captured.append(int(max_workers))
+        return real_init(
+            self,
+            target_latency_ms=target_latency_ms,
+            max_workers=max_workers,
+            **kwargs,
+        )
+
+    from core import throttler as throttler_mod
+
+    real_init = throttler_mod.BoarThrottler.__init__
+    monkeypatch.setattr(throttler_mod.BoarThrottler, "__init__", _spy_init)
+    eng._run_audit_targets()
+    assert captured == [2]


### PR DESCRIPTION
## Summary

- **#1320:** Wire `BoarThrottler` into the production `--config` path (`core/engine.py` `_run_audit_targets`). When `scan.adaptive_rate_limit: true`, effective target concurrency follows latency feedback (1 → `scan.max_workers`), with cool-off from existing `get_sleep_time()`. **Default off** — fixed `ThreadPoolExecutor(max_workers)` unchanged.
- **#1321:** Document ARL in `USAGE.md` / `USAGE.pt_BR.md` (mechanics, config, tier cap #551, `rate_limit` interaction, when to use). Cross-refs in `TECH_GUIDE` (+ pt-BR) and `TROUBLESHOOTING_CONNECTIVITY` (+ pt-BR). Manual freio at USAGE §Timeouts and load now points to ARL.
- Config loader normalizes `adaptive_rate_limit` (default false) and clamps `target_latency_ms` (default 200).

## Why one PR

#1321 explicitly pairs with the wiring fix — documenting `adaptive_rate_limit` without engine support would mislead operators.

## PLAN_*.md

**Not added.** #1320 is `[bug][perf][P2]` wiring of existing `BoarThrottler`; #1321 is docs-only. No new product surface beyond opt-in config flags on an existing controller — acceptance is tests + USAGE, not a multi-phase plan row.

## Tier cap

`guard.worker_cap()` still clamps `_max_workers` in `start_audit` before ARL runs; `BoarThrottler(max_workers=…)` receives the clamped ceiling (`test_engine_adaptive_throttler_ceiling_uses_clamped_max_workers`).

## Tests

- `tests/test_engine_adaptive_rate_limit.py` — fixed pool reaches high concurrency; ARL caps at 1 in-flight under induced latency; default off; throttler ceiling = clamped max_workers.

Closes #1320
Closes #1321

## Test plan

- [x] `uv run pytest tests/test_engine_adaptive_rate_limit.py -v`
- [x] `./scripts/check-all.sh --enforced` green