### PR TITLE
fix(connector): Oracle sampling identifiers + lab-smoke init sidecars

### DIFF
--- a/connectors/sql_connector.py
+++ b/connectors/sql_connector.py
@@ -500,6 +500,9 @@ class SQLConnector:
                     fetch_budget = resolve_fetch_row_budget(
                         use_limit, estimated_row_count=est
                     )
+                    oracle_raw = {"raw_col": column_name, "raw_table": table}
+                    if schema:
+                        oracle_raw["raw_schema"] = schema
                     plan = SamplingManager.build_column_sample(
                         dialect,
                         safe_col=safe_col,
@@ -509,6 +512,7 @@ class SQLConnector:
                         limit=fetch_budget,
                         table_metadata=table_meta,
                         statement_timeout_ms=to,
+                        **(oracle_raw if (dialect or "").lower() == "oracle" else {}),
                     )
                     if self._sql_sampling_audit_key != audit_key:
                         self._sql_sampling_audit_key = audit_key

--- a/connectors/sql_sampling.py
+++ b/connectors/sql_sampling.py
@@ -19,7 +19,10 @@ place to evolve dialect-specific strategies (TABLESAMPLE, metadata-driven caps).
 
 Identifiers passed into `SamplingManager.build_column_sample` (and the legacy
 `SqlColumnSampleQueryBuilder.build`) must already be dialect-escaped (see
-`sql_connector.sample`); this module only composes SQL shape.
+`sql_connector.sample`); this module only composes SQL shape. **Oracle** is the
+exception: pass optional ``raw_col`` / ``raw_table`` / ``raw_schema`` from
+discovery (may be ``quoted_name``) so case-sensitive quoted objects are preserved;
+unquoted dictionary names are emitted without double quotes (uppercase).
 
 Architecture (orchestrator vs fixed strings):
 - `SamplingManager` picks a **strategy label** and builds a `TextClause` from
@@ -51,9 +54,10 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from typing import Any
 
 from sqlalchemy import text
-from sqlalchemy.sql.elements import TextClause
+from sqlalchemy.sql.elements import TextClause, quoted_name
 
 # Leading comment on all generated sampling SQL (pg_stat_activity / DMVs).
 #
@@ -216,6 +220,32 @@ def _ansi_quoted_table(safe_schema: str, safe_table: str, schema: str | None) ->
     return f'"{safe_schema}"."{safe_table}"' if schema else f'"{safe_table}"'
 
 
+def oracle_sql_identifier(name: Any) -> str:
+    """
+    Render an Oracle SQL identifier from a discovery/reflection name.
+
+    SQLAlchemy reflects unquoted Oracle objects as lowercase strings; wrapping
+    those in double quotes forces case-sensitive resolution and yields ORA-00942.
+    Objects created with quoted lowercase identifiers are reflected as
+    ``quoted_name(..., quote=True)`` and must keep exact case inside quotes.
+    """
+    raw = str(name)
+    safe = raw.replace('"', '""')
+    if isinstance(name, quoted_name) and getattr(name, "quote", False):
+        return f'"{safe}"'
+    if raw != raw.lower() and raw != raw.upper():
+        return f'"{safe}"'
+    return safe.upper()
+
+
+def _oracle_table_ref(schema_name: Any, table_name: Any, schema: str | None) -> str:
+    if schema:
+        return (
+            f"{oracle_sql_identifier(schema_name)}.{oracle_sql_identifier(table_name)}"
+        )
+    return oracle_sql_identifier(table_name)
+
+
 def _large_table_flags(
     table_metadata: TableSamplingMetadata | None,
 ) -> tuple[bool, str]:
