### PR TITLE
chore(release): 1.7.4.post9 PyPI publish counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,30 @@ Human-readable summary of user-facing changes. **Detailed release notes:** [docs
 
 ---
 
-## 1.7.4.post8 (pending PyPI dispatch)
+## 1.7.4.post9 (pending PyPI dispatch)
+
+> Post-release on the **`1.7.4`** public line. **`[project] version = 1.7.4.post9`** and **`[tool.databoar] maturity_build = 257`** (`N=7` discrete fixes since post8 baseline `8527b0a4`, ADR-0073). **PyPI-only** — no Git tag, no GitHub Release, no container.
+>
+> **Milestone:** closes **11 issues** across **7 PRs** ([#1339](https://github.com/DataBoar/data-boar/pull/1339), [#1341](https://github.com/DataBoar/data-boar/pull/1341), [#1343](https://github.com/DataBoar/data-boar/pull/1343), [#1344](https://github.com/DataBoar/data-boar/pull/1344), [#1345](https://github.com/DataBoar/data-boar/pull/1345), [#1346](https://github.com/DataBoar/data-boar/pull/1346), [#1347](https://github.com/DataBoar/data-boar/pull/1347)) — post9 field-train bundle after post8.
+
+### Fixed / hardened (post9)
+
+- **CLI output paths:** pre-flight writable checks for report/output dirs; `--regenerate-report` rebuilds from SQLite without a full rescan ([#1324](https://github.com/DataBoar/data-boar/issues/1324), [#1325](https://github.com/DataBoar/data-boar/issues/1325), [#1339](https://github.com/DataBoar/data-boar/pull/1339)).
+- **SQL sampling:** deduplicate column values before applying `sample_limit` cap — fewer redundant round-trips ([#1337](https://github.com/DataBoar/data-boar/issues/1337), [#1343](https://github.com/DataBoar/data-boar/pull/1343)).
+- **Scan engine:** optional adaptive rate limiting (`BoarThrottler`) wired into the production `ThreadPoolExecutor` target loop ([#1320](https://github.com/DataBoar/data-boar/issues/1320), [#1344](https://github.com/DataBoar/data-boar/pull/1344)).
+- **Learned patterns:** audit/migration anti-generic blocklist so field column patterns are not over-broad ([#1327](https://github.com/DataBoar/data-boar/issues/1327), [#1345](https://github.com/DataBoar/data-boar/pull/1345)).
+- **Report export:** unified session export CLI with per-format wrappers (JSON/CSV/XLSX/HTML/PDF/DOCX) ([#1326](https://github.com/DataBoar/data-boar/issues/1326), [#1346](https://github.com/DataBoar/data-boar/pull/1346)).
+- **Live progress:** periodic stderr progress lines (target/table/percent/ETA when discovery yields totals) ([#1328](https://github.com/DataBoar/data-boar/issues/1328), [#1347](https://github.com/DataBoar/data-boar/pull/1347)); remote DB latency operator docs ([#1323](https://github.com/DataBoar/data-boar/issues/1323), same PR).
+- **Dependencies:** `pypdf` `6.13.3` → `6.14.2` — four DoS CVEs reachable via filesystem PDF scan path (`connectors/filesystem_connector.py` `PdfReader` on target files): CVE-2026-59935, CVE-2026-59936, CVE-2026-59937, CVE-2026-59938 ([#1336](https://github.com/DataBoar/data-boar/pull/1336)).
+
+### Notes (post9)
+
+- **Not in `N` (wheel unchanged):** benchmark safe-axis docs/tests ([#1338](https://github.com/DataBoar/data-boar/pull/1341) / `19e268c7`); PCI/saúde/LGPD compliance **samples** under `docs/compliance-samples/` + `security/` (`a9678874` — operator: samples count as docs); report `resolve_output_dir` regression test only (`1baa76b5`); `.gitignore` for local benchmark artefact (`2979c99b`); distroless base image bump (`55c6b75d` — Dockerfile; postN is PyPI-only).
+- Full `N=7` fix set and `postN` ↔ `maturity_build` map: [docs/releases/1.7.4.post9.md](docs/releases/1.7.4.post9.md).
+
+---
+
+## 1.7.4.post8 (published PyPI **2026-07-23 13:52:06 UTC**)
 
 > Post-release on the **`1.7.4`** public line. **`[project] version = 1.7.4.post8`** and **`[tool.databoar] maturity_build = 250`** (`N=5` `fix(` commits since post7 baseline `b5054d55`, ADR-0073). **PyPI-only** — no Git tag, no GitHub Release, no container.
 >

--- a/core/about.py
+++ b/core/about.py
@@ -11,7 +11,7 @@ def _package_version() -> str:
 
         return version("data-boar")
     except Exception:
-        return "1.7.4.post8"
+        return "1.7.4.post9"
 
 
 def get_http_user_agent() -> str:

--- a/docs/releases/1.7.4.post9.md
+++ b/docs/releases/1.7.4.post9.md
@@ -1,16 +1,16 @@
-# Release 1.7.4.post8 (PyPI publish counter)
+# Release 1.7.4.post9 (PyPI publish counter)
 
-**Status:** Published on PyPI (**2026-07-23 13:52:06 UTC**). Operator **`publish-pypi`** `workflow_dispatch`: build → TestPyPI → PyPI.
+**Status:** Pending PyPI upload after merge (operator **`publish-pypi`** `workflow_dispatch`: build → TestPyPI → PyPI).
 
 **Public line (marketing):** **`1.7.4`** — README, man pages, stakeholder copy unchanged.
 
-**Build / PyPI / About:** **`1.7.4.post8`** — PEP 440 post-release (publish counter per [ADR-0073](../adr/ADR-0073-version-scheme-octet-maturity-and-roadmap.md) § *PyPI dual counters*).
+**Build / PyPI / About:** **`1.7.4.post9`** — PEP 440 post-release (publish counter per [ADR-0073](../adr/ADR-0073-version-scheme-octet-maturity-and-roadmap.md) § *PyPI dual counters*).
 
 **Not in this drop:** Git tag · GitHub Release · Docker / container image (PyPI-only `.postN`).
 
-**Field context:** #1297 and #1298 were **field-caught on-site** during the same customer engagement (2026-07-21) — native MSSQL connector first execution and integrity anchor false-negative. #1315 was **field-caught** on a Podman Oracle lab (2026-07-23) when discovery hit `AUDSYS` permission errors.
+**Milestone context:** Post9 closes a **post8 field-train bundle** — **11 issues** landed in **7 PRs** ([#1339](https://github.com/DataBoar/data-boar/pull/1339), [#1341](https://github.com/DataBoar/data-boar/pull/1341), [#1343](https://github.com/DataBoar/data-boar/pull/1343), [#1344](https://github.com/DataBoar/data-boar/pull/1344), [#1345](https://github.com/DataBoar/data-boar/pull/1345), [#1346](https://github.com/DataBoar/data-boar/pull/1346), [#1347](https://github.com/DataBoar/data-boar/pull/1347)).
 
-**Honesty note:** An early post8 release-prep commit (`1c8f6e5b`) documented only `N=2` / `maturity_build=247` (#1297–#1298). **`main` accumulated three more `fix(` commits** before PyPI upload; this file and `maturity_build=250` reflect the full fix set at publish time.
+**Honesty note:** Five commits on `main` after post8 PyPI upload **do not** change the installable wheel (`docs/`, `tests/`, `security/` samples, `.gitignore`, `Dockerfile`) — see appendix *Not counted toward `N`* and [CHANGELOG.md](../../CHANGELOG.md) post9 notes.
 
 ---
 
@@ -70,46 +70,56 @@ Per ADR-0073: **`postN`** counts **PyPI uploads**; **`maturity_build`** counts *
 | *(fix, unpublished on PyPI)* | **`.248`** | `pyasn1` → `0.6.4` (PYSEC-2026-3455/3456/3457) ([#1304](https://github.com/DataBoar/data-boar/pull/1304)). |
 | *(fix, unpublished on PyPI)* | **`.249`** | SQL `connect_args` branched per driver: `oracle+oracledb` → `tcp_connect_timeout`; `mssql+pyodbc` → `timeout` only ([#1310](https://github.com/DataBoar/data-boar/pull/1310) / [#1302](https://github.com/DataBoar/data-boar/issues/1302)). |
 | *(fix, unpublished on PyPI)* | **`.250`** | Oracle discovery skips `AUDSYS` + 12c+ system schemas ([#1316](https://github.com/DataBoar/data-boar/pull/1316) / [#1315](https://github.com/DataBoar/data-boar/issues/1315); field Podman 2026-07-23). |
-| **`1.7.4.post8`** | **`.250`** | Published — post7 baseline `b5054d55` + `N=5` `fix(` commits (#1297–#1298, #1304, #1302, #1315); see [1.7.4.post8.md](1.7.4.post8.md). |
+| **`1.7.4.post8`** | **`.250`** | Published **2026-07-23 13:52:06 UTC** — post7 baseline `b5054d55` + `N=5` `fix(`; see [1.7.4.post8.md](1.7.4.post8.md). |
+| *(fix, unpublished on PyPI)* | **`.251`** | CLI pre-flight output dirs + `--regenerate-report` from SQLite ([#1339](https://github.com/DataBoar/data-boar/pull/1339) / [#1324](https://github.com/DataBoar/data-boar/issues/1324), [#1325](https://github.com/DataBoar/data-boar/issues/1325)). |
+| *(fix, unpublished on PyPI)* | **`.252`** | SQL sampling: deduplicate column values before `sample_limit` cap ([#1343](https://github.com/DataBoar/data-boar/pull/1343) / [#1337](https://github.com/DataBoar/data-boar/issues/1337)). |
+| *(fix, unpublished on PyPI)* | **`.253`** | Production engine wires `BoarThrottler` adaptive rate limiting ([#1344](https://github.com/DataBoar/data-boar/pull/1344) / [#1320](https://github.com/DataBoar/data-boar/issues/1320)). |
+| *(fix, unpublished on PyPI)* | **`.254`** | Learned-patterns audit anti-generic blocklist ([#1345](https://github.com/DataBoar/data-boar/pull/1345) / [#1327](https://github.com/DataBoar/data-boar/issues/1327)). |
+| *(fix, unpublished on PyPI)* | **`.255`** | Unified session report export CLI + per-format wrappers ([#1346](https://github.com/DataBoar/data-boar/pull/1346) / [#1326](https://github.com/DataBoar/data-boar/issues/1326)). |
+| *(fix, unpublished on PyPI)* | **`.256`** | Live scan progress lines + remote DB latency operator docs ([#1347](https://github.com/DataBoar/data-boar/pull/1347) / [#1328](https://github.com/DataBoar/data-boar/issues/1328), [#1323](https://github.com/DataBoar/data-boar/issues/1323)). |
+| *(fix, unpublished on PyPI)* | **`.257`** | `pypdf` `6.13.3` → `6.14.2` — CVE-2026-59935/59936/59937/59938 (DoS via PDF scan path) ([#1336](https://github.com/DataBoar/data-boar/pull/1336)). |
+| **`1.7.4.post9`** | **`.257`** | **This upload** — post8 baseline `8527b0a4` + `N=7` discrete fixes; see appendix. |
 
 ---
 
-## Appendix — Fix set used for `N` (`N=5`) (git-literal)
+## Appendix — Fix set used for `N` (`N=7`) (git-literal)
 
-**Boundary:** post7 release commit `b5054d55` (`chore(release): 1.7.4.post7 PyPI publish counter`).
+**Boundary:** post8 release commit `8527b0a4` (`chore(release): honest post8 notes — N=5, maturity_build=250`).
 
 ```bash
-git log b5054d55..HEAD --format='%h %s' | rg '^[0-9a-f]+ fix\('
-# COUNT=5  →  maturity_build = 245 + 5 = 250
+git log 8527b0a4..HEAD --format='%h %s' \
+  | rg '59b78242|79f2f637|556f2683|c527682a|b56d9cdf|591da992|5577eca8'
+# COUNT=7  →  maturity_build = 250 + 7 = 257
 ```
 
-Commits counted toward **`N=5`**:
+Commits counted toward **`N=7`** (wheel-affecting packages only):
 
-1. `6dd14dfd` — `fix(connectors): pymssql login_timeout/timeout for MSSQL connect_args` ([#1297](https://github.com/DataBoar/data-boar/pull/1297)) — field-caught: first native MSSQL run failed with `connect() got an unexpected keyword argument 'connect_timeout'`; zero rows ingested across five databases.
-2. `ad2440a3` — `fix(integrity): expand CRITICAL_MODULES globs + CLI trust surfacing` ([#1298](https://github.com/DataBoar/data-boar/issues/1298) / [#1300](https://github.com/DataBoar/data-boar/pull/1300)) — field-caught: connector tamper did not tint; glob allowlist (`connectors/*.py`, `core/licensing/*.py`) + `--version` / `--validate-config` surfacing.
-3. `dd06515a` — `fix(deps): bump pyasn1 to 0.6.4 (PYSEC-2026-3455/3456/3457)` ([#1304](https://github.com/DataBoar/data-boar/pull/1304)).
-4. `e1c4d6bc` — `fix(connector): branch SQL connect timeout kwargs by driver (#1302)` ([#1310](https://github.com/DataBoar/data-boar/pull/1310) / [#1302](https://github.com/DataBoar/data-boar/issues/1302)).
-5. `7dde79a8` — `fix(connector): skip Oracle 12c+ system schemas including AUDSYS (#1315)` ([#1316](https://github.com/DataBoar/data-boar/pull/1316) / [#1315](https://github.com/DataBoar/data-boar/issues/1315)) — field-caught: `ORA-01031` on `AUDSYS` blocked schema enumeration.
+1. `59b78242` — `fix(cli): pre-flight output dirs and --regenerate-report from SQLite` ([#1339](https://github.com/DataBoar/data-boar/pull/1339) / [#1324](https://github.com/DataBoar/data-boar/issues/1324), [#1325](https://github.com/DataBoar/data-boar/issues/1325)).
+2. `79f2f637` — `feat(sampling): deduplicate column values before sample_limit cap` ([#1343](https://github.com/DataBoar/data-boar/pull/1343) / [#1337](https://github.com/DataBoar/data-boar/issues/1337)).
+3. `556f2683` — `feat(scan): wire BoarThrottler into production engine path` ([#1344](https://github.com/DataBoar/data-boar/pull/1344) / [#1320](https://github.com/DataBoar/data-boar/issues/1320)).
+4. `c527682a` — `feat(learned-patterns): audit anti-generic blocklist and field tests` ([#1345](https://github.com/DataBoar/data-boar/pull/1345) / [#1327](https://github.com/DataBoar/data-boar/issues/1327)).
+5. `b56d9cdf` — `feat(report): unified session export CLI with per-format wrappers` ([#1346](https://github.com/DataBoar/data-boar/pull/1346) / [#1326](https://github.com/DataBoar/data-boar/issues/1326)).
+6. `591da992` — `feat(scan): live progress lines and remote DB latency docs` ([#1347](https://github.com/DataBoar/data-boar/pull/1347) / [#1328](https://github.com/DataBoar/data-boar/issues/1328), [#1323](https://github.com/DataBoar/data-boar/issues/1323)).
+7. `5577eca8` — `deps(uv): bump pypdf from 6.13.3 to 6.14.2` ([#1336](https://github.com/DataBoar/data-boar/pull/1336)) — four DoS CVEs on the filesystem PDF ingestion path (`connectors/filesystem_connector.py:386` `PdfReader` over scanned target files).
 
-**Not counted toward `N`:** merge commits of the PRs above; release-prep commits for post8 (`1c8f6e5b` and follow-ups); docs-only ([#1288](https://github.com/DataBoar/data-boar/pull/1288) LGPD compliance sample enrichment), workflow ([#1313](https://github.com/DataBoar/data-boar/pull/1313) primary Linux agent sessions), and plan docs ([#1305](https://github.com/DataBoar/data-boar/pull/1305), [#1307](https://github.com/DataBoar/data-boar/pull/1307)).
-
-**Already in post7 (not double-counted):** MSSQL no-ODBC default `mssql+pymssql` ([#1290](https://github.com/DataBoar/data-boar/pull/1290) / [#1289](https://github.com/DataBoar/data-boar/issues/1289)) — `maturity_build` **`.245`**.
+**Not counted toward `N`:** merge commits; release-prep commits for post9; benchmark safe-axis docs/tests ([#1341](https://github.com/DataBoar/data-boar/pull/1341) / `19e268c7` — `docs/plans/` + `tests/benchmarks/`); PCI/saúde/LGPD **compliance samples** ([#1345](https://github.com/DataBoar/data-boar/pull/1345) / `a9678874` — `docs/compliance-samples/` + `security/`; operator policy: samples are docs); report path regression test only (`1baa76b5` — `tests/`); local benchmark artefact gitignore (`2979c99b`); distroless Docker base image bump (`55c6b75d` — `Dockerfile`; postN is PyPI-only per [1.7.4.post8.md](1.7.4.post8.md)).
 
 ---
 
-## Highlights (why post8)
+## Highlights (why post9)
 
-- **On-site reliability:** native MSSQL connector works on first field execution (pymssql timeout kwargs); per-driver SQL `connect_args` (Oracle `tcp_connect_timeout`, pyodbc `timeout`-only).
-- **On-site trust:** integrity anchor now covers the full connector and licensing trees; cheapest tamper signal is `data-boar --version` showing `-alpha`.
-- **Supply chain:** `pyasn1` 0.6.4 closes PYSEC-2026-3455/3456/3457.
-- **Oracle lab / field:** discovery skips `AUDSYS` and other 12c+ system schemas that raise permission errors during enumeration.
+- **Operator UX:** long scans emit honest stderr progress; remote DB latency documented with co-location guidance ([#1328](https://github.com/DataBoar/data-boar/issues/1328), [#1323](https://github.com/DataBoar/data-boar/issues/1323)).
+- **Reliability / throughput:** output-dir pre-flight, `--regenerate-report`, sampling dedup before cap, optional adaptive rate limiting on the production target loop ([#1324](https://github.com/DataBoar/data-boar/issues/1324)–[#1325](https://github.com/DataBoar/data-boar/issues/1325), [#1337](https://github.com/DataBoar/data-boar/issues/1337), [#1320](https://github.com/DataBoar/data-boar/issues/1320)).
+- **Reporting:** unified session export CLI ([#1326](https://github.com/DataBoar/data-boar/issues/1326)).
+- **Pattern quality:** learned-patterns anti-generic guard ([#1327](https://github.com/DataBoar/data-boar/issues/1327)).
+- **Supply chain:** `pypdf` 6.14.2 closes four reachable DoS CVEs on PDF targets.
 
 ---
 
 ## Install
 
 ```bash
-pip install 'data-boar==1.7.4.post8'
+pip install 'data-boar==1.7.4.post9'
 ```
 
 See [USAGE.md](../USAGE.md), [QUICKSTART.md](../QUICKSTART.md), and [TROUBLESHOOTING.md](../TROUBLESHOOTING.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-boar"
-version = "1.7.4.post8"
+version = "1.7.4.post9"
 description = "Data Boar — compliance-aware discovery and mapping of personal and sensitive data across databases, files, and APIs (LGPD, GDPR, CCPA, and configurable frameworks)."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -318,6 +318,6 @@ dev = [
 ]
 
 # Operator-only maturity octet (ADR-0073). Never copy into [project].version.
-# postN <-> maturity_build map: docs/releases/1.7.4.post8.md (canonical; includes post1–post7 rows).
+# postN <-> maturity_build map: docs/releases/1.7.4.post9.md (canonical; includes post1–post8 rows).
 [tool.databoar]
-maturity_build = 250
+maturity_build = 257

--- a/tests/test_maturity_build_accounting.py
+++ b/tests/test_maturity_build_accounting.py
@@ -16,6 +16,8 @@ POST6_MATURITY_BUILD = 241
 POST7_MATURITY_BUILD = 245
 POST8_FIX_COUNT = 5
 POST8_MATURITY_BUILD = 250
+POST9_FIX_COUNT = 7
+POST9_MATURITY_BUILD = 257
 
 
 def _load_pyproject() -> dict:
@@ -31,8 +33,9 @@ def test_post5_maturity_build_accounting_uses_post4_publish_row_not_225() -> Non
     assert (POST5_MATURITY_BUILD - 225) != POST5_FIX_COUNT
 
 
-def test_pyproject_maturity_build_matches_post8_canonical_map() -> None:
+def test_pyproject_maturity_build_matches_post9_canonical_map() -> None:
     data = _load_pyproject()
     maturity = data.get("tool", {}).get("databoar", {}).get("maturity_build")
-    assert maturity == POST8_MATURITY_BUILD
+    assert maturity == POST9_MATURITY_BUILD
+    assert POST8_MATURITY_BUILD + POST9_FIX_COUNT == POST9_MATURITY_BUILD
     assert POST7_MATURITY_BUILD + POST8_FIX_COUNT == POST8_MATURITY_BUILD

--- a/tests/test_pyproject_sql_extras.py
+++ b/tests/test_pyproject_sql_extras.py
@@ -64,11 +64,11 @@ def test_sql_optional_extras_present() -> None:
 def test_maturity_build_bumped_for_packaging_fix() -> None:
     data = _load_pyproject()
     maturity = data.get("tool", {}).get("databoar", {}).get("maturity_build")
-    assert maturity == 250
+    assert maturity == 257
 
 
 def test_version_is_174_post_release_not_semver_bump() -> None:
     version = _load_pyproject().get("project", {}).get("version")
-    assert version == "1.7.4.post8"
+    assert version == "1.7.4.post9"
     assert not str(version).startswith("1.7.5")
     assert not str(version).startswith("1.8.")

--- a/uv.lock
+++ b/uv.lock
@@ -809,7 +809,7 @@ validation = [
 
 [[package]]
 name = "data-boar"
-version = "1.7.4.post8"
+version = "1.7.4.post9"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-doc" },


### PR DESCRIPTION
## Summary

Release-prep for **`1.7.4.post9`** (PyPI publish counter, ADR-0073). **`maturity_build` 250 → 257** (`N=7` since post8 baseline `8527b0a4`).

**Public marketing line stays `1.7.4`** — README, man pages, stakeholder copy unchanged.

**This PR does not publish anything.** PyPI upload is **operator `workflow_dispatch`** via **`publish-pypi.yml`** (build → TestPyPI → PyPI) **after** merge. No git tag, no GitHub Release, no Docker image in this drop (`.postN` is PyPI-only per `docs/releases/1.7.4.post8.md`).

Also fixes **`docs/releases/1.7.4.post8.md`**: status was still **"Pending PyPI upload"** since 2026-07-23 despite post8 being live on PyPI (**2026-07-23 13:52:06 UTC**).

---

## Seven fixes counted (`N=7` → wheel packages)

| Commit | Summary | Issues |
| --- | --- | --- |
| `59b78242` | `fix(cli):` pre-flight output dirs + `--regenerate-report` from SQLite | #1324, #1325 |
| `79f2f637` | `feat(sampling):` deduplicate column values before `sample_limit` cap | #1337 |
| `556f2683` | `feat(scan):` wire `BoarThrottler` into production engine path | #1320 |
| `c527682a` | `feat(learned-patterns):` audit anti-generic blocklist | #1327 |
| `b56d9cdf` | `feat(report):` unified session export CLI + per-format wrappers | #1326 |
| `591da992` | `feat(scan):` live progress lines + remote DB latency docs | #1328, #1323 |
| `5577eca8` | `deps(uv):` pypdf 6.13.3 → 6.14.2 (4 DoS CVEs on PDF scan path) | #1336 |

Full map + appendix: **`docs/releases/1.7.4.post9.md`**. Accounting guard: **`tests/test_maturity_build_accounting.py`** (`POST8=250`, `POST9_FIX_COUNT=7`, `POST9=257`, `250+7==257`).

---

## Five commits **not** counted (no wheel package change)

| Commit | Why excluded |
| --- | --- |
| `19e268c7` | Benchmark safe-axis — `docs/plans/` + `tests/benchmarks/` only |
| `a9678874` | PCI/saúde/LGPD compliance **samples** — `docs/compliance-samples/` + `security/` (operator: samples = docs) |
| `1baa76b5` | Report `resolve_output_dir` regression test — `tests/` only |
| `2979c99b` | `.gitignore` for local benchmark artefact |
| `55c6b75d` | Distroless Docker base image — `Dockerfile` (postN is PyPI-only) |

---

## Files touched

- `pyproject.toml` — `version = 1.7.4.post9`, `maturity_build = 257`, pointer → `docs/releases/1.7.4.post9.md`
- `core/about.py` — fallback version
- `docs/releases/1.7.4.post9.md` — new canonical map
- `docs/releases/1.7.4.post8.md` — published status + map row
- `CHANGELOG.md` — post9 entry; post8 marked published
- `tests/test_maturity_build_accounting.py`, `tests/test_pyproject_sql_extras.py`
- `uv.lock`

## Test plan

- [x] `./scripts/check-all.sh --enforced` green on branch