### PR TITLE
docs(release): mark 1.7.4.post1–post7 published on PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Human-readable summary of user-facing changes. **Detailed release notes:** [docs
 
 ---
 
-## 1.7.4.post7 (pending PyPI dispatch)
+## 1.7.4.post7 (published PyPI **2026-07-21 12:03:52 UTC**)
 
 > Post-release on the **`1.7.4`** public line. **`[project] version = 1.7.4.post7`** and **`[tool.databoar] maturity_build = 245`** (`N=4` discrete fixes since post6 baseline `6dc54642`, ADR-0073). **PyPI-only** — no Git tag, no GitHub Release, no container.
 
@@ -74,7 +74,7 @@ Human-readable summary of user-facing changes. **Detailed release notes:** [docs
 
 ---
 
-## 1.7.4.post6 (pending PyPI dispatch)
+## 1.7.4.post6 (published PyPI **2026-07-15 22:48:46 UTC**)
 
 > Post-release on the **`1.7.4`** public line. **`[project] version = 1.7.4.post6`** and **`[tool.databoar] maturity_build = 241`** (`N=1` `fix(` commit since post5 `b7de32ba`, ADR-0073). **PyPI-only** — no Git tag, no GitHub Release, no container.
 
@@ -88,7 +88,7 @@ Human-readable summary of user-facing changes. **Detailed release notes:** [docs
 
 ---
 
-## 1.7.4.post5 (pending PyPI dispatch)
+## 1.7.4.post5 (published PyPI **2026-07-15 21:44:36 UTC**)
 
 > Post-release on the **`1.7.4`** public line. **`[project] version = 1.7.4.post5`** and **`[tool.databoar] maturity_build = 240`** (`N=14` `fix(` commits since post4 merge `656fdc3d`, ADR-0073). **PyPI-only** — no Git tag, no GitHub Release, no container.
 
@@ -108,7 +108,7 @@ Human-readable summary of user-facing changes. **Detailed release notes:** [docs
 
 ---
 
-## 1.7.4.post4 (pending PyPI dispatch)
+## 1.7.4.post4 (published PyPI **2026-07-13 16:29:05 UTC**)
 
 > Post-release on the **`1.7.4`** public line. **`[project] version = 1.7.4.post4`** and **`[tool.databoar] maturity_build = 226`** (`N=15` fixes since post3 baseline, ADR-0073 dual counter policy).
 
@@ -131,7 +131,7 @@ Human-readable summary of user-facing changes. **Detailed release notes:** [docs
 
 ---
 
-## 1.7.4.post3 (pending PyPI dispatch)
+## 1.7.4.post3 (published PyPI **2026-07-10 21:58:29 UTC**)
 
 > Post-release on the **`1.7.4`** public line. **`[project] version = 1.7.4.post3`** and **`[tool.databoar] maturity_build = 211`** (ADR-0073 dual counter policy).
 

--- a/docs/releases/1.7.4.post1.md
+++ b/docs/releases/1.7.4.post1.md
@@ -1,6 +1,6 @@
 # Release 1.7.4.post1 (PyPI publish counter)
 
-**Status:** Pending PyPI upload after merge of PR for [#1047](https://github.com/FabioLeitao/data-boar/issues/1047).
+**Status:** Published on PyPI (**2026-06-27 19:15:14 UTC**). Operator **`publish-pypi`** `workflow_dispatch`: build → TestPyPI → PyPI.
 
 **Public line (marketing):** **`1.7.4`** — README, man pages, stakeholder copy unchanged.
 
@@ -15,7 +15,7 @@ Per ADR-0073 (ratified 2026-06-27): without this table, publication and maturity
 | PyPI / `[project] version` | `maturity_build` (octet) | Notes |
 | --- | --- | --- |
 | **`1.7.4`** | **`.201`** | GA on PyPI (immutable); release PR **#1024** |
-| **`1.7.4.post1`** | **`.202`** | SQL drivers → optional extras; lean core `pip install` ([#1047](https://github.com/FabioLeitao/data-boar/issues/1047)) |
+| **`1.7.4.post1`** | **`.202`** | Published **2026-06-27 19:15:14 UTC** — SQL drivers → optional extras; lean core `pip install` ([#1047](https://github.com/FabioLeitao/data-boar/issues/1047)). |
 
 **Divergence example (policy):** If fixes advance the octet without a PyPI upload, the publish counter stays on the last **`postN`** until republication. After **`1.7.4.post1`** was published at **`.202`**, fixes **`.203`–`.208`** accumulated on `main`; the next upload is **`1.7.4.post2`** ↔ **`.208`** — see [`1.7.4.post2.md`](1.7.4.post2.md).
 

--- a/docs/releases/1.7.4.post2.md
+++ b/docs/releases/1.7.4.post2.md
@@ -1,6 +1,6 @@
 # Release 1.7.4.post2 (PyPI publish counter)
 
-**Status:** Pending PyPI upload after merge (operator **`publish-pypi`** `workflow_dispatch`).
+**Status:** Published on PyPI (**2026-07-01 10:06:12 UTC**). Operator **`publish-pypi`** `workflow_dispatch`: build → TestPyPI → PyPI.
 
 **Public line (marketing):** **`1.7.4`** — README, man pages, stakeholder copy unchanged.
 
@@ -21,7 +21,7 @@ Per ADR-0073: **`postN`** counts **PyPI uploads**; **`maturity_build`** counts *
 | *(fix, unpublished on PyPI)* | **`.206`** | `main.py --version` without config (ADR-0073 CLI) |
 | **`1.7.4.post1`** | **`.202`** | SQL drivers → optional extras ([#1047](https://github.com/FabioLeitao/data-boar/issues/1047)) — **published** 2026-06-27 |
 | *(fix, unpublished on PyPI)* | **`.207`** | `fix(connectors)` symlink / reparse-point loop guard ([#1080](https://github.com/FabioLeitao/data-boar/pull/1080)) — **security** |
-| **`1.7.4.post2`** | **`.208`** | **This upload** — headline fixes below; also ships licensing + `--demo` accumulated on `main` |
+| **`1.7.4.post2`** | **`.208`** | Published **2026-07-01 10:06:12 UTC** — headline fixes below; also ships licensing + `--demo` accumulated on `main` |
 
 **Divergence (policy):** Octets **`.203`–`.207`** are **fixes** that landed without a PyPI upload; **`postN` stayed at `post1`** until this **`post2`**. **`maturity_build` is not a publish counter** — do not advance it only because `postN` changed.
 

--- a/docs/releases/1.7.4.post3.md
+++ b/docs/releases/1.7.4.post3.md
@@ -1,6 +1,6 @@
 # Release 1.7.4.post3 (PyPI publish counter)
 
-**Status:** Pending PyPI upload after merge (operator **`publish-pypi`** `workflow_dispatch`).
+**Status:** Published on PyPI (**2026-07-10 21:58:29 UTC**). Operator **`publish-pypi`** `workflow_dispatch`: build → TestPyPI → PyPI.
 
 **Public line (marketing):** **`1.7.4`** — README, man pages, stakeholder copy unchanged.
 
@@ -24,7 +24,7 @@ Per ADR-0073: **`postN`** counts **PyPI uploads**; **`maturity_build`** counts *
 | **`1.7.4.post2`** | **`.208`** | Prior upload on this line |
 | *(fix, unpublished on PyPI)* | **`.209`** | SQL sampling failures now surface in `scan_failures` ([#1140](https://github.com/FabioLeitao/data-boar/issues/1140), [#1144](https://github.com/FabioLeitao/data-boar/pull/1144)) |
 | *(fix, unpublished on PyPI)* | **`.210`** | Encrypted/corrupt archive members now surface in `scan_failures` (open-core slice of [#828](https://github.com/FabioLeitao/data-boar/issues/828), [#1146](https://github.com/FabioLeitao/data-boar/pull/1146)) |
-| **`1.7.4.post3`** | **`.211`** | **This upload** — `soupsieve` CVE fix ([#1177](https://github.com/FabioLeitao/data-boar/pull/1177)) |
+| **`1.7.4.post3`** | **`.211`** | Published **2026-07-10 21:58:29 UTC** — `soupsieve` CVE fix ([#1177](https://github.com/FabioLeitao/data-boar/pull/1177)) |
 
 ---
 

--- a/docs/releases/1.7.4.post4.md
+++ b/docs/releases/1.7.4.post4.md
@@ -1,6 +1,6 @@
 # Release 1.7.4.post4 (PyPI publish counter)
 
-**Status:** Pending PyPI upload after merge (operator **`publish-pypi`** `workflow_dispatch`).
+**Status:** Published on PyPI (**2026-07-13 16:29:05 UTC**). Operator **`publish-pypi`** `workflow_dispatch`: build → TestPyPI → PyPI.
 
 **Public line (marketing):** **`1.7.4`** — README, man pages, stakeholder copy unchanged.
 
@@ -39,7 +39,7 @@ Per ADR-0073: **`postN`** counts **PyPI uploads**; **`maturity_build`** counts *
 | *(fix, unpublished on PyPI)* | **`.223`** | Help output now aligns dev invocation and installed command contract (#1130). |
 | *(fix, unpublished on PyPI)* | **`.224`** | Demo sessions now resolve audit trail correctly via `/logs/{session_id}` (#1218). |
 | *(fix, unpublished on PyPI)* | **`.225`** | Logs fallback hardening removed the CodeQL path-injection sink in demo retrieval (#1218, `4bd3e5bc`). |
-| **`1.7.4.post4`** | **`.226`** | **This upload** — Pillow `12.2.0` -> `12.3.0` to clear `PYSEC-2026-2253..2257` (5 CVEs); baseline `1.7.4.post3` + `N=15` fixes. |
+| **`1.7.4.post4`** | **`.226`** | Published **2026-07-13 16:29:05 UTC** — Pillow `12.2.0` -> `12.3.0` to clear `PYSEC-2026-2253..2257` (5 CVEs); baseline `1.7.4.post3` + `N=15` fixes. |
 
 ---
 

--- a/docs/releases/1.7.4.post5.md
+++ b/docs/releases/1.7.4.post5.md
@@ -1,6 +1,6 @@
 # Release 1.7.4.post5 (PyPI publish counter)
 
-**Status:** Pending PyPI upload after merge (operator **`publish-pypi`** `workflow_dispatch`: build → TestPyPI → PyPI).
+**Status:** Published on PyPI (**2026-07-15 21:44:36 UTC**). Operator **`publish-pypi`** `workflow_dispatch`: build → TestPyPI → PyPI.
 
 **Public line (marketing):** **`1.7.4`** — README, man pages, stakeholder copy unchanged.
 
@@ -55,7 +55,7 @@ Per ADR-0073: **`postN`** counts **PyPI uploads**; **`maturity_build`** counts *
 | *(fix, unpublished on PyPI)* | **`.237`** | Read `.7z` members via py7zr `BytesIOFactory` (#1250, #1248). |
 | *(fix, unpublished on PyPI)* | **`.238`** | Extract pre-budget `.7z` members on budget stop (#1250, #1248). |
 | *(fix, unpublished on PyPI)* | **`.239`** | Orphan session reaper (PID liveness) + interrupt → `interrupted` (#1251). |
-| **`1.7.4.post5`** | **`.240`** | **This upload** — TOCTOU-safe reaper UPDATE + post5 wave; baseline `1.7.4.post4` + `N=14` `fix(` commits. |
+| **`1.7.4.post5`** | **`.240`** | Published **2026-07-15 21:44:36 UTC** — TOCTOU-safe reaper UPDATE + post5 wave; baseline `1.7.4.post4` + `N=14` `fix(` commits. |
 
 ---
 

--- a/docs/releases/1.7.4.post6.md
+++ b/docs/releases/1.7.4.post6.md
@@ -1,6 +1,6 @@
 # Release 1.7.4.post6 (PyPI publish counter)
 
-**Status:** Pending PyPI upload after merge (operator **`publish-pypi`** `workflow_dispatch`: build → TestPyPI → PyPI).
+**Status:** Published on PyPI (**2026-07-15 22:48:46 UTC**). Operator **`publish-pypi`** `workflow_dispatch`: build → TestPyPI → PyPI.
 
 **Public line (marketing):** **`1.7.4`** — README, man pages, stakeholder copy unchanged.
 
@@ -56,7 +56,7 @@ Per ADR-0073: **`postN`** counts **PyPI uploads**; **`maturity_build`** counts *
 | *(fix, unpublished on PyPI)* | **`.238`** | Extract pre-budget `.7z` members on budget stop (#1250, #1248). |
 | *(fix, unpublished on PyPI)* | **`.239`** | Orphan session reaper (PID liveness) + interrupt → `interrupted` (#1251). |
 | **`1.7.4.post5`** | **`.240`** | Post5 wave (archives/sessions/security/integrity train); baseline post4 + `N=14` `fix(` — see [1.7.4.post5.md](1.7.4.post5.md). |
-| **`1.7.4.post6`** | **`.241`** | Integrity anchor re-baselines on legitimate release upgrade (#1262 / #1263); baseline `1.7.4.post5` + `N=1` `fix(` commit. |
+| **`1.7.4.post6`** | **`.241`** | Published **2026-07-15 22:48:46 UTC** — Integrity anchor re-baselines on legitimate release upgrade (#1262 / #1263); baseline `1.7.4.post5` + `N=1` `fix(` commit. |
 
 ---
 

--- a/docs/releases/1.7.4.post7.md
+++ b/docs/releases/1.7.4.post7.md
@@ -1,6 +1,6 @@
 # Release 1.7.4.post7 (PyPI publish counter)
 
-**Status:** Pending PyPI upload after merge (operator **`publish-pypi`** `workflow_dispatch`: build → TestPyPI → PyPI).
+**Status:** Published on PyPI (**2026-07-21 12:03:52 UTC**). Operator **`publish-pypi`** `workflow_dispatch`: build → TestPyPI → PyPI.
 
 **Public line (marketing):** **`1.7.4`** — README, man pages, stakeholder copy unchanged.
 
@@ -60,7 +60,7 @@ Per ADR-0073: **`postN`** counts **PyPI uploads**; **`maturity_build`** counts *
 | *(fix, unpublished on PyPI)* | **`.242`** | `.7z` batch-extract / post-extract failures sanitized via `clean_error()` (#1257). |
 | *(fix, unpublished on PyPI)* | **`.243`** | WebAuthn session satisfies `require_api_key` on JSON routes (#1258). |
 | *(fix, unpublished on PyPI)* | **`.244`** | `learned_patterns`: skip bare filenames + anchor `output_file` to `report.output_dir` (#1259, #1260). |
-| **`1.7.4.post7`** | **`.245`** | Post6 baseline `6dc54642` + `N=4` discrete fixes (incl. MSSQL defect-fix #1290/#1289); see [1.7.4.post7.md](1.7.4.post7.md). |
+| **`1.7.4.post7`** | **`.245`** | Published **2026-07-21 12:03:52 UTC** — Post6 baseline `6dc54642` + `N=4` discrete fixes (incl. MSSQL defect-fix #1290/#1289); see [1.7.4.post7.md](1.7.4.post7.md). |
 
 ---
 


### PR DESCRIPTION
## Summary

Backlog cleanup: **12 false “still pending” claims** on the public `1.7.4.postN` line (`post1`–`post7`). All were live on PyPI for weeks; release docs and CHANGELOG still said **Pending** / **pending PyPI dispatch**.

**post8** and **post9** already fixed in #1350 / #1351 — untouched here.

## Root cause (why this happened)

Release notes are written at prep time with **Pending** — correct until upload. No step in the old process **closed** the doc after `publish-pypi.yml` succeeded, so the claim rotted silently (post8 sat wrong for ~4 days until a manual PyPI check).

**Going forward:** operator wrapper `data-boar-publish` gains a **`stamp`** subcommand that confirms the artefact on PyPI, reads the **real** upload timestamp, and stamps `docs/releases/*.md` + `CHANGELOG.md`. **Pending** should only exist while it is true. This PR clears historical debt.

## Changes

### `docs/releases/1.7.4.postN.md` (post1–post7)

- **Status** line → `Published on PyPI (**<timestamp> UTC**). Operator publish-pypi workflow_dispatch…` (same format as post8/post9).
- Map rows: `**This upload**` / implicit pending → **Published** + PyPI wheel upload timestamp where applicable.

| Version | PyPI upload (UTC) |
| --- | --- |
| `1.7.4.post1` | 2026-06-27 19:15:14 |
| `1.7.4.post2` | 2026-07-01 10:06:12 |
| `1.7.4.post3` | 2026-07-10 21:58:29 |
| `1.7.4.post4` | 2026-07-13 16:29:05 |
| `1.7.4.post5` | 2026-07-15 21:44:36 |
| `1.7.4.post6` | 2026-07-15 22:48:46 |
| `1.7.4.post7` | 2026-07-21 12:03:52 |

Timestamps from `pypi.org/pypi/data-boar/json` (operator-verified, no cache).

### `CHANGELOG.md`

- Headings for **post3–post7** only (`post1`/`post2` have no section — unchanged).

## Test plan

- [x] `./scripts/check-all.sh --enforced` green
- [x] Grep post1–post7: no `Pending`, `This upload`, or `after merge` left