@@ -286,21 +316,22 @@ def _plan_mysql_column_sample(
 
 
 def _plan_oracle_column_sample(
-    safe_col: str,
-    safe_schema: str,
-    safe_table: str,
+    col: Any,
+    schema_name: Any,
+    table_name: Any,
     schema: str | None,
     lim: int,
     large: bool,
     audit_notes: str,
 ) -> ColumnSamplePlan:
     label = _with_large_suffix("non_null_rownum_oracle", large)
-    t = _ansi_quoted_table(safe_schema, safe_table, schema)
+    t = _oracle_table_ref(schema_name, table_name, schema)
+    col_sql = oracle_sql_identifier(col)
     # Inner filter first: ROWNUM on the outer query caps non-null rows only.
     q = text(
         _tag_sql(
-            f'SELECT * FROM (SELECT "{safe_col}" FROM {t} '  # nosec B608
-            f'WHERE "{safe_col}" IS NOT NULL) WHERE ROWNUM <= :lim'
+            f"SELECT * FROM (SELECT {col_sql} FROM {t} "  # nosec B608
+            f"WHERE {col_sql} IS NOT NULL) WHERE ROWNUM <= :lim"
         )
     ).bindparams(lim=lim)
     return ColumnSamplePlan(
@@ -501,6 +532,9 @@ class SamplingManager:
         limit: int,
         table_metadata: TableSamplingMetadata | None = None,
         statement_timeout_ms: int | None = None,
+        raw_col: Any | None = None,
+        raw_table: Any | None = None,
+        raw_schema: Any | None = None,
     ) -> ColumnSamplePlan:
         lim = _clamp_limit(limit)
         d = (dialect or "").lower()
@@ -524,7 +558,13 @@ class SamplingManager:
             )
         if d == "oracle":
             return _plan_oracle_column_sample(
-                safe_col, safe_schema, safe_table, schema, lim, large, audit_notes
+                raw_col if raw_col is not None else safe_col,
+                raw_schema if raw_schema is not None else safe_schema,
+                raw_table if raw_table is not None else safe_table,
+                schema,
+                lim,
+                large,
+                audit_notes,
             )
         if d in ("mssql", "microsoft sql server"):
             return _plan_mssql_column_sample(
@@ -605,6 +645,9 @@ class SqlColumnSampleQueryBuilder:
         limit: int,
         table_metadata: TableSamplingMetadata | None = None,
         statement_timeout_ms: int | None = None,
+        raw_col: Any | None = None,
+        raw_table: Any | None = None,
+        raw_schema: Any | None = None,
     ) -> TextClause:
         return SamplingManager.build_column_sample(
             dialect,
@@ -615,6 +658,9 @@ class SqlColumnSampleQueryBuilder:
             limit=limit,
             table_metadata=table_metadata,
             statement_timeout_ms=statement_timeout_ms,
+            raw_col=raw_col,
+            raw_table=raw_table,
+            raw_schema=raw_schema,
         ).query
 
 
