### PR TITLE
docs(release): mark 1.7.4.post10 published on PyPI (2026-07-28 16:37:23 UTC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Human-readable summary of user-facing changes. **Detailed release notes:** [docs
 
 ---
 
-## 1.7.4.post10 (release prep — PyPI upload pending)
+## 1.7.4.post10 (published PyPI **2026-07-28 16:37:23 UTC**)
 
 > Post-release on the **`1.7.4`** public line. **`[project] version = 1.7.4.post10`** and **`[tool.databoar] maturity_build = 261`** (`N=4` discrete fixes since post9 baseline `9fa991c2`, ADR-0073). **PyPI-only** — no Git tag, no GitHub Release, no container. Operator runs **`publish-pypi`** after merge.
 

--- a/docs/releases/1.7.4.post10.md
+++ b/docs/releases/1.7.4.post10.md
@@ -1,6 +1,6 @@
 # Release 1.7.4.post10 (PyPI publish counter)
 
-**Status:** Pending PyPI upload after merge (operator **`publish-pypi`** `workflow_dispatch`: build → TestPyPI → PyPI).
+**Status:** Published on PyPI (**2026-07-28 16:37:23 UTC**). Operator **`publish-pypi`** `workflow_dispatch`: build → TestPyPI → PyPI.
 
 **Public line (marketing):** **`1.7.4`** — README, man pages, stakeholder copy unchanged.
 
@@ -83,7 +83,7 @@ Per ADR-0073: **`postN`** counts **PyPI uploads**; **`maturity_build`** counts *
 | *(fix, unpublished on PyPI)* | **`.259`** | Redis: distinguish `WRONGTYPE` from connection failure; per-type value-not-sampled counts ([#1348](https://github.com/DataBoar/data-boar/issues/1348) Part A, [#1357](https://github.com/DataBoar/data-boar/pull/1357)). |
 | *(fix, unpublished on PyPI)* | **`.260`** | `archive_type_mismatch` when compressed extension and magic disagree ([#1354](https://github.com/DataBoar/data-boar/issues/1354) Part A, [#1357](https://github.com/DataBoar/data-boar/pull/1357)). |
 | *(fix, unpublished on PyPI)* | **`.261`** | `pypdf` floor `>=6.14.2` in `pyproject.toml` (future resolve cannot slip below patched pin) ([#1340](https://github.com/DataBoar/data-boar/issues/1340), [#1357](https://github.com/DataBoar/data-boar/pull/1357)). |
-| **`1.7.4.post10`** | **`.261`** | Pending PyPI — post9 baseline `9fa991c2` + `N=4` discrete fixes; see this file. |
+| **`1.7.4.post10`** | **`.261`** | Published **2026-07-28 16:37:23 UTC** — post9 baseline `9fa991c2` + `N=4` discrete fixes; see this file. |
 
 ---
 


### PR DESCRIPTION
## Summary

PyPI publish stamp for **`1.7.4.post10`** — timestamp from wheel `upload_time` (**2026-07-28 16:37:23 UTC**), applied via operator `data-boar-publish stamp` wrapper.

Updates the three places that must stay in sync after upload:

1. **`docs/releases/1.7.4.post10.md`** — `**Status:**` line
2. **`docs/releases/1.7.4.post10.md`** — `postN` ↔ `maturity_build` map row for `1.7.4.post10`
3. **`CHANGELOG.md`** — section heading

## Why this PR exists

A “Pending” state lives in **three** surfaces; leaving any one stale misstates whether the build is on PyPI (post8 stayed wrong for days in at least one place when closure depended on a later audit). The publish wrapper now rewrites all three in one step; this commit lands that stamp on `main`.

## Test plan

- [x] `./scripts/check-all.sh --enforced` green