### PR TITLE
docs(release): mark 1.7.4.post9 published on PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Human-readable summary of user-facing changes. **Detailed release notes:** [docs
 
 ---
 
-## 1.7.4.post9 (pending PyPI dispatch)
+## 1.7.4.post9 (published PyPI **2026-07-28 10:34:16 UTC**)
 
 > Post-release on the **`1.7.4`** public line. **`[project] version = 1.7.4.post9`** and **`[tool.databoar] maturity_build = 257`** (`N=7` discrete fixes since post8 baseline `8527b0a4`, ADR-0073). **PyPI-only** — no Git tag, no GitHub Release, no container.
 >

--- a/docs/releases/1.7.4.post9.md
+++ b/docs/releases/1.7.4.post9.md
@@ -1,6 +1,6 @@
 # Release 1.7.4.post9 (PyPI publish counter)
 
-**Status:** Pending PyPI upload after merge (operator **`publish-pypi`** `workflow_dispatch`: build → TestPyPI → PyPI).
+**Status:** Published on PyPI (**2026-07-28 10:34:16 UTC**). Operator **`publish-pypi`** `workflow_dispatch`: build → TestPyPI → PyPI.
 
 **Public line (marketing):** **`1.7.4`** — README, man pages, stakeholder copy unchanged.
 
@@ -78,7 +78,7 @@ Per ADR-0073: **`postN`** counts **PyPI uploads**; **`maturity_build`** counts *
 | *(fix, unpublished on PyPI)* | **`.255`** | Unified session report export CLI + per-format wrappers ([#1346](https://github.com/DataBoar/data-boar/pull/1346) / [#1326](https://github.com/DataBoar/data-boar/issues/1326)). |
 | *(fix, unpublished on PyPI)* | **`.256`** | Live scan progress lines + remote DB latency operator docs ([#1347](https://github.com/DataBoar/data-boar/pull/1347) / [#1328](https://github.com/DataBoar/data-boar/issues/1328), [#1323](https://github.com/DataBoar/data-boar/issues/1323)). |
 | *(fix, unpublished on PyPI)* | **`.257`** | `pypdf` `6.13.3` → `6.14.2` — CVE-2026-59935/59936/59937/59938 (DoS via PDF scan path) ([#1336](https://github.com/DataBoar/data-boar/pull/1336)). |
-| **`1.7.4.post9`** | **`.257`** | **This upload** — post8 baseline `8527b0a4` + `N=7` discrete fixes; see appendix. |
+| **`1.7.4.post9`** | **`.257`** | Published **2026-07-28 10:34:16 UTC** — post8 baseline `8527b0a4` + `N=7` discrete fixes; see [1.7.4.post9.md](1.7.4.post9.md). |
 
 ---
 


### PR DESCRIPTION
## Summary

`docs/releases/1.7.4.post9.md` still said **Pending PyPI upload** after the operator published **`1.7.4.post9`** at **2026-07-28 10:34:16 UTC** (PyPI JSON, wheel upload timestamp).

## Changes

- **`docs/releases/1.7.4.post9.md`**
  - Status line → `Published on PyPI (**2026-07-28 10:34:16 UTC**)` (same pattern as post8.md in #1350).
  - Mandatory map row for **`1.7.4.post9`**: `**This upload**` → published row with timestamp (no false “still pending” wording).
- **`CHANGELOG.md`**: post9 section header `pending PyPI dispatch` → `published PyPI **2026-07-28 10:34:16 UTC**` (same false-claim class).

No code or version bump — documentation truthfulness only.

## Test plan

- [x] `./scripts/check-all.sh --enforced` green