@@ -628,6 +674,9 @@ def column_sample_sql_for_cursor(
     limit: int,
     table_metadata: TableSamplingMetadata | None = None,
     statement_timeout_ms: int | None = None,
+    raw_col: Any | None = None,
+    raw_table: Any | None = None,
+    raw_schema: Any | None = None,
 ) -> tuple[str, dict[str, object], str, str, str]:
     """
     For DB-API drivers without SQLAlchemy execution (e.g. Snowflake connector).
@@ -647,14 +696,21 @@ def column_sample_sql_for_cursor(
         limit=limit,
         table_metadata=table_metadata,
         statement_timeout_ms=to,
+        raw_col=raw_col,
+        raw_table=raw_table,
+        raw_schema=raw_schema,
     )
     d = (dialect or "").lower()
     if d == "oracle":
         lim_v = _clamp_limit(limit)
-        t = _ansi_quoted_table(safe_schema, safe_table, schema)
+        col = raw_col if raw_col is not None else safe_col
+        sch = raw_schema if raw_schema is not None else safe_schema
+        tbl = raw_table if raw_table is not None else safe_table
+        t = _oracle_table_ref(sch, tbl, schema)
+        col_sql = oracle_sql_identifier(col)
         sql = _tag_sql(
-            f'SELECT * FROM (SELECT "{safe_col}" FROM {t} '  # nosec B608
-            f'WHERE "{safe_col}" IS NOT NULL) WHERE ROWNUM <= {lim_v}'
+            f"SELECT * FROM (SELECT {col_sql} FROM {t} "  # nosec B608
+            f"WHERE {col_sql} IS NOT NULL) WHERE ROWNUM <= {lim_v}"
         )
         human = plan.human_strategy or plan.strategy_label
         return sql, {}, plan.strategy_label, plan.audit_notes, human

--- a/deploy/lab-smoke-stack/README.md
+++ b/deploy/lab-smoke-stack/README.md
@@ -20,7 +20,7 @@ docker compose -f docker-compose.mongo.yml up -d
 
 **Config example for Data Boar:** `config.lab-smoke.example.yaml` (copy elsewhere, set hub host IP, mount `tests/data/compressed` and `tests/data/homelab_synthetic` as documented). External/public API + DB eval: **`docs/ops/LAB_EXTERNAL_CONNECTIVITY_EVAL.md`**.
 
-**SQL seeds:** `init/postgres/`, `init/mariadb/`, `init/mssql/`, and `init/oracle/` — `01_*` base tables, `02_*` linkage + minor-adjacent + shared-phone rows (same semantic corpus as the postgres seed).
+**SQL seeds:** `init/postgres/` and `init/mariadb/` load via each image’s `/docker-entrypoint-initdb.d` hook. **`init/mssql/`** and **`init/oracle/`** load via one-shot **`lab-mssql-init`** and **`lab-oracle-init`** (same pattern as **`lab-redis-init`**) — the official MSSQL image has no auto-init mount, and gvenzl Oracle hooks run as SYS on the CDB root instead of `XEPDB1`. Scripts: `init/mssql/apply_lab_smoke.sh`, `init/oracle/apply_lab_smoke_pdb.sh`. Corpus: `01_*` base tables, `02_*` linkage + minor-adjacent + shared-phone rows.
 
 **Mongo seed:** `init/mongodb/01_lab_smoke_seed.js` (database `lab_smoke_mongo`).
 

--- a/deploy/lab-smoke-stack/docker-compose.yml
+++ b/deploy/lab-smoke-stack/docker-compose.yml
@@ -59,8 +59,6 @@ services:
       MSSQL_PID: Developer
     ports:
       - "${LAB_MSSQL_PORT:-14333}:1433"
-    volumes:
-      - ./init/mssql:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test:
         [
@@ -72,6 +70,20 @@ services:
       retries: 10
       start_period: 60s
 
+  lab-mssql-init:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    depends_on:
+      lab-mssql:
+        condition: service_healthy
+    environment:
+      MSSQL_HOST: lab-mssql
+      MSSQL_PORT: "1433"
+      MSSQL_SA_PASSWORD: ${LAB_MSSQL_SA_PASSWORD:-Lab_Smoke_Change_Me1!}
+    volumes:
+      - ./init/mssql:/seed:ro
+    entrypoint: ["/bin/bash", "/seed/apply_lab_smoke.sh"]
+    restart: "no"
+
   lab-oracle:
     image: gvenzl/oracle-xe:21-slim
     environment:
@@ -80,14 +92,28 @@ services:
       APP_USER_PASSWORD: ${LAB_ORACLE_PASSWORD:-lab_smoke_change_me}
     ports:
       - "${LAB_ORACLE_PORT:-15211}:1521"
-    volumes:
-      - ./init/oracle:/container-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD", "healthcheck.sh"]
       interval: 15s
       timeout: 10s
       retries: 10
       start_period: 120s
+
+  lab-oracle-init:
+    image: gvenzl/oracle-xe:21-slim
+    depends_on:
+      lab-oracle:
+        condition: service_healthy
+    environment:
+      ORACLE_HOST: lab-oracle
+      ORACLE_PORT: "1521"
+      ORACLE_SERVICE: XEPDB1
+      APP_USER: ${LAB_ORACLE_USER:-lab_smoke}
+      APP_USER_PASSWORD: ${LAB_ORACLE_PASSWORD:-lab_smoke_change_me}
+    volumes:
+      - ./init/oracle:/seed:ro
+    entrypoint: ["/bin/bash", "/seed/apply_lab_smoke_pdb.sh"]
+    restart: "no"
 
   lab-redis:
     image: redis:7-alpine

--- a/deploy/lab-smoke-stack/init/mssql/apply_lab_smoke.sh
+++ b/deploy/lab-smoke-stack/init/mssql/apply_lab_smoke.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# One-shot MSSQL seed for lab-smoke-stack (#1369).
+# The official SQL Server image does not auto-run /docker-entrypoint-initdb.d scripts.
+set -euo pipefail
+
+MSSQL_HOST="${MSSQL_HOST:-lab-mssql}"
+MSSQL_PORT="${MSSQL_PORT:-1433}"
+SA_PASSWORD="${MSSQL_SA_PASSWORD:?MSSQL_SA_PASSWORD required}"
+SQLCMD="/opt/mssql-tools18/bin/sqlcmd"
+SEED_DIR="${SEED_DIR:-/seed}"
+
+wait_for_mssql() {
+  attempt=0
+  while [ "$attempt" -lt 90 ]; do
+    if "$SQLCMD" -S "${MSSQL_HOST},${MSSQL_PORT}" -U sa -P "$SA_PASSWORD" -C -Q "SELECT 1" -b -o /dev/null 2>/dev/null; then
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    sleep 2
+  done
+  echo "lab-mssql-init: SQL Server not ready at ${MSSQL_HOST}:${MSSQL_PORT}" >&2
+  exit 1
+}
+
+wait_for_mssql
+
+for sql_file in "$SEED_DIR"/01_lab_smoke.sql "$SEED_DIR"/02_lab_smoke_linkage.sql; do
+  if [ ! -f "$sql_file" ]; then
+    echo "lab-mssql-init: missing $sql_file" >&2
+    exit 1
+  fi
+  echo "lab-mssql-init: applying $(basename "$sql_file")"
+  "$SQLCMD" -S "${MSSQL_HOST},${MSSQL_PORT}" -U sa -P "$SA_PASSWORD" -C -i "$sql_file"
+done
+
+echo "lab-mssql-init: seed applied"

--- a/deploy/lab-smoke-stack/init/oracle/apply_lab_smoke_pdb.sh
+++ b/deploy/lab-smoke-stack/init/oracle/apply_lab_smoke_pdb.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# One-shot Oracle XE PDB seed for lab-smoke-stack (#1369).
+# gvenzl init hooks run as SYS on the CDB root; lab tables must live in XEPDB1.
+set -euo pipefail
+
+ORACLE_HOST="${ORACLE_HOST:-lab-oracle}"
+ORACLE_PORT="${ORACLE_PORT:-1521}"
+ORACLE_SERVICE="${ORACLE_SERVICE:-XEPDB1}"
+APP_USER="${APP_USER:-lab_smoke}"
+APP_USER_PASSWORD="${APP_USER_PASSWORD:?APP_USER_PASSWORD required}"
+SEED_DIR="${SEED_DIR:-/seed}"
+
+CONN="${APP_USER}/${APP_USER_PASSWORD}@//${ORACLE_HOST}:${ORACLE_PORT}/${ORACLE_SERVICE}"
+
+wait_for_oracle() {
+  attempt=0
+  while [ "$attempt" -lt 120 ]; do
+    if echo "SELECT 1 FROM dual;" | sqlplus -s "$CONN" >/dev/null 2>&1; then
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    sleep 2
+  done
+  echo "lab-oracle-init: Oracle PDB not ready at ${ORACLE_HOST}:${ORACLE_PORT}/${ORACLE_SERVICE}" >&2
+  exit 1
+}
+
+run_sql_file() {
+  sql_file="$1"
+  echo "lab-oracle-init: applying $(basename "$sql_file")"
+  sqlplus -s "$CONN" @"$sql_file" || {
+    rc=$?
+    echo "lab-oracle-init: sqlplus failed for $(basename "$sql_file") (exit $rc)" >&2
+    exit "$rc"
+  }
+}
+
+wait_for_oracle
+
+for sql_file in "$SEED_DIR"/01_lab_smoke.sql "$SEED_DIR"/02_lab_smoke_linkage.sql; do
+  if [ ! -f "$sql_file" ]; then
+    echo "lab-oracle-init: missing $sql_file" >&2
+    exit 1
+  fi
+  run_sql_file "$sql_file"
+done
+
+echo "lab-oracle-init: seed applied"

--- a/tests/test_sql_sampling.py
+++ b/tests/test_sql_sampling.py
@@ -1,10 +1,13 @@
 """Tests for SQL column sampling helpers (non-null filter, env cap, dialect SQL shape)."""
 
+from sqlalchemy.sql.elements import quoted_name
+
 from connectors.sql_sampling import (
     SamplingManager,
     SqlColumnSampleQueryBuilder,
     TableSamplingMetadata,
     column_sample_sql_for_cursor,
+    oracle_sql_identifier,
     resolve_sql_sample_limit,
     resolve_statement_timeout_ms_for_sampling,
 )
@@ -74,7 +77,59 @@ def test_build_oracle_subquery_rownum():
     s = str(q)
     assert "IS NOT NULL" in s
     assert "ROWNUM" in s
+    assert "S.T" in s
+    assert '"' not in s
     assert q.compile().params.get("lim") == 4
+
+
+def test_oracle_sql_identifier_reflected_lowercase_unquoted():
+    assert oracle_sql_identifier("lab_customers") == "LAB_CUSTOMERS"
+    assert oracle_sql_identifier("id") == "ID"
+    assert oracle_sql_identifier("LAB_CUSTOMERS") == "LAB_CUSTOMERS"
+
+
+def test_oracle_sql_identifier_quoted_lowercase_preserved():
+    qn = quoted_name("lab_customers", quote=True)
+    assert oracle_sql_identifier(qn) == '"lab_customers"'
+
+
+def test_oracle_sql_identifier_mixed_case_quoted():
+    assert oracle_sql_identifier("Lab_Customers") == '"Lab_Customers"'
+
+
+def test_build_oracle_reflected_lowercase_emits_unquoted_upper():
+    """Regression #1370: quoted lowercase breaks ORA-00942 on default Oracle objects."""
+    q = SqlColumnSampleQueryBuilder.build(
+        "oracle",
+        safe_col="id",
+        safe_table="lab_customers",
+        safe_schema="lab_smoke",
+        schema="lab_smoke",
+        limit=4,
+    )
+    s = str(q)
+    assert '"lab_smoke"' not in s
+    assert '"lab_customers"' not in s
+    assert '"id"' not in s
+    assert "LAB_SMOKE.LAB_CUSTOMERS" in s
+    assert "ID IS NOT NULL" in s
+
+
+def test_build_oracle_quoted_lowercase_table_preserved():
+    qn_table = quoted_name("lab_customers", quote=True)
+    q = SqlColumnSampleQueryBuilder.build(
+        "oracle",
+        safe_col="national_id",
+        safe_table="lab_customers",
+        safe_schema="lab_smoke",
+        schema="lab_smoke",
+        limit=2,
+        raw_table=qn_table,
+    )
+    s = str(q)
+    assert '"lab_customers"' in s
+    assert "LAB_SMOKE" in s
+    assert "NATIONAL_ID IS NOT NULL" in s
 
 
 def test_build_mssql_top_nolock():
