### PR TITLE
test(deploy): comparable config-ref harness across corners (#1368)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -14,6 +14,7 @@ Contents of this folder:
 - `ansible/` — Ansible playbooks for Debian/Ubuntu hosts (Docker Compose stack or full install); see `ansible/README.md`.
 - `opentofu/` — OpenTofu/Terraform module for container runtime, ports, and volumes (application config via Ansible).
 - `lab-smoke-stack/` — Docker Compose bundle for LAN-only multi-DB lab smoke tests (PostgreSQL, MariaDB, optional MongoDB).
+- `compat-matrix-config-ref/` — Comparable post-GA config harness across OS corners (files + lab-smoke DBs); see `compat-matrix-config-ref/README.md` (#1368).
 - `samples/` — Tracked starter configs for evaluators (LGPD starter YAML and scope-import pointers); see `samples/README.md`.
 
 All paths in the deploy guides assume you run commands from the **repository root** or from this folder as indicated.

--- a/deploy/compat-matrix-config-ref/README.md
+++ b/deploy/compat-matrix-config-ref/README.md
@@ -1,0 +1,141 @@
+# `compat-matrix-config-ref` — comparable `config.yaml` across corners (#1368)
+
+Companion to the OS `--demo` matrix in
+[`docs/ops/OS_COMPATIBILITY_TESTING_MATRIX.md`](../../docs/ops/OS_COMPATIBILITY_TESTING_MATRIX.md).
+While the `--demo` matrix proves **install and dependencies**, this harness proves what
+it **does not touch**: the post-GA fix surface (post3→post10) — archives, connectors,
+latency, throttler.
+
+> **"The matrix closed" means install, not connectors.** Those are orthogonal axes.
+> The 10-point `--demo` matrix does not execute a single line of connector code.
+
+## Why this lives under `deploy/` (not vault-only, not inside `lab-smoke-stack/`)
+
+| Option | Verdict |
+| --- | --- |
+| **Vault only + repo pointer** | Rejected — acceptance needs a **versioned, cloneable** harness; design invariants must survive without operator-local notes. |
+| **`deploy/lab-smoke-stack/`** | Rejected as home — layer 1 is an **OS-corner filesystem** run (wheelhouse / Podman / metal). Nesting it under the DB Compose bundle implies the wrong owner. |
+| **`docs/ops/` alone** | Rejected — YAML + runnable shell are deploy-time assets, not prose. |
+| **`deploy/compat-matrix-config-ref/`** (here) | **Chosen** — sibling of `lab-smoke-stack/`: layer 2 *targets* that stack; layer 1 stays independent; discoverable next to other deploy harnesses. |
+
+Operator session notes / raw corner transcripts may still live in the private vault; this
+directory is the **canonical tracked source**.
+
+## Two layers, for a reason
+
+| Layer | File | Credential | Runs where |
+| --- | --- | --- | --- |
+| **1 — files** | `config-files.yaml` | **none** | any corner, including the Celeron floor |
+| **2 — databases** | `config-db.yaml` | `pass_from_env` only | corners with LAN reach to `lab-smoke-stack` |
+
+Layer 1 is what produces the **comparable number**. If it required credentials, it would
+stop running on the most constrained corners — exactly the ones that matter most.
+
+## Three design decisions (do not “optimize” these away)
+
+### 1. Comparable output has TWO measures, not one
+
+1. **findings** by sensitivity
+2. **`scan_failures` BY REASON**
+
+For this family of fixes, **absence of error is not a result**. The result is the failure
+staying **visible when it should occur**. A scan that “passes clean” is exactly the symptom
+[#1354](https://github.com/DataBoar/data-boar/issues/1354) and
+[#1348](https://github.com/DataBoar/data-boar/issues/1348) attack — and what produced, in
+the field, *“7 findings become 1, and `scan_failures` with 0 rows”*.
+
+### 2. `max_workers: 1`
+
+The matrix floor is **single-core** (Celeron 900). Comparability requires the **same
+parallelism** on every corner. This is **not** a performance tweak.
+
+### 3. `adaptive_rate_limit: true` even on local targets
+
+On purpose — to prove that enabled does **not** change the **RESULT**, only the pace
+([#1320](https://github.com/DataBoar/data-boar/issues/1320)).
+
+## Corpus: fixtures from this repo
+
+Extracted from `origin/main` (`tests/data/`), **once**, and mounted read-only into each
+corner — same bytes everywhere, checked by SHA-256. Per-corner extraction would open
+space for silent divergence — the failure mode this config exists to catch.
+
+| Fixture | Role |
+| --- | --- |
+| `sample1.zip` · `sample3.tgz` | normal compressed read (#828, #1250, #1257) |
+| `sample2.7z` | needs extra `[compressed]` (py7zr) — see finding below |
+| `sample4.tar.bz2` | **gzip with a lying extension** → `archive_type_mismatch` (#1354 Part A) |
+| `homelab_synthetic/` | baseline PII/ML findings, including `DOB_POSSIBLE_MINOR` |
+
+`sample3.tgz` and `sample4.tar.bz2` have the **same bytes and size**. The lying extension
+is **deliberate** — bait for content-type detection.
+
+## Measured baselines (2026-07-29) — do not re-run to “prove” the PR
+
+### Layer 1 — identical on 6 points
+
+debian, fedora, alpine cp312, alpine cp314, void-musl, and **metal** alpine-emachines
+(Celeron 900):
+
+```
+19 findings | archive_unsupported=1 · archive_type_mismatch=1
+```
+
+A corner with extra `[compressed]` (py7zr) gave **26** and only `archive_type_mismatch=1`.
+
+**Exact delta: 7 findings** = contents of `sample2.7z`, unreadable without py7zr.
+
+The point to keep: the 7 lost findings do **not** vanish silently — they become
+`archive_unsupported` in `scan_failures`. Capacity degraded, and the product **said** it
+degraded. `archive_type_mismatch` appeared on **every** corner — first field exercise of
+#1354 Part A outside unit tests.
+
+### Layer 2 — after #1369 sidecars + #1370 Oracle fix
+
+Against `deploy/lab-smoke-stack`:
+
+| Engine | Findings | `scan_failures` |
+| --- | ---: | --- |
+| Postgres | 20 | none |
+| MariaDB | 20 | none |
+| MSSQL | 20 | none |
+| Oracle | 20 | none |
+| Redis | **5** | none |
+
+Redis **5** is the **correct** baseline, not a defect: the seed exists to expose #1348
+(connector uses `GET` only; PII in hash/list/set must not appear until the fix).
+
+## Usage
+
+```sh
+# Layer 1 — one corner (data-boar on PATH)
+sh deploy/compat-matrix-config-ref/run-config-matrix.sh [work-dir]
+
+# Layer 1 — all container corners; corpus mounted read-only
+# musl corners need: export WHEELHOUSE_DIR=/path/to/wheelhouse-x86-64-v1
+bash deploy/compat-matrix-config-ref/run-across-corners.sh
+
+# Layer 2 — copy config-db.yaml, set REPLACE_WITH_LAB_HOST_IP, export env.example
+# passwords via pass_from_env, then:
+#   data-boar --config ./config-db.local.yaml
+# Compare findings per engine + scan_failures BY REASON (same two measures).
+```
+
+`config.lab-smoke.example.yaml` remains the **quick smoke** copy (inline example
+passwords for the synthetic stack). This directory is the **comparable matrix** contract
+(`max_workers: 1`, throttler on, `pass_from_env` only, dual measures).
+
+## Pitfalls already paid (do not repeat)
+
+- **`--demo` does not return** — runs the scan and leaves the API listening on
+  `127.0.0.1:8088`. These scripts use `--config`, which **returns**.
+- **`--demo` report** goes under `$TMPDIR/data_boar_demo`; with `--config` it respects
+  `report.output_dir`.
+- **`--platform linux/amd64` explicit** on every `podman run` — without it a local tag
+  may be another architecture and the corner runs emulated (30+ min stuck — measured).
+
+## Related
+
+- Seeds / Compose: [`deploy/lab-smoke-stack/`](../lab-smoke-stack/)
+- OS install matrix: [`docs/ops/OS_COMPATIBILITY_TESTING_MATRIX.md`](../../docs/ops/OS_COMPATIBILITY_TESTING_MATRIX.md)
+- Issues: [#1368](https://github.com/DataBoar/data-boar/issues/1368) · [#1354](https://github.com/DataBoar/data-boar/issues/1354) · [#1348](https://github.com/DataBoar/data-boar/issues/1348) · [#1320](https://github.com/DataBoar/data-boar/issues/1320) · [#1237](https://github.com/DataBoar/data-boar/issues/1237)

--- a/deploy/compat-matrix-config-ref/config-db.yaml
+++ b/deploy/compat-matrix-config-ref/config-db.yaml
@@ -1,0 +1,106 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# config-db.yaml — LAYER 2 of the comparable matrix (#1368)
+#
+# Targets: deploy/lab-smoke-stack synthetic engines (LAN hub).
+# Replace REPLACE_WITH_LAB_HOST_IP in every host: field.
+# Credentials: ONLY pass_from_env — never commit passwords.
+#   Export names match deploy/lab-smoke-stack/env.example (or inject from Bitwarden).
+#
+# Fix each target exercises:
+#   Lab_Postgres_Synthetic  -> SQL baseline / control (LAN latency)
+#   Lab_MariaDB_Synthetic   -> MySQL-family driver path
+#   Lab_MSSQL_Synthetic     -> #1297 / #1299 (HML-class timeouts; pymssql)
+#   Lab_OracleXE_Synthetic  -> #1310 / #1316 / #1370 (restricted user, identifiers)
+#   Lab_Redis_Synthetic     -> #1348 Part A (mixed types; GET-only today)
+#   scan.adaptive_rate_limit -> #1320 BoarThrottler (has something to adapt on LAN)
+#
+# Optional cloud lane (commented): Supabase sa-east-1 for genuine remote latency
+# (#1237 / #1337). Keep host/user as operator-local env; never commit real project ids.
+#
+# Baseline measured 2026-07-29 (after #1369 sidecars + #1370 Oracle fix):
+#   Postgres 20 · MariaDB 20 · MSSQL 20 · Oracle 20 · Redis 5 · scan_failures: none
+# Redis=5 is the CORRECT baseline, not a seed bug: seed exposes #1348 (connector
+# uses GET only; PII in hash/list/set must not appear until the fix).
+# ─────────────────────────────────────────────────────────────────────────────
+targets:
+  - name: Lab_Postgres_Synthetic
+    type: database
+    driver: postgresql+psycopg2
+    host: REPLACE_WITH_LAB_HOST_IP
+    port: 55432
+    user: lab_smoke
+    pass_from_env: LAB_PG_PASSWORD
+    database: lab_smoke_pg
+    connect_timeout_seconds: 25
+    read_timeout_seconds: 90
+
+  - name: Lab_MariaDB_Synthetic
+    type: database
+    driver: mysql+pymysql
+    host: REPLACE_WITH_LAB_HOST_IP
+    port: 33306
+    user: lab_smoke
+    pass_from_env: LAB_MY_PASSWORD
+    database: lab_smoke_my
+    connect_timeout_seconds: 25
+    read_timeout_seconds: 90
+
+  - name: Lab_MSSQL_Synthetic
+    type: database
+    driver: mssql+pymssql
+    host: REPLACE_WITH_LAB_HOST_IP
+    port: 14333
+    user: sa
+    pass_from_env: LAB_MSSQL_SA_PASSWORD
+    database: lab_smoke_mssql
+    connect_timeout_seconds: 25
+    read_timeout_seconds: 90
+
+  - name: Lab_OracleXE_Synthetic
+    type: database
+    driver: oracle+oracledb
+    host: REPLACE_WITH_LAB_HOST_IP
+    port: 15211
+    user: lab_smoke
+    pass_from_env: LAB_ORACLE_PASSWORD
+    database: XEPDB1
+    connect_timeout_seconds: 25
+    read_timeout_seconds: 90
+
+  - name: Lab_Redis_Synthetic
+    type: database
+    driver: redis
+    host: REPLACE_WITH_LAB_HOST_IP
+    port: 56379
+    # Redis lab image has no auth by default; leave pass_from_env unset unless
+    # you enable requirepass. When set, export LAB_REDIS_PASSWORD.
+
+  # Optional remote latency lane (#1237 / #1337) — fill from operator vault, not git:
+  # - name: Cloud_Postgres_Remote
+  #   type: database
+  #   driver: postgresql+psycopg2
+  #   host: REPLACE_WITH_REMOTE_PG_HOST
+  #   port: 6543
+  #   user: REPLACE_WITH_REMOTE_PG_USER
+  #   pass_from_env: DATABOAR_REMOTE_PG_PASS
+  #   database: postgres
+  #   connect_timeout_seconds: 25
+  #   read_timeout_seconds: 90
+
+file_scan:
+  sample_limit: 5
+
+report:
+  output_dir: ./out-db
+
+sqlite_path: ./out-db/matrix-db.db
+
+scan:
+  # Same invariants as layer 1 — comparability, not performance.
+  max_workers: 1
+  adaptive_rate_limit: true
+
+api:
+  port: 8099
+  host: 127.0.0.1
+  require_api_key: false

--- a/deploy/compat-matrix-config-ref/config-files.yaml
+++ b/deploy/compat-matrix-config-ref/config-files.yaml
@@ -1,0 +1,53 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# config-files.yaml — LAYER 1 of the comparable matrix (#1368)
+#
+# Runs on ANY corner, including the Celeron 900 floor, with ZERO credentials.
+# This is the layer that produces a comparable number across hosts — the
+# equivalent of `--demo`, but exercising the post-GA archive/file surface.
+#
+# Corpus: fixtures from THIS REPO (tests/data/), extracted from origin/main by
+# the runner. Do NOT invent a new corpus — the sample3.tgz / sample4.tar.bz2
+# pair has the SAME BYTES and a deliberate lying extension; that is the
+# canonical #1354 bait.
+#
+# What each path exercises:
+#   sample1.zip / sample2.7z / sample3.tgz  -> compressed read (#828, #1250, #1257)
+#   sample4.tar.bz2 (gzip with .bz2 suffix) -> archive_type_mismatch (#1354 Part A)
+#   homelab_synthetic/                       -> baseline PII/ML findings
+# ─────────────────────────────────────────────────────────────────────────────
+targets:
+  - name: corpus_compressed
+    type: filesystem
+    path: ./corpus/compressed
+
+  - name: corpus_synthetic
+    type: filesystem
+    path: ./corpus/homelab_synthetic
+
+file_scan:
+  extensions: [.txt, .csv, .pdf, .docx, .xlsx, .md, .json, .yaml, .log]
+  recursive: true
+  scan_compressed: true
+  scan_sqlite_as_db: true
+  # Intentionally low sample_limit: makes #1337 dedupe measurable when layer 2
+  # (databases) joins with columns of repeated values.
+  sample_limit: 5
+  file_sample_max_chars: 12000
+
+report:
+  output_dir: ./out
+
+sqlite_path: ./out/matrix.db
+
+scan:
+  # 1 worker: the matrix floor is single-core (Celeron 900). Comparability
+  # requires the SAME parallelism on every corner — not a performance tweak.
+  max_workers: 1
+  # #1320 — BoarThrottler. On a local target it has nothing to adapt; kept ON
+  # on purpose to prove that enabled does NOT change the RESULT (only pace).
+  adaptive_rate_limit: true
+
+api:
+  port: 8099
+  host: 127.0.0.1
+  require_api_key: false

--- a/deploy/compat-matrix-config-ref/run-across-corners.sh
+++ b/deploy/compat-matrix-config-ref/run-across-corners.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# run-across-corners.sh — LAYER 1 of the comparable config (#1368) on every corner.
+#
+# DESIGN DECISION: extract the corpus ONCE on the host and mount it read-only into
+# each corner. Comparability requires the SAME BYTES everywhere — per-corner
+# extraction would open the door to silent divergence, which is exactly the
+# failure mode this config exists to catch.
+#
+# Comparable output per corner: findings + scan_failures BY REASON.
+#
+# Env:
+#   DATABOAR_REPO       — repo root (default: two levels above this script)
+#   WHEELHOUSE_DIR      — wheelhouse-x86-64-v1 root (required for musl corners)
+#   CONFIG_MATRIX_WORK  — work/results dir (default: ${TMPDIR:-/tmp}/data-boar-config-matrix)
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="${DATABOAR_REPO:-$(cd "$HERE/../.." && pwd)}"
+BASE="${CONFIG_MATRIX_WORK:-${TMPDIR:-/tmp}/data-boar-config-matrix}"
+CORPUS="$BASE/corpus"
+RES="$BASE/res"; rm -rf "$RES"; mkdir -p "$RES"
+WH="${WHEELHOUSE_DIR:-}"
+
+echo "########## corpus (once, from origin/main) ##########"
+if [ ! -d "$CORPUS/compressed" ]; then
+  mkdir -p "$CORPUS"
+  git -C "$REPO" archive origin/main tests/data | tar -x -C "$CORPUS" --strip-components=2 || exit 1
+fi
+echo "  $(find "$CORPUS" -type f | wc -l) files · $(du -sh "$CORPUS" | cut -f1)"
+sha256sum "$CORPUS"/compressed/*.* 2>/dev/null | sed 's|.*/|  |' | head -4
+
+# extract findings + failures inside the corner (same code for container and metal)
+EXTRACT='
+S=$(ls -1 /w/out/POC_SUMMARY_*.md 2>/dev/null | head -1)
+[ -n "$S" ] && grep -o "[0-9]* achados em base · [0-9]* em arquivos · [0-9]* falhas" "$S" | head -1
+python3 - <<PYEOF
+import sqlite3, os
+db="/w/out/matrix.db"
+if os.path.exists(db):
+    c=sqlite3.connect(db)
+    try:
+        for r,n in c.execute("SELECT reason, COUNT(*) FROM scan_failures GROUP BY reason ORDER BY 2 DESC"):
+            print("FAIL:%s=%d" % (r, n))
+    except Exception:
+        print("FAIL:tabela-ausente")
+else: print("FAIL:sem-db")
+PYEOF
+'
+
+corner() {  # $1=label $2=image $3=prep $4=mount_wheelhouse(0|1)
+  NAME="$1"; IMG="$2"; PREP="$3"; MOUNT="$4"
+  printf '  %-16s ' "$NAME"
+  if [ "$MOUNT" = 1 ] && [ -z "$WH" ]; then
+    echo "SKIP (set WHEELHOUSE_DIR for musl corners)"
+    return 0
+  fi
+  ARGS="--rm --replace --name cfg-$NAME --platform linux/amd64 -v $CORPUS:/corpus:ro -v $HERE:/cfg:ro"
+  [ "$MOUNT" = 1 ] && ARGS="$ARGS -v $WH/musllinux:/wh:ro"
+  # shellcheck disable=SC2086
+  podman run $ARGS "$IMG" sh -c "$PREP
+. /v/bin/activate 2>/dev/null || true
+export TMPDIR=/var/tmp/db && mkdir -p \$TMPDIR /w/out && cd /w
+cp /cfg/config-files.yaml ./config.yaml
+sed -i 's|\./corpus|/corpus|g; s|\./out|/w/out|g' ./config.yaml
+data-boar --config ./config.yaml --scan-compressed --content-type-check >/w/scan.log 2>&1
+$EXTRACT" > "$RES/$NAME.txt" 2>&1
+  F=$(grep -o "[0-9]* em arquivos" "$RES/$NAME.txt" | head -1 | grep -o "[0-9]*")
+  FAILS=$(grep "^FAIL:" "$RES/$NAME.txt" | sed 's/^FAIL://' | tr '\n' ' ')
+  if [ -n "${F:-}" ]; then echo "OK ${F} findings | failures: ${FAILS:-none}"
+  else echo "FAIL $(tail -2 "$RES/$NAME.txt" | tr '\n' ' ' | cut -c1-80)"; fi
+}
+
+PREP_DEB='apt-get -qq update >/dev/null 2>&1; DEBIAN_FRONTEND=noninteractive apt-get -qq install -y python3-venv >/dev/null 2>&1
+python3 -m venv /v && . /v/bin/activate && pip install -q data-boar'
+PREP_FED='dnf -q -y install python3 >/dev/null 2>&1; python3 -m venv /v && . /v/bin/activate && pip install -q data-boar'
+PREP_ALP='apk add --no-cache libgomp >/dev/null 2>&1
+python3 -m venv /v && . /v/bin/activate
+pip install -q --find-links /wh data-boar
+pip install -q --no-index --find-links /wh --force-reinstall numpy scipy scikit-learn pandas'
+PREP_VOIDM='xbps-install -Syu xbps >/dev/null 2>&1; xbps-install -Sy python3 python3-devel >/dev/null 2>&1
+python3 -m venv /v && . /v/bin/activate
+pip install -q --find-links /wh data-boar
+pip install -q --no-index --find-links /wh --force-reinstall numpy scipy scikit-learn pandas'
+
+echo; echo "########## corners ##########"
+# --platform linux/amd64 is mandatory: without it a local tag may be another
+# arch and the corner runs emulated (30+ min stuck — measured).
+corner debian   docker.io/library/debian:trixie      "$PREP_DEB"   0
+corner fedora   docker.io/library/fedora:latest      "$PREP_FED"   0
+corner alpine312 docker.io/library/python:3.12-alpine "$PREP_ALP"  1
+corner alpine314 docker.io/library/python:3.14-alpine "$PREP_ALP"  1
+corner voidmusl ghcr.io/void-linux/void-musl-full:latest "$PREP_VOIDM" 1
+echo; echo "CORNERS_DONE"; date

--- a/deploy/compat-matrix-config-ref/run-config-matrix.sh
+++ b/deploy/compat-matrix-config-ref/run-config-matrix.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# run-config-matrix.sh — run LAYER 1 (files) and extract COMPARABLE output. (#1368)
+#
+# Comparable = two measures, not one:
+#   (a) findings by sensitivity
+#   (b) scan_failures BY REASON  <- the axis post-GA fixes attack
+# Absence of error is NOT a result. The result is the failure staying VISIBLE when it should.
+#
+# Usage:  sh run-config-matrix.sh [work-directory]
+# No argument → ./matrix-run. No credentials required.
+set -u
+WORK="${1:-$PWD/matrix-run}"
+HERE=$(cd "$(dirname "$0")" && pwd)
+REPO="${DATABOAR_REPO:-$(cd "$HERE/../.." && pwd)}"
+
+echo "########## corner: $(uname -s)/$(uname -m) · $(grep -m1 '^PRETTY_NAME=' /etc/os-release 2>/dev/null | cut -d'"' -f2) ##########"
+command -v data-boar >/dev/null 2>&1 || { echo "FATAL: data-boar not on PATH"; exit 1; }
+data-boar --version
+
+mkdir -p "$WORK/corpus" "$WORK/out"
+cd "$WORK" || exit 1
+
+echo; echo "=== [1/4] corpus: fixtures from THIS repo (origin/main) ==="
+if [ -d corpus/compressed ]; then
+  echo "  already present, reusing"
+else
+  # git archive reads from ORIGIN (published truth) without touching the working tree
+  git -C "$REPO" archive origin/main tests/data | tar -x -C corpus --strip-components=2 \
+    || { echo "FATAL: could not extract tests/data from origin/main"; exit 1; }
+fi
+echo "  compressed: $(ls corpus/compressed 2>/dev/null | wc -l) files"
+ls -la corpus/compressed 2>/dev/null | awk 'NR>1 && NF>=9 {printf "    %-24s %s bytes\n", $9, $5}'
+echo "  NOTE: sample3.tgz and sample4.tar.bz2 have the SAME bytes; the .bz2 extension LIES (#1354 bait)"
+
+cp "$HERE/config-files.yaml" ./config.yaml
+
+echo; echo "=== [2/4] scan ==="; date
+# --demo does NOT return (starts API and stays in LISTEN); a normal --config scan returns.
+# --scan-compressed and --content-type-check: the #1354 pair.
+data-boar --config ./config.yaml --scan-compressed --content-type-check 2>&1 | tail -12
+date
+
+echo; echo "=== [3/4] findings ==="
+S=$(ls -1 out/POC_SUMMARY_*.md 2>/dev/null | head -1)
+if [ -n "$S" ]; then
+  grep -o "[0-9]* achados em base · [0-9]* em arquivos · [0-9]* falhas" "$S" | head -1 | sed 's/^/  /'
+  grep -E "^### (Alta|Média|Baixa)" -A1 "$S" | grep -vE "^--|^$" | sed 's/^/  /'
+else
+  echo "  NO POC_SUMMARY in out/ — see scan output above"
+fi
+
+echo; echo "=== [4/4] scan_failures BY REASON (what the fixes make visible) ==="
+python3 - <<'PY'
+import sqlite3, os, sys
+db = "out/matrix.db"
+if not os.path.exists(db):
+    print("  no out/matrix.db"); sys.exit(0)
+c = sqlite3.connect(db)
+try:
+    rows = c.execute(
+        "SELECT reason, target_name, COUNT(*) FROM scan_failures GROUP BY reason, target_name ORDER BY 3 DESC"
+    ).fetchall()
+except sqlite3.OperationalError as e:
+    print("  scan_failures table missing:", e); sys.exit(0)
+if not rows:
+    print("  NO failures recorded")
+    print("  WARNING: with sample4.tar.bz2 in corpus, EXPECT >=1 `archive_type_mismatch` (#1354 Part A).")
+    print("     Zero rows here = fix missing from this artifact, or path not exercised.")
+else:
+    for reason, target, n in rows:
+        print("  %-28s %-24s %d" % (reason, target or "-", n))
+    if not any(r[0] == "archive_type_mismatch" for r in rows):
+        print("  WARNING: no `archive_type_mismatch` — check whether #1354 Part A is in this artifact")
+PY
+echo; echo "CONFIG_MATRIX_DONE"; date

--- a/deploy/lab-smoke-stack/README.md
+++ b/deploy/lab-smoke-stack/README.md
@@ -20,6 +20,8 @@ docker compose -f docker-compose.mongo.yml up -d
 
 **Config example for Data Boar:** `config.lab-smoke.example.yaml` (copy elsewhere, set hub host IP, mount `tests/data/compressed` and `tests/data/homelab_synthetic` as documented). External/public API + DB eval: **`docs/ops/LAB_EXTERNAL_CONNECTIVITY_EVAL.md`**.
 
+**Comparable matrix config (#1368):** for cross-corner findings + `scan_failures` by reason (not quick smoke), use **[`../compat-matrix-config-ref/`](../compat-matrix-config-ref/)** — `config-db.yaml` targets this stack with `pass_from_env` only, `max_workers: 1`, and `adaptive_rate_limit: true`.
+
 **SQL seeds:** `init/postgres/` and `init/mariadb/` load via each image’s `/docker-entrypoint-initdb.d` hook. **`init/mssql/`** and **`init/oracle/`** load via one-shot **`lab-mssql-init`** and **`lab-oracle-init`** (same pattern as **`lab-redis-init`**) — the official MSSQL image has no auto-init mount, and gvenzl Oracle hooks run as SYS on the CDB root instead of `XEPDB1`. Scripts: `init/mssql/apply_lab_smoke.sh`, `init/oracle/apply_lab_smoke_pdb.sh`. Corpus: `01_*` base tables, `02_*` linkage + minor-adjacent + shared-phone rows, `03_*` **#1332** INTEGER false-positive repro (`lab_fp_numeric_ids`).
 
 ### Expected detector signal — `lab_fp_numeric_ids` ([#1332](https://github.com/DataBoar/data-boar/issues/1332) / [#1371](https://github.com/DataBoar/data-boar/issues/1371))

--- a/docs/ops/OS_COMPATIBILITY_TESTING_MATRIX.md
+++ b/docs/ops/OS_COMPATIBILITY_TESTING_MATRIX.md
@@ -96,6 +96,17 @@ Install contract (two-step `pipx` + offline ML swap + `boar_fast_filter` inject)
 
 **Redis / DB lab smoke** (separate checklist): Postgres/MariaDB/MSSQL/Oracle synthetic targets **20 findings each**; Redis **5** — see `deploy/lab-smoke-stack/`.
 
+### Tier 3.7: Comparable config-ref (connectors / archives) — [#1368](https://github.com/DataBoar/data-boar/issues/1368)
+
+`--demo` (Tier 3.6) proves **install**. It does **not** run connector code or the post-GA archive/`scan_failures` surface.
+
+Tracked harness: **[`deploy/compat-matrix-config-ref/`](../../deploy/compat-matrix-config-ref/)** — two layers (files / lab-smoke DBs), dual measures (**findings** + **`scan_failures` by reason**), `max_workers: 1`, `adaptive_rate_limit: true`, credentials only via `pass_from_env`.
+
+| Layer | Signal (2026-07-29) |
+| ----- | ------------------- |
+| **1 — files** | **19** findings on 6 corners without `[compressed]`; `archive_unsupported=1` + `archive_type_mismatch=1`. With py7zr: **26** / only mismatch. Lost 7 findings stay visible as `archive_unsupported`. |
+| **2 — DBs** | lab-smoke: Postgres/MariaDB/MSSQL/Oracle **20** each; Redis **5** (correct #1348 baseline); `scan_failures`: none |
+
 ---
 
 ### Tier 4: Solaris lineage (**illumos**) — historical OpenSolaris / exploratory

--- a/docs/ops/OS_COMPATIBILITY_TESTING_MATRIX.pt_BR.md
+++ b/docs/ops/OS_COMPATIBILITY_TESTING_MATRIX.pt_BR.md
@@ -34,6 +34,8 @@ Release verificado: [wheelhouse-x86-64-v1-2026-07-29](https://github.com/DataBoa
 
 **Lab-smoke DB/Redis (checklist separado):** Postgres/MariaDB/MSSQL/Oracle **20 achados cada**; Redis **5** — `deploy/lab-smoke-stack/`.
 
+**Config-ref comparável (conectores / arquivos) — [#1368](https://github.com/DataBoar/data-boar/issues/1368):** o `--demo` prova **instalação**, não conectores. Harness versionado em [`deploy/compat-matrix-config-ref/`](../../deploy/compat-matrix-config-ref/) — duas camadas, duas medidas (achados + `scan_failures` por razão), `max_workers: 1`, `adaptive_rate_limit: true`, só `pass_from_env`. Camada 1: **19** achados idênticos em 6 cantos (sem py7zr); com `[compressed]`: **26**. Camada 2 (lab-smoke): 20/20/20/20 e Redis **5** (baseline correta da #1348).
+
 - Fonte operacional: [TROUBLESHOOTING.pt_BR.md](../TROUBLESHOOTING.pt_BR.md).
 
 **Ordem sugerida:** AlmaLinux 9 → Arch/Manjaro → Void/Alpine (musl) → Gentoo (se houver tempo) → **illumos** (ex. OpenIndiana) / legado **OpenSolaris** só **depois** (Tier 4; OpenSolaris oficial é histórico; preferir **illumos** atual).


### PR DESCRIPTION
## Summary
- Version the post-GA **comparable config** harness under `deploy/compat-matrix-config-ref/` (chosen home: sibling of `lab-smoke-stack/`, not vault-only and not nested inside the Compose bundle).
- Preserve the three design invariants in tracked prose: **dual measures** (findings + `scan_failures` by reason), **`max_workers: 1`**, **`adaptive_rate_limit: true`**; layer 2 uses **`pass_from_env` only** against lab-smoke engines.
- Document measured baselines (layer 1: 19 identical / 26 with py7zr; layer 2: 20×4 + Redis 5) and point from the OS matrix + lab-smoke README.

## Why this location
| Option | Decision |
| --- | --- |
| Vault + repo pointer only | Rejected — acceptance needs a cloneable harness |
| Inside `deploy/lab-smoke-stack/` | Rejected — layer 1 is OS-corner filesystem, not Compose-owned |
| `docs/ops/` only | Rejected — YAML + runners are deploy assets |
| **`deploy/compat-matrix-config-ref/`** | **Chosen** — layer 2 targets lab-smoke; layer 1 stays independent |

## Test plan
- [ ] Skim `deploy/compat-matrix-config-ref/README.md` — three design decisions + baselines match field notes
- [ ] Confirm `config-db.yaml` has no inline passwords / no real hostnames (only `REPLACE_WITH_LAB_HOST_IP` + `pass_from_env`)
- [ ] Optional: `sh deploy/compat-matrix-config-ref/run-config-matrix.sh` on one corner with `data-boar` on PATH (expects 19 + `archive_unsupported`/`archive_type_mismatch` without py7zr)

Closes #1368