### PR TITLE
feat(scan): live progress + remote DB latency docs (#1328, #1323)

### DIFF
--- a/api/templates/help.html
+++ b/api/templates/help.html
@@ -45,7 +45,9 @@
 {{ prog }} --config config.yaml --regenerate-report &lt;session_id&gt;
 {{ prog }} --config config.yaml --tenant "Acme Corp" --technician "Alice Colleague-V"
 # Same optional toggles as the dashboard checkboxes (this run only):
-{{ prog }} --config config.yaml --scan-compressed --content-type-check --scan-stego --jurisdiction-hint</code></pre>
+{{ prog }} --config config.yaml --scan-compressed --content-type-check --scan-stego --jurisdiction-hint --progress
+# Disable live progress lines for this run:
+{{ prog }} --config config.yaml --no-progress</code></pre>
   <p><strong>{{ t('help.run_cli_api') }}</strong></p>
   <p class="muted">{{ t('help.run_cli_tls') }}</p>
   <pre><code>{{ prog }} --config config.yaml --web --https-cert-file server.crt --https-key-file server.key

--- a/connectors/snowflake_connector.py
+++ b/connectors/snowflake_connector.py
@@ -78,6 +78,7 @@ class SnowflakeConnector:
         self._inter_query_delay_s = max(
             0.0, float(self.config.get("inter_query_delay_ms", 0) or 0) / 1000.0
         )
+        self._scan_progress = target_config.get("_scan_progress")
 
     def connect(self) -> None:
         if not _SNOWFLAKE_AVAILABLE:
@@ -252,9 +253,19 @@ class SnowflakeConnector:
             except Exception:
                 pass
             tables = self._list_tables()
-            for t in tables:
+            progress = self._scan_progress
+            if progress is not None and getattr(progress, "enabled", False):
+                progress.set_tables_total(len(tables), target_name=target_name)
+            for table_index, t in enumerate(tables, start=1):
                 schema = t["schema"]
                 table = t["table"]
+                table_label = f"{schema}.{table}" if schema else table
+                if progress is not None and getattr(progress, "enabled", False):
+                    progress.advance_table(
+                        table_index,
+                        table_label=table_label,
+                        target_name=target_name,
+                    )
                 columns = self._get_columns(schema, table)
                 for col in columns:
                     if self._inter_query_delay_s > 0:

--- a/connectors/sql_connector.py
+++ b/connectors/sql_connector.py
@@ -347,6 +347,7 @@ class SQLConnector:
         self._inter_query_delay_s = max(
             0.0, float(self.config.get("inter_query_delay_ms", 0) or 0) / 1000.0
         )
+        self._scan_progress = target_config.get("_scan_progress")
 
     def connect(self) -> None:
         ensure_sql_driver_available(self.config.get("driver"))
@@ -642,9 +643,20 @@ class SQLConnector:
             log_connection(audit_name, "database", server_ip or "local")
             engine_name = self.engine.dialect.name if self.engine else "sql"
             self._save_inventory_snapshot(target_name, engine_name)
-            for item in self.discover():
+            discovered = self.discover()
+            progress = self._scan_progress
+            if progress is not None and getattr(progress, "enabled", False):
+                progress.set_tables_total(len(discovered), target_name=target_name)
+            for table_index, item in enumerate(discovered, start=1):
                 schema = item["schema"]
                 table = item["table"]
+                table_label = f"{schema}.{table}" if schema else table
+                if progress is not None and getattr(progress, "enabled", False):
+                    progress.advance_table(
+                        table_index,
+                        table_label=table_label,
+                        target_name=target_name,
+                    )
                 for col in item["columns"]:
                     self._process_one_finding(
                         target_name,

--- a/core/engine.py
+++ b/core/engine.py
@@ -8,6 +8,7 @@ Exposes db_manager, is_running, get_current_findings_count() for API.
 
 import hashlib
 import logging
+import threading
 import time
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, as_completed, wait
 from pathlib import Path
@@ -89,6 +90,7 @@ except ImportError:  # noqa: BLE001
 from core.connector_registry import connector_for_target
 from core.crypto_audit import StrongCryptoSignal, summarize_crypto_from_connection_info
 from core.database import LocalDBManager
+from core.scan_progress import scan_progress_from_config
 from core.sampling import SamplingPolicy
 from core.scanner import DataScanner
 from core.session import new_session_id
@@ -160,6 +162,14 @@ class AuditEngine:
         self._crypto_signals: list[tuple[str, set[StrongCryptoSignal]]] = []
         # Declarative sampling / SRE posture for API ``audit_log`` (refreshed after each scan).
         self._scan_audit_log: dict[str, Any] | None = None
+        self._scan_progress = scan_progress_from_config(config)
+        self._target_seq = 0
+        self._target_seq_lock = threading.Lock()
+
+    def _next_target_index(self) -> int:
+        with self._target_seq_lock:
+            self._target_seq += 1
+            return self._target_seq
 
     def _configure_audit_log_directory(self, *, config_path: str | None) -> None:
         """
@@ -389,6 +399,8 @@ class AuditEngine:
         self._is_running = True
         session_id = self.db_manager.current_session_id
         targets = self.config.get("targets", [])
+        self._target_seq = 0
+        self._scan_progress.start_run(len(targets))
         final_status = "completed"
         try:
             if self._adaptive_rate_limit:
@@ -426,6 +438,16 @@ class AuditEngine:
 
     def _run_target(self, target: dict[str, Any]) -> None:
         """Run one target: resolve connector, instantiate, run()."""
+
+        target_index = self._next_target_index()
+        target_name_for_progress = str(target.get("name") or "unknown")
+        self._scan_progress.begin_target(target_index, target_name_for_progress)
+        try:
+            self._run_target_inner(target)
+        finally:
+            self._scan_progress.end_target(target_name_for_progress)
+
+    def _run_target_inner(self, target: dict[str, Any]) -> None:
         from core.connector_registry import require_connector_allowed
         from core.licensing.errors import FeatureTierBlockedError
 
@@ -455,7 +477,11 @@ class AuditEngine:
         t = target.get("type")
         fs_config = self.config.get("file_scan", {})
         # Inject file_scan into target so connectors (filesystem, shares) see scan_compressed, etc.
-        target_with_fs = {**target, "file_scan": fs_config}
+        target_with_fs = {
+            **target,
+            "file_scan": fs_config,
+            "_scan_progress": self._scan_progress,
+        }
         scan_sqlite_as_db = fs_config.get("scan_sqlite_as_db", True)
         sample_limit = fs_config.get("sample_limit", 5)
         file_sample_max_chars = int(
@@ -501,7 +527,7 @@ class AuditEngine:
                 )
             elif t in ("powerbi", "dataverse", "powerapps"):
                 connector = connector_class(
-                    target,
+                    target_with_fs,
                     self.scanner,
                     self.db_manager,
                     sample_limit=sample_limit,
@@ -514,7 +540,7 @@ class AuditEngine:
                 if issubclass(connector_class, _CONNECTOR_SAMPLING_POLICY_BASES):
                     extra_kw["sampling_policy"] = self._sampling_policy
                 connector = connector_class(
-                    target,
+                    target_with_fs,
                     self.scanner,
                     self.db_manager,
                     sample_limit=sample_limit,

--- a/core/scan_progress.py
+++ b/core/scan_progress.py
@@ -1,0 +1,225 @@
+"""
+Live scan progress lines for long-running audits (#1328).
+
+Emits periodic ``target X/Y · table N/M · ~Z% · ETA ~W min`` to stderr when enabled.
+Table totals come from connector discovery (e.g. SQLAlchemy ``discover()``) — not guessed.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, TextIO
+
+
+@dataclass
+class _TargetTableState:
+    target_index: int
+    target_name: str
+    tables_total: int | None = None
+    tables_done: int = 0
+    table_started_at: float = 0.0
+    first_table_at: float | None = None
+
+
+@dataclass
+class ScanProgressConfig:
+    enabled: bool = True
+    interval_seconds: float = 30.0
+    interval_tables: int = 5
+
+    @classmethod
+    def from_scan_config(cls, scan_cfg: dict[str, Any] | None) -> ScanProgressConfig:
+        raw = scan_cfg if isinstance(scan_cfg, dict) else {}
+        enabled = raw.get("progress", True)
+        if isinstance(enabled, str):
+            enabled = enabled.strip().lower() not in {"0", "false", "no", "off"}
+        try:
+            interval_seconds = float(raw.get("progress_interval_seconds", 30.0))
+        except (TypeError, ValueError):
+            interval_seconds = 30.0
+        try:
+            interval_tables = int(raw.get("progress_interval_tables", 5))
+        except (TypeError, ValueError):
+            interval_tables = 5
+        return cls(
+            enabled=bool(enabled),
+            interval_seconds=max(5.0, interval_seconds),
+            interval_tables=max(1, interval_tables),
+        )
+
+
+class ScanProgress:
+    """Thread-safe progress reporter for multi-target scans."""
+
+    def __init__(
+        self,
+        config: ScanProgressConfig,
+        *,
+        stream: TextIO | None = None,
+        monotonic: Any = time.monotonic,
+    ) -> None:
+        self._cfg = config
+        self._stream = stream if stream is not None else sys.stderr
+        self._monotonic = monotonic
+        self._lock = threading.Lock()
+        self._targets_total = 0
+        self._targets_started = 0
+        self._targets_finished = 0
+        self._run_started = 0.0
+        self._last_emit = 0.0
+        self._by_thread: dict[int, _TargetTableState] = {}
+
+    @property
+    def enabled(self) -> bool:
+        return self._cfg.enabled
+
+    def start_run(self, targets_total: int) -> None:
+        if not self.enabled:
+            return
+        with self._lock:
+            self._targets_total = max(0, int(targets_total))
+            self._targets_started = 0
+            self._targets_finished = 0
+            self._run_started = self._monotonic()
+            self._last_emit = 0.0
+            self._by_thread.clear()
+
+    def begin_target(self, target_index: int, target_name: str) -> None:
+        if not self.enabled:
+            return
+        tid = threading.get_ident()
+        with self._lock:
+            self._targets_started = max(self._targets_started, target_index)
+            self._by_thread[tid] = _TargetTableState(
+                target_index=target_index,
+                target_name=target_name,
+                table_started_at=self._monotonic(),
+            )
+        self._maybe_emit(force=True)
+
+    def end_target(self, target_name: str) -> None:
+        if not self.enabled:
+            return
+        tid = threading.get_ident()
+        with self._lock:
+            self._targets_finished += 1
+            self._by_thread.pop(tid, None)
+        self._maybe_emit(force=True)
+
+    def set_tables_total(self, total: int, *, target_name: str | None = None) -> None:
+        if not self.enabled:
+            return
+        tid = threading.get_ident()
+        with self._lock:
+            state = self._by_thread.get(tid)
+            if state is None:
+                return
+            if target_name and state.target_name != target_name:
+                return
+            state.tables_total = max(0, int(total))
+
+    def advance_table(
+        self,
+        table_index: int,
+        *,
+        table_label: str = "",
+        target_name: str | None = None,
+    ) -> None:
+        """Call once per table (after discovery). ``table_index`` is 1-based."""
+        if not self.enabled:
+            return
+        now = self._monotonic()
+        tid = threading.get_ident()
+        with self._lock:
+            state = self._by_thread.get(tid)
+            if state is None:
+                return
+            if target_name and state.target_name != target_name:
+                return
+            state.tables_done = max(state.tables_done, int(table_index))
+            state.table_started_at = now
+            if state.first_table_at is None:
+                state.first_table_at = now
+        force = False
+        if table_index == 1:
+            force = True
+        elif (
+            self._cfg.interval_tables > 0
+            and table_index % self._cfg.interval_tables == 0
+        ):
+            force = True
+        self._maybe_emit(force=force, table_label=table_label)
+
+    def _maybe_emit(self, *, force: bool = False, table_label: str = "") -> None:
+        if not self.enabled:
+            return
+        now = self._monotonic()
+        with self._lock:
+            if not force and (now - self._last_emit) < self._cfg.interval_seconds:
+                return
+            line = self._format_line(table_label=table_label, now=now)
+            self._last_emit = now
+        if line:
+            self._stream.write(line + "\n")
+            self._stream.flush()
+
+    def _format_line(self, *, table_label: str, now: float) -> str:
+        tid = threading.get_ident()
+        state = self._by_thread.get(tid)
+        if state is None and self._by_thread:
+            state = next(iter(self._by_thread.values()))
+        if state is None:
+            done = self._targets_finished
+            total = self._targets_total
+            return f"[data-boar] scan progress · target {done}/{total}"
+
+        t_idx = state.target_index
+        t_total = self._targets_total
+        name = state.target_name
+        n = state.tables_done
+        m = state.tables_total
+
+        parts = [f"[data-boar] scan progress · target {t_idx}/{t_total} ({name})"]
+        if m is not None and m > 0:
+            pct = min(100, int(round(100.0 * n / m)))
+            parts.append(f"table {n}/{m}")
+            if table_label:
+                parts[-1] += f" ({table_label})"
+            parts.append(f"~{pct}%")
+            eta = self._eta_minutes(state, now=now)
+            if eta is not None:
+                parts.append(f"ETA ~{eta:.0f} min")
+            else:
+                parts.append("ETA n/a")
+        else:
+            parts.append(f"table {n}")
+            if table_label:
+                parts.append(f"({table_label})")
+            parts.append("total tables pending discovery")
+        return " · ".join(parts)
+
+    def _eta_minutes(self, state: _TargetTableState, *, now: float) -> float | None:
+        if state.tables_total is None or state.tables_total <= 0:
+            return None
+        if state.tables_done < 2 or state.first_table_at is None:
+            return None
+        elapsed = now - state.first_table_at
+        if elapsed <= 0:
+            return None
+        per_table = elapsed / max(1, state.tables_done - 1)
+        remaining_tables = max(0, state.tables_total - state.tables_done)
+        return (remaining_tables * per_table) / 60.0
+
+
+_NOOP = ScanProgress(ScanProgressConfig(enabled=False))
+
+
+def scan_progress_from_config(config: dict[str, Any]) -> ScanProgress:
+    scan_cfg = config.get("scan") if isinstance(config.get("scan"), dict) else {}
+    cfg = ScanProgressConfig.from_scan_config(scan_cfg)
+    if not cfg.enabled:
+        return _NOOP
+    return ScanProgress(cfg)

--- a/docs/TECH_GUIDE.md
+++ b/docs/TECH_GUIDE.md
@@ -255,6 +255,10 @@ rate_limit:
 
 **Adaptive rate limiting (ARL):** optional `scan.adaptive_rate_limit: true` tunes effective `max_workers` from per-target latency in the production engine path (`core/engine.py`). Default is **off** (fixed pool). See [USAGE.md](USAGE.md) § *Adaptive rate limiting (ARL)* for mechanics, defaults, and interaction with licensing worker caps (#551).
 
+**Live scan progress (#1328):** when `scan.progress` is true (default), stderr shows `target X/Y · table N/M · ~Z% · ETA` during long SQL scans. Table totals come from connector discovery after `discover()` — not guessed. CLI: `--progress` / `--no-progress`. See [USAGE.md](USAGE.md) § *Live scan progress*.
+
+**Remote DB latency:** cross-region scans (e.g. Brazil → `us-east-1` RDS) are often **RTT-bound** — low server CPU with long wall-clock usually means network wait, not Python GIL. Co-locate scanner and DB when possible. `scan.max_workers` parallelizes **targets only** today ([#1322](https://github.com/DataBoar/data-boar/issues/1322) tracks per-table/column parallelism for a future milestone). See [USAGE.md](USAGE.md) § *Remote database latency* and [TROUBLESHOOTING_CONNECTIVITY.md](TROUBLESHOOTING_CONNECTIVITY.md).
+
 When `enabled` is true, API endpoints that start scans (`POST /scan`, `/start`, `/scan_database`) may respond with **HTTP 429** and a JSON payload describing the reason (e.g. too many running scans or minimum interval not elapsed). The CLI only prints warnings using the same logic, so existing scripts keep working. See [USAGE.md](USAGE.md) and [data_boar.5](data_boar.5) for full configuration details and examples.
 
 ## Run

--- a/docs/TECH_GUIDE.pt_BR.md
+++ b/docs/TECH_GUIDE.pt_BR.md
@@ -255,6 +255,10 @@ rate_limit:
 
 **Limitação de taxa adaptativa (ARL):** `scan.adaptive_rate_limit: true` (padrão **false**) ajusta workers efetivos a partir da latência por alvo no engine de produção. Veja [USAGE.pt_BR.md](USAGE.pt_BR.md) § *Limitação de taxa adaptativa (ARL)* e interação com o teto de licença (#551).
 
+**Progresso ao vivo (#1328):** com `scan.progress` true (padrão), stderr mostra `target X/Y · table N/M · ~Z% · ETA` em scans SQL longos. Totais vêm da discovery do conector — não são chutados. CLI: `--progress` / `--no-progress`. Veja [USAGE.pt_BR.md](USAGE.pt_BR.md) § *Progresso ao vivo do scan*.
+
+**Latência de banco remoto:** scans cross-region (ex.: Brasil → RDS `us-east-1`) costumam ser limitados por **RTT** — CPU baixa no servidor com scan longo indica espera de rede, não GIL. Co-localize quando possível. `scan.max_workers` paraleliza só **targets** hoje ([#1322](https://github.com/DataBoar/data-boar/issues/1322) — milestone 1.8.x, trabalho futuro). Veja [USAGE.pt_BR.md](USAGE.pt_BR.md) e [TROUBLESHOOTING_CONNECTIVITY.pt_BR.md](TROUBLESHOOTING_CONNECTIVITY.pt_BR.md).
+
 Quando `enabled` é true, os endpoints da API que iniciam varreduras (`POST /scan`, `/start`, `/scan_database`) podem responder com **HTTP 429** e um payload JSON descrevendo o motivo (ex.: muitas varreduras em execução ou intervalo mínimo não decorrido). A CLI apenas imprime avisos com a mesma lógica, então scripts existentes continuam funcionando. Veja [USAGE.md](USAGE.md) e [data_boar.5](data_boar.5) para detalhes e exemplos completos de configuração.
 
 ## Executar

--- a/docs/TROUBLESHOOTING_CONNECTIVITY.md
+++ b/docs/TROUBLESHOOTING_CONNECTIVITY.md
@@ -54,6 +54,27 @@ This document helps you diagnose and fix **unreachable**, **timeout**, and **per
 - Re-run during off-peak or from a host/region closer to the target.
 - Check the audit log for which operation timed out (e.g. connect vs read); that tells you whether to focus on network or target performance.
 
+### 3.3 Remote database latency (RTT-bound scans)
+
+**Symptoms:** Scan runs for tens of minutes; CloudWatch (or equivalent) shows **low CPU** and **low ReadLatency** on the database, while the operator workstation is far away (different region or continent).
+
+**Cause:** Each column sample in SQL connectors issues at least one round trip. Wall-clock time scales with **(number of queries × RTT)**, not link bandwidth. The server can be idle while the client waits on the network.
+
+**Diagnosis checklist:**
+
+1. **Server not overloaded:** CPU and read latency metrics stay low — this is **not** “the DB cannot keep up” and **not** Python GIL on the scanner host for this pattern.
+2. **Client wait:** Threads blocked on I/O; `ss -tn dst :<db-port>` shows open connections during the scan.
+3. **High RTT:** Measure TCP RTT between scanner host and DB endpoint (same path the scan uses).
+
+**Mitigations (in order):**
+
+1. **Co-locate** — run Data Boar in the **same VPC/region** as the database (jump box, CI runner, lab VM). This removes most cross-region RTT.
+2. **Reduce scope** — fewer schemas/tables, tighter `sample_limit`, or dedicated audit replica in-region.
+3. **`scan.max_workers`** — increases **parallel targets only**. It does **not** parallelize tables inside one PostgreSQL/RDS target today. Future per-table parallelism is tracked in [#1322](https://github.com/DataBoar/data-boar/issues/1322) (1.8.x milestone; not scheduled for the current release line).
+4. **ARL** — `scan.adaptive_rate_limit: true` tunes target concurrency from latency; it does not remove RTT per query.
+
+**Live progress:** enable `scan.progress` (default) or `--progress` so stderr shows `target X/Y · table N/M` without manual log archaeology — see [USAGE.md](USAGE.md) § *Live scan progress*.
+
 ---
 
 ## 4. Permission denied

--- a/docs/TROUBLESHOOTING_CONNECTIVITY.pt_BR.md
+++ b/docs/TROUBLESHOOTING_CONNECTIVITY.pt_BR.md
@@ -48,6 +48,16 @@ Corrija DNS (use IP ou servidor DNS correto); abra firewall para a porta necess�
 
 No config, defina `timeout` maior para o alvo que falha (veja [USAGE.pt_BR.md](USAGE.pt_BR.md)). Reexecute em horário de menor uso ou de um host/região mais próxima do alvo.
 
+### 3.3 Latência de banco remoto (scan limitado por RTT)
+
+**Sintomas:** varredura de dezenas de minutos; CloudWatch (ou equivalente) com **CPU baixa** e **ReadLatency** ociosa no banco, enquanto o operador está longe (outra região).
+
+**Causa:** cada amostragem de coluna paga pelo menos um round trip. O tempo escala com **(consultas × RTT)**, não com banda do link.
+
+**Diagnóstico:** CPU/latência de leitura baixas no servidor **não** indicam GIL nem servidor sobrecarregado neste padrão — verifique RTT e conexões no cliente (`ss -tn dst :<porta>`).
+
+**Mitigações:** (1) **co-localizar** scanner e banco na mesma VPC/região; (2) reduzir escopo/amostragem; (3) `scan.max_workers` só paraleliza **targets**, não tabelas dentro de um único RDS — comportamento atual; [#1322](https://github.com/DataBoar/data-boar/issues/1322) rastreia paralelismo por tabela/coluna (milestone 1.8.x, sem promessa de data). **Progresso ao vivo:** `scan.progress` ou `--progress` — veja [USAGE.pt_BR.md](USAGE.pt_BR.md) § *Progresso ao vivo do scan*.
+
 ---
 
 ## 4. Permission denied

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -674,6 +674,40 @@ scan:
 
 See also [TECH_GUIDE.md](TECH_GUIDE.md) (detection / performance) and [TROUBLESHOOTING_CONNECTIVITY.md](TROUBLESHOOTING_CONNECTIVITY.md) (timeouts and load).
 
+### Live scan progress (stderr, #1328)
+
+Long database scans can run for tens of minutes. Data Boar emits **periodic progress lines** to **stderr** (and the audit log when configured) so operators do not need to reverse-engineer table order from logs.
+
+**Format (example):** `target 2/5 (prod-rds) · table 120/450 (public.users) · ~27% · ETA ~12 min`
+
+- **Target X/Y** — position among configured `targets` in this session.
+- **Table N/M** — after SQL discovery lists tables for the current target (`SQLConnector.discover()` / Snowflake `_list_tables()`). **M is known only after discovery** for that target — not from `tables_override_count` in audit logs.
+- **~Z%** and **ETA** — linear estimate from elapsed time per table **after at least two tables** on that target. Omitted when the table total is not yet known (non-SQL targets show `table N` without percent/ETA).
+
+**Enable / tune:**
+
+| Knob | Default | Meaning |
+| ---- | ------- | ------- |
+| `scan.progress` | `true` | Master switch |
+| `scan.progress_interval_seconds` | `30` | Minimum seconds between lines |
+| `scan.progress_interval_tables` | `5` | Also emit every N tables |
+| `--progress` / `--no-progress` | (config) | CLI override for one run |
+
+Progress is **observability only** — it does not change findings, sampling, or reports.
+
+### Remote database latency (cross-region)
+
+When the scanner and the database are in **different regions** (e.g. Brazil workstation → `us-east-1` RDS), wall-clock time is often dominated by **network round-trip time (RTT)**, not CPU on the server.
+
+- **Cost model:** Each column sample pays at least **one RTT** (often more). Total time scales roughly with **(queries × RTT)**, not link throughput.
+- **Symptoms:** CloudWatch **CPUUtilization** low (e.g. ~7%), **ReadLatency** near idle (~1 ms on the server), but the scan still takes tens of minutes — the client spends time **waiting on the network**.
+- **Not GIL / not “server overloaded”:** Python GIL does not explain multi-minute SQL scans with idle server CPU; check client-side wait and RTT first.
+- **Recommendation #1:** **Co-locate** the scanner with the database — same **VPC/region** as RDS (jump host, CI runner, or lab VM in that region).
+- **`scan.max_workers` caveat (current behaviour):** Database parallelism is **per target**, not per table or column within one database. `max_workers: 8` helps only when you have **many targets**; it does **not** speed up a single large RDS with one target. Finer-grained DB parallelism is tracked as future work ([#1322](https://github.com/DataBoar/data-boar/issues/1322) — 1.8.x milestone; not promised for the current release line).
+- **How to measure:** Client concurrency `ss -tn dst :<port>`; server **DatabaseConnections**, **ReadLatency**, **CPUUtilization** (CloudWatch or equivalent); baseline **TCP RTT** (`ping` / `mtr` — interpret with care through firewalls).
+
+See [TROUBLESHOOTING_CONNECTIVITY.md](TROUBLESHOOTING_CONNECTIVITY.md) § *Remote database latency* and [TECH_GUIDE.md](TECH_GUIDE.md).
+
 ### API and security (CSP, headers)
 
 The web API and dashboard send **security headers** on every response (see [SECURITY.md](../SECURITY.md)): X-Content-Type-Options, X-Frame-Options, **Content-Security-Policy (CSP)**, Referrer-Policy, Permissions-Policy, and HSTS when the request is considered HTTPS.

--- a/docs/USAGE.pt_BR.md
+++ b/docs/USAGE.pt_BR.md
@@ -615,6 +615,33 @@ scan:
 
 Veja também [TECH_GUIDE.pt_BR.md](TECH_GUIDE.pt_BR.md) e [TROUBLESHOOTING_CONNECTIVITY.pt_BR.md](TROUBLESHOOTING_CONNECTIVITY.pt_BR.md).
 
+### Progresso ao vivo do scan (stderr, #1328)
+
+Varreduras longas em banco podem levar dezenas de minutos. O Data Boar emite **linhas periódicas de progresso** em **stderr** (e no audit log quando configurado) para o operador não precisar estimar ETA cruzando ordem alfabética de tabelas com o SQLite.
+
+**Formato (exemplo):** `target 2/5 (prod-rds) · table 120/450 (public.users) · ~27% · ETA ~12 min`
+
+- **Target X/Y** — posição entre os `targets` desta sessão.
+- **Table N/M** — após a descoberta SQL listar as tabelas do alvo atual (`SQLConnector.discover()` / Snowflake `_list_tables()`). **M só é conhecido depois da discovery** — não confundir com `tables_override_count` nos logs de auditoria.
+- **~Z%** e **ETA** — estimativa linear após **pelo menos duas tabelas** no mesmo alvo. Sem total conhecido (alvos não-SQL), mostra `table N` sem percentual/ETA.
+
+**Ativar / ajustar:** `scan.progress` (padrão `true`), `scan.progress_interval_seconds` (30), `scan.progress_interval_tables` (5), ou `--progress` / `--no-progress` na CLI.
+
+Somente **observabilidade** — não altera achados, amostragem nem relatório.
+
+### Latência de banco remoto (cross-region)
+
+Com scanner e banco em **regiões diferentes** (ex.: estação no Brasil → RDS `us-east-1`), o tempo costuma ser dominado pelo **RTT de rede**, não pela CPU do servidor.
+
+- **Modelo de custo:** cada amostragem de coluna paga pelo menos **1 RTT**; tempo ≈ **(consultas × RTT)**, não throughput do link.
+- **Sintomas:** **CPUUtilization** baixa no CloudWatch, **ReadLatency** ~ociosa no servidor, scan ainda lento — o cliente fica em **espera de rede**.
+- **Não é GIL / servidor sobrecarregado:** com CPU ociosa no RDS, investigue RTT e filas no cliente primeiro.
+- **Recomendação #1:** **Co-localizar** scanner e banco — mesma **VPC/região** (jump host, runner de CI ou VM de lab na região).
+- **Caveat `scan.max_workers` (comportamento atual):** paralelismo de DB é **por target**, não por tabela/coluna. `max_workers` alto só ajuda com **vários targets**; não acelera um único RDS grande. Paralelismo fino dentro do DB está em [#1322](https://github.com/DataBoar/data-boar/issues/1322) (milestone 1.8.x — trabalho futuro, sem promessa de data).
+- **Como medir:** `ss -tn dst :<porta>` no cliente; **DatabaseConnections**, **ReadLatency**, **CPUUtilization** no servidor; RTT TCP de referência.
+
+Veja [TROUBLESHOOTING_CONNECTIVITY.pt_BR.md](TROUBLESHOOTING_CONNECTIVITY.pt_BR.md) § *Latência de banco remoto* e [TECH_GUIDE.pt_BR.md](TECH_GUIDE.pt_BR.md).
+
 ### API e segurança (CSP, cabeçalhos)
 
 A API web e o dashboard enviam **cabeçalhos de segurança** em toda resposta (veja [SECURITY.md](../SECURITY.md)): X-Content-Type-Options, X-Frame-Options, **Content-Security-Policy (CSP)**, Referrer-Policy, Permissions-Policy e HSTS quando a requisição é considerada HTTPS.

--- a/docs/data_boar.1
+++ b/docs/data_boar.1
@@ -345,6 +345,17 @@ Not a legal conclusion; also configurable under
 .BR report.jurisdiction_hints .
 Stored on the session when set via CLI or API.
 .
+.TP
+.B \-\-progress
+Emit periodic scan progress to stderr (target X/Y, table N/M, percent, ETA when known).
+Default follows
+.B scan.progress
+in config (on unless disabled).
+.
+.TP
+.B \-\-no\-progress
+Disable live scan progress lines for this run.
+.
 .SH CONFIGURATION
 The main config file (YAML or JSON) defines:
 .IP \(bu 2
@@ -374,7 +385,14 @@ optionally require_api_key, api_key or api_key_from_env for API key protection (
 .IR audit_results.db ).
 .IP \(bu 2
 .B scan
-\- max_workers for parallelism.
+\- max_workers for parallelism;
+.B adaptive_rate_limit
+(opt\-in; default false) tunes effective workers from per\-target latency;
+.B target_latency_ms
+(default 200) is the ARL feedback target in milliseconds when ARL is enabled;
+.B progress
+(default true) enables periodic stderr progress lines (override with
+.BR \-\-progress / \-\-no\-progress ).
 .IP \(bu 2
 Optional:
 .B rate_limit

--- a/main.py
+++ b/main.py
@@ -385,6 +385,7 @@ def main() -> None:
             "\n"
             "  # One-shot with archive scan + content-type detection (this run only)\n"
             f"  {prog} --config config.yaml --scan-compressed --content-type-check\n"
+            f"  {prog} --config config.yaml --progress\n"
             "\n"
             "  # Validate config only (loader checks; no scan or API startup)\n"
             f"  {prog} --config config.yaml --validate-config\n"
@@ -654,6 +655,23 @@ def main() -> None:
             "for this process and stores the opt-in on the session."
         ),
     )
+    progress_group = parser.add_mutually_exclusive_group()
+    progress_group.add_argument(
+        "--progress",
+        action="store_true",
+        dest="scan_progress",
+        default=None,
+        help=(
+            "Emit periodic scan progress to stderr (target X/Y, table N/M, percent, ETA). "
+            "Default when omitted: scan.progress in config (true unless disabled)."
+        ),
+    )
+    progress_group.add_argument(
+        "--no-progress",
+        action="store_false",
+        dest="scan_progress",
+        help="Disable live scan progress lines for this run.",
+    )
     args = parser.parse_args()
 
     if args.version:
@@ -811,6 +829,8 @@ def main() -> None:
     if args.jurisdiction_hint:
         config.setdefault("report", {}).setdefault("jurisdiction_hints", {})
         config["report"]["jurisdiction_hints"]["enabled"] = True
+    if getattr(args, "scan_progress", None) is not None:
+        config.setdefault("scan", {})["progress"] = bool(args.scan_progress)
 
     # #856 (Phase E): integrity anchor first-run validation / startup re-verify.
     # Runs in ANY licensing mode (including open); fail-soft (state=unknown).

--- a/tests/operator_help_sync_manifest.py
+++ b/tests/operator_help_sync_manifest.py
@@ -44,6 +44,7 @@ _MAN_EXPORT_AUDIT = r"\-\-export\-audit\-trail"
 _MAN_TENANT = r"\-\-tenant"
 _MAN_TECH = r"\-\-technician"
 _MAN_JURISDICTION_HINT = r"\-\-jurisdiction\-hint"
+_MAN_SCAN_PROGRESS = r"\-\-progress"
 _MAN_HTTPS_CERT = r"\-\-https\-cert\-file"
 _MAN_HTTPS_KEY = r"\-\-https\-key\-file"
 _MAN_ALLOW_INSECURE_HTTP = r"\-\-allow\-insecure\-http"
@@ -164,6 +165,18 @@ OPERATOR_HELP_MARKERS: tuple[OperatorHelpMarker, ...] = (
         "--jurisdiction-hint",
         "--jurisdiction-hint",
         _MAN_JURISDICTION_HINT,
+    ),
+    OperatorHelpMarker(
+        "scan_progress",
+        "--progress",
+        "--progress",
+        _MAN_SCAN_PROGRESS,
+    ),
+    OperatorHelpMarker(
+        "scan_no_progress",
+        "--no-progress",
+        "--no-progress",
+        None,
     ),
     # Dev canonical invocation is python main.py; installed entry point is data-boar.
     # Man pages document installed usage, so man1 is intentionally skipped here.

--- a/tests/test_scan_progress.py
+++ b/tests/test_scan_progress.py
@@ -1,0 +1,128 @@
+"""Tests for live scan progress reporting (#1328)."""
+
+from __future__ import annotations
+
+import io
+from typing import Any
+
+from core.scan_progress import (
+    ScanProgress,
+    ScanProgressConfig,
+    scan_progress_from_config,
+)
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.t = 0.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, seconds: float) -> None:
+        self.t += seconds
+
+
+def test_scan_progress_disabled_emits_nothing() -> None:
+    buf = io.StringIO()
+    prog = ScanProgress(ScanProgressConfig(enabled=False), stream=buf)
+    prog.start_run(2)
+    prog.begin_target(1, "db1")
+    prog.set_tables_total(10)
+    prog.advance_table(1, table_label="public.users")
+    assert buf.getvalue() == ""
+
+
+def test_scan_progress_table_line_includes_target_and_percent() -> None:
+    clock = _FakeClock()
+    buf = io.StringIO()
+    prog = ScanProgress(
+        ScanProgressConfig(enabled=True, interval_seconds=999, interval_tables=1),
+        stream=buf,
+        monotonic=clock,
+    )
+    prog.start_run(1)
+    prog.begin_target(1, "prod-rds")
+    prog.set_tables_total(4)
+    prog.advance_table(1, table_label="public.a")
+    clock.advance(60)
+    prog.advance_table(2, table_label="public.b")
+    out = buf.getvalue()
+    assert "target 1/1 (prod-rds)" in out
+    assert "table 2/4" in out
+    assert "~50%" in out
+    assert "ETA" in out
+
+
+def test_scan_progress_without_table_total_omits_percent_and_eta() -> None:
+    buf = io.StringIO()
+    prog = ScanProgress(
+        ScanProgressConfig(enabled=True, interval_seconds=0, interval_tables=1),
+        stream=buf,
+        monotonic=_FakeClock(),
+    )
+    prog.start_run(1)
+    prog.begin_target(1, "fs1")
+    prog.advance_table(3, table_label="docs/file.txt")
+    out = buf.getvalue()
+    assert "table 3" in out
+    assert "pending discovery" in out
+    assert "~" not in out.split("pending")[0] or "~" not in out  # no percent line
+
+
+def test_scan_progress_from_config_defaults_enabled() -> None:
+    prog = scan_progress_from_config({"scan": {}})
+    assert prog.enabled is True
+
+
+def test_scan_progress_from_config_respects_false() -> None:
+    prog = scan_progress_from_config({"scan": {"progress": False}})
+    assert prog.enabled is False
+
+
+def test_sql_connector_calls_discover_once(monkeypatch: Any) -> None:
+    """Regression: table total for progress uses discover() list length, not per-iteration rediscovery."""
+    from connectors.sql_connector import SQLConnector
+
+    calls = {"discover": 0}
+
+    class _FakeEngine:
+        dialect = type("D", (), {"name": "postgresql"})()
+
+    def fake_discover(self: SQLConnector) -> list[dict[str, Any]]:
+        calls["discover"] += 1
+        return [
+            {
+                "schema": "public",
+                "table": "t1",
+                "columns": [{"name": "c1", "type": "text"}],
+            }
+        ]
+
+    monkeypatch.setattr(SQLConnector, "discover", fake_discover)
+    monkeypatch.setattr(SQLConnector, "connect", lambda self: None)
+    monkeypatch.setattr(SQLConnector, "close", lambda self: None)
+    monkeypatch.setattr(SQLConnector, "_save_inventory_snapshot", lambda *a, **k: None)
+    monkeypatch.setattr(
+        SQLConnector,
+        "_process_one_finding",
+        lambda *a, **k: None,
+    )
+
+    buf = io.StringIO()
+    progress = ScanProgress(
+        ScanProgressConfig(enabled=True, interval_seconds=0, interval_tables=1),
+        stream=buf,
+    )
+    progress.start_run(1)
+    progress.begin_target(1, "lab-db")
+
+    connector = SQLConnector(
+        {"name": "lab-db", "type": "postgresql", "_scan_progress": progress},
+        scanner=object(),
+        db_manager=object(),
+    )
+    connector.engine = _FakeEngine()
+    connector.run()
+    assert calls["discover"] == 1
+    assert "table 1/1" in buf.getvalue()


### PR DESCRIPTION
## Summary

Closes #1328
Closes #1323

### #1328 — Live scan progress (stderr)

- New `core/scan_progress.py`: thread-safe reporter emitting lines like `target X/Y · tabela N/M · ~Z% · ETA ~W min` on stderr when interval (default 30s or every 5 tables) elapses.
- Wired through `AuditEngine` (`core/engine.py`) and SQL/Snowflake connectors after `discover()` / `_list_tables()` sets `tables_total`.
- **ETA honesty:** percent and ETA appear only when table total is known from discovery (cheap, one list per target). Without a total, the line shows target + table index only — no invented ETA.
- CLI: `--progress` / `--no-progress`; config: `scan.progress`, `scan.progress_interval_seconds`, `scan.progress_interval_tables`.
- **Acceptance:** progress is logging-only — no change to findings, reports, or scan logic. Unit tests in `tests/test_scan_progress.py` simulate timing/tables (no 53-minute scan).
- Operator surfaces: `docs/data_boar.1`, `api/templates/help.html`, help sync manifest.

### #1323 — Remote database latency (bilingual docs)

- **USAGE** + **TECH_GUIDE** + **TROUBLESHOOTING_CONNECTIVITY** (EN + pt_BR): RTT dominates cross-region scans; diagnosis (low CPU + IO-wait + high RTT); co-locate scanner with DB as primary mitigation; measurement (`ss`, CloudWatch, TCP RTT).
- **`max_workers` caveat (current behaviour):** parallelism is **per-target**, not per-table. Documented as today’s behaviour with link to #1322 (1.8.x future work) — no “em breve” / “will be fixed soon”.

### Bonus — man page consistency

- `docs/data_boar.1`: added `scan.adaptive_rate_limit` and `scan.target_latency_ms` (ARL keys missing after #1344).

### PLAN_*.md

Not added: both issues are additive (progress logging + operator docs); no architecture or milestone table change required.

## Test plan

- [x] `./scripts/check-all.sh --enforced` green on branch (post-merge with `origin/main`)
- [x] `tests/test_scan_progress.py` — format, ETA when total known, no percent/ETA without total, disabled mode, `discover()` called once regression
- [x] `tests/test_operator_help_sync.py` — `--progress` / `--no-progress` in CLI, web help, man1