@@ -238,5 +293,7 @@ def test_column_sample_sql_for_cursor_oracle_literal_rownum():
     assert sql.startswith("-- Data Boar Compliance Scan\n")
     assert "ROWNUM" in sql
     assert "<= 5" in sql
+    assert "S.T" in sql
+    assert '"s"' not in sql
     assert label == "non_null_rownum_oracle"
     assert human == "ROWNUM inner filter (Oracle)"


### PR DESCRIPTION
## Summary

- **#1370:** Oracle column sampling no longer wraps reflected identifiers in lowercase double quotes (`"lab_smoke"."lab_customers"` → `LAB_SMOKE.LAB_CUSTOMERS`). New `oracle_sql_identifier()` emits unquoted uppercase for dictionary names (SQLAlchemy’s lowercase reflection of unquoted objects) and preserves `quoted_name(..., quote=True)` / mixed-case names for deliberately case-sensitive objects.
- **#1369:** `lab-mssql-init` and `lab-oracle-init` one-shot sidecars (same pattern as `lab-redis-init`) seed `lab_smoke_mssql` and `LAB_SMOKE@XEPDB1`; removed non-functional init volume mounts from the main MSSQL/Oracle services.

## Field validation (operator, isolated venv)

Patch applied on top of **PyPI `1.7.4.post10`** (only `connectors/sql_sampling.py` + `connectors/sql_connector.py`) against **lab-smoke-stack** Oracle XE already seeded:

| Target | Findings |
| --- | ---: |
| Lab_Postgres_Synthetic | 20 |
| Lab_MariaDB_Synthetic | 20 |
| Lab_MSSQL_Synthetic | 20 |
| Lab_OracleXE_Synthetic | **20** (was **0** + 20 `sampling_error`) |
| Lab_Redis_Synthetic | 5 |
| `scan_failures` | **none** (was 20 `sampling_error` on Oracle) |

Cross-engine parity restored. `oracle_sql_identifier` spot checks:

- `lab_customers` → `LAB_CUSTOMERS` (unquoted uppercase)
- `quoted_name('lab_customers', quote=True)` → `"lab_customers"`
- `LabCustomers` → `"LabCustomers"`

## Verifiable acceptance (lab-smoke-stack)

After `docker compose up -d` (including `lab-mssql-init` / `lab-oracle-init` completing):

- Postgres / MariaDB / MSSQL / Oracle synthetic targets: **20 findings each**
- Redis synthetic target: **5 findings**
- **No** `sampling_error` rows for Oracle (or other SQL engines) in `scan_failures`

## Test plan

- [x] `tests/test_sql_sampling.py` — Oracle identifier cases + ROWNUM shape
- [x] `./scripts/check-all.sh` green on branch
- [x] Operator field run vs lab-smoke-stack (counts above)

Closes #1370
Closes #1369