### PR TITLE
chore(release): 1.7.4.post11 PyPI publish counter

### DIFF
--- a/.github/workflows/wheelhouse-recipe.yml
+++ b/.github/workflows/wheelhouse-recipe.yml
@@ -91,7 +91,10 @@ jobs:
         env:
           WHEELHOUSE_OUT: ${{ runner.temp }}/wheelhouse
           DOCKER: docker
-        run: bash scripts/wheelhouse/run_cell.sh "${{ steps.canary.outputs.libc }}" "${{ steps.canary.outputs.py }}"
+          # Env (not run-script interpolation) — avoids zizmor template-injection on outputs.
+          CELL_LIBC: ${{ steps.canary.outputs.libc }}
+          CELL_PY: ${{ steps.canary.outputs.py }}
+        run: bash scripts/wheelhouse/run_cell.sh "$CELL_LIBC" "$CELL_PY"
 
   matrix-cell:
     name: Full cell ${{ matrix.libc }} × ${{ matrix.py }}
@@ -123,4 +126,6 @@ jobs:
         env:
           WHEELHOUSE_OUT: ${{ runner.temp }}/wheelhouse
           DOCKER: docker
-        run: bash scripts/wheelhouse/run_cell.sh "${{ matrix.libc }}" "${{ matrix.py }}"
+          CELL_LIBC: ${{ matrix.libc }}
+          CELL_PY: ${{ matrix.py }}
+        run: bash scripts/wheelhouse/run_cell.sh "$CELL_LIBC" "$CELL_PY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ Human-readable summary of user-facing changes. **Detailed release notes:** [docs
 
 ---
 
+## 1.7.4.post11 (release prep — PyPI upload pending)
+
+> Post-release on the **`1.7.4`** public line. **`[project] version = 1.7.4.post11`** and **`[tool.databoar] maturity_build = 262`** (`N=1` discrete fix since post10 baseline `.261`, ADR-0073). **PyPI-only** — no Git tag, no GitHub Release, no container. Operator runs **`publish-pypi`** after merge.
+
+### Fixed / hardened (post11, N=1)
+
+- **Oracle sampling identifiers (#1370):** stop emitting lowercase quoted schema/table/column names on the Oracle dialect path — Oracle folds unquoted identifiers to UPPERCASE, so `"lab_smoke"."lab_customers"` raised `ORA-00942` on **every** column sample while discovery still worked (zero findings vs 20 on peer engines). Validated on lab-smoke: Postgres/MariaDB/MSSQL/Oracle **20** · Redis **5** · `scan_failures` none ([#1372](https://github.com/DataBoar/data-boar/pull/1372)).
+
+### Notes (post11 — not in N)
+
+- **[#1369](https://github.com/DataBoar/data-boar/issues/1369)** — lab-smoke MSSQL/Oracle one-shot init sidecars (test infra).
+- **[#1371](https://github.com/DataBoar/data-boar/issues/1371)** — `#1332` CREDIT_CARD FP fixture with `xfail(strict=True)`.
+- **[#1368](https://github.com/DataBoar/data-boar/issues/1368)** — comparable config-ref harness under `deploy/compat-matrix-config-ref/`.
+- **[#1365](https://github.com/DataBoar/data-boar/issues/1365)** — wheelhouse `x86-64-v1` troubleshooting docs (TROUBLESHOOTING + matrix + PLAN).
+- **Refs [#1367](https://github.com/DataBoar/data-boar/issues/1367)** — reproducible `mariadb` glibc recipe in PLAN ([#1377](https://github.com/DataBoar/data-boar/pull/1377)).
+- **[#1379](https://github.com/DataBoar/data-boar/issues/1379)** — wheelhouse recipe CI ([#1380](https://github.com/DataBoar/data-boar/pull/1380)); wheelhouse remains a **`data-boar-site`** release, not part of this PyPI wheel.
+- Full `N=1` fix set and `postN` ↔ `maturity_build` map: [docs/releases/1.7.4.post11.md](docs/releases/1.7.4.post11.md).
+
+---
+
 ## 1.7.4.post10 (published PyPI **2026-07-28 16:37:23 UTC**)
 
 > Post-release on the **`1.7.4`** public line. **`[project] version = 1.7.4.post10`** and **`[tool.databoar] maturity_build = 261`** (`N=4` discrete fixes since post9 baseline `9fa991c2`, ADR-0073). **PyPI-only** — no Git tag, no GitHub Release, no container. Operator runs **`publish-pypi`** after merge.

--- a/core/about.py
+++ b/core/about.py
@@ -11,7 +11,7 @@ def _package_version() -> str:
 
         return version("data-boar")
     except Exception:
-        return "1.7.4.post10"
+        return "1.7.4.post11"
 
 
 def get_http_user_agent() -> str:

--- a/docs/releases/1.7.4.post11.md
+++ b/docs/releases/1.7.4.post11.md
@@ -1,0 +1,120 @@
+# Release 1.7.4.post11 (PyPI publish counter)
+
+**Status:** Pending PyPI upload after merge (operator **`publish-pypi`** `workflow_dispatch`: build → TestPyPI → PyPI).
+
+**Public line (marketing):** **`1.7.4`** — README, man pages, stakeholder copy unchanged.
+
+**Build / PyPI / About:** **`1.7.4.post11`** — PEP 440 post-release (publish counter per [ADR-0073](../adr/ADR-0073-version-scheme-octet-maturity-and-roadmap.md) § *PyPI dual counters*).
+
+**Not in this drop:** Git tag · GitHub Release · Docker / container image (PyPI-only `.postN`).
+
+**Theme:** **Oracle sampling correctness** — one wheel-affecting fix (`N=1`). Oracle dialect sampling emitted **lowercase quoted** identifiers; Oracle folds unquoted names to UPPERCASE, so every column sample failed with `ORA-00942` while discovery still worked — **zero findings** against a corpus that yields 20 on Postgres/MariaDB/MSSQL.
+
+---
+
+## Mandatory map: `postN` ↔ `maturity_build`
+
+Per ADR-0073: **`postN`** counts **PyPI uploads**; **`maturity_build`** counts **discrete fixes** and may run ahead. This map is the mandatory audit trail.
+
+| PyPI / `[project] version` | `maturity_build` (octet) | Notes |
+| --- | --- | --- |
+| **`1.7.4`** | **`.201`** | GA on PyPI (immutable); release PR **#1024** |
+| **`1.7.4.post1`** | **`.202`** | SQL drivers → optional extras ([#1047](https://github.com/DataBoar/data-boar/issues/1047)) — published |
+| *(fix, unpublished on PyPI)* | **`.203`** | [#1026](https://github.com/DataBoar/data-boar/pull/1026) |
+| *(fix, unpublished on PyPI)* | **`.204`** | [#1028](https://github.com/DataBoar/data-boar/pull/1028) |
+| *(fix, unpublished on PyPI)* | **`.205`** | Deploy / packaging fix train |
+| *(fix, unpublished on PyPI)* | **`.206`** | `main.py --version` without config |
+| *(fix, unpublished on PyPI)* | **`.207`** | `fix(connectors)` symlink / reparse-point loop guard ([#1080](https://github.com/DataBoar/data-boar/pull/1080)) |
+| **`1.7.4.post2`** | **`.208`** | Prior upload on this line |
+| *(fix, unpublished on PyPI)* | **`.209`** | SQL sampling failures now surface in `scan_failures` ([#1140](https://github.com/DataBoar/data-boar/issues/1140), [#1144](https://github.com/DataBoar/data-boar/pull/1144)) |
+| *(fix, unpublished on PyPI)* | **`.210`** | Encrypted/corrupt archive members now surface in `scan_failures` (open-core slice of [#828](https://github.com/DataBoar/data-boar/issues/828), [#1146](https://github.com/DataBoar/data-boar/pull/1146)) |
+| **`1.7.4.post3`** | **`.211`** | Published with `soupsieve` CVE fix ([#1177](https://github.com/DataBoar/data-boar/pull/1177)) |
+| *(fix, unpublished on PyPI)* | **`.212`** | RBAC now defaults to deny on the full route map (#1133). |
+| *(fix, unpublished on PyPI)* | **`.213`** | API key comparison now uses UTF-8 byte-safe `compare_digest` (#1150). |
+| *(fix, unpublished on PyPI)* | **`.214`** | Operator-gated reopen workflow pins were restored to keep governance automation stable. |
+| *(fix, unpublished on PyPI)* | **`.215`** | SQL sampling transaction scope is now isolated per connection (#1194). |
+| *(fix, unpublished on PyPI)* | **`.216`** | One-class compliance profiles now preserve declared-term detections (#1195). |
+| *(fix, unpublished on PyPI)* | **`.217`** | XLSX exports now neutralize formula-leading cells to prevent spreadsheet injection (#1201). |
+| *(fix, unpublished on PyPI)* | **`.218`** | Web exposure defaults now enforce a safe-by-default posture for remote surface (#1202). |
+| *(fix, unpublished on PyPI)* | **`.219`** | Follow-up CodeQL logging and import-cycle hardening landed on the web-exposure path (#1202). |
+| *(fix, unpublished on PyPI)* | **`.220`** | Remaining routes-context import cycle was removed to stabilize route wiring. |
+| *(fix, unpublished on PyPI)* | **`.221`** | Config redaction now masks DSN/URL embedded credentials in `/config` (#1137). |
+| *(fix, unpublished on PyPI)* | **`.222`** | Prefilter now preserves recall parity with active profile terms/regexes (#1198). |
+| *(fix, unpublished on PyPI)* | **`.223`** | Help output now aligns dev invocation and installed command contract (#1130). |
+| *(fix, unpublished on PyPI)* | **`.224`** | Demo sessions now resolve audit trail correctly via `/logs/{session_id}` (#1218). |
+| *(fix, unpublished on PyPI)* | **`.225`** | Logs fallback hardening removed the CodeQL path-injection sink in demo retrieval (#1218, `4bd3e5bc`). |
+| **`1.7.4.post4`** | **`.226`** | Pillow `12.2.0` → `12.3.0` (PYSEC-2026-2253..2257); baseline post3 + `N=15`. |
+| *(fix, unpublished on PyPI)* | **`.227`** | Align ATS import footer skill path to private (#1191). |
+| *(fix, unpublished on PyPI)* | **`.228`** | Standalone HTML form CSRF without WebAuthn (#1231). |
+| *(fix, unpublished on PyPI)* | **`.229`** | Dataverse `org_url` / `token_url` SSRF guards (#1232). |
+| *(fix, unpublished on PyPI)* | **`.230`** | Aggregate archive decompression budgets (#1233). |
+| *(fix, unpublished on PyPI)* | **`.231`** | Reject non-finite `max_expansion_ratio` (nan/inf). |
+| *(fix, unpublished on PyPI)* | **`.232`** | Secret-by-identity lock + reachable JWT GRACE (#1210, #1212). |
+| *(fix, unpublished on PyPI)* | **`.233`** | Fail-closed on non-numeric license `exp` claim. |
+| *(fix, unpublished on PyPI)* | **`.234`** | Honest `build_digest_matched` (no `signature_ok` overclaim) (#1211). |
+| *(fix, unpublished on PyPI)* | **`.235`** | Zero legacy `build_digest_matched` bit on migrate (#1211). |
+| *(fix, unpublished on PyPI)* | **`.236`** | Drop `Invoke-Expression` from `external-review-pack.ps1` (#1192). |
+| *(fix, unpublished on PyPI)* | **`.237`** | Read `.7z` members via py7zr `BytesIOFactory` (#1250, #1248). |
+| *(fix, unpublished on PyPI)* | **`.238`** | Extract pre-budget `.7z` members on budget stop (#1250, #1248). |
+| *(fix, unpublished on PyPI)* | **`.239`** | Orphan session reaper (PID liveness) + interrupt → `interrupted` (#1251). |
+| **`1.7.4.post5`** | **`.240`** | Post5 wave (archives/sessions/security/integrity train); baseline post4 + `N=14` `fix(` — see [1.7.4.post5.md](1.7.4.post5.md). |
+| **`1.7.4.post6`** | **`.241`** | Integrity anchor re-baselines on legitimate release upgrade (#1262 / #1263); baseline `1.7.4.post5` + `N=1` `fix(` — see [1.7.4.post6.md](1.7.4.post6.md). |
+| *(fix, unpublished on PyPI)* | **`.242`** | `.7z` batch-extract / post-extract failures sanitized via `clean_error()` (#1257). |
+| *(fix, unpublished on PyPI)* | **`.243`** | WebAuthn session satisfies `require_api_key` on JSON routes (#1258). |
+| *(fix, unpublished on PyPI)* | **`.244`** | `learned_patterns`: skip bare filenames + anchor `output_file` to `report.output_dir` (#1259, #1260). |
+| **`1.7.4.post7`** | **`.245`** | Post6 baseline `6dc54642` + `N=4` discrete fixes (incl. MSSQL defect-fix #1290/#1289) — see [1.7.4.post7.md](1.7.4.post7.md). |
+| *(fix, unpublished on PyPI)* | **`.246`** | MSSQL pymssql `login_timeout` / `timeout` connect args (#1297, field-caught 2026-07-21). |
+| *(fix, unpublished on PyPI)* | **`.247`** | Integrity anchor: `CRITICAL_MODULES` globs + CLI trust surfacing (#1298, field-caught 2026-07-21). |
+| *(fix, unpublished on PyPI)* | **`.248`** | `pyasn1` → `0.6.4` (PYSEC-2026-3455/3456/3457) ([#1304](https://github.com/DataBoar/data-boar/pull/1304)). |
+| *(fix, unpublished on PyPI)* | **`.249`** | SQL `connect_args` branched per driver: `oracle+oracledb` → `tcp_connect_timeout`; `mssql+pyodbc` → `timeout` only ([#1310](https://github.com/DataBoar/data-boar/pull/1310) / [#1302](https://github.com/DataBoar/data-boar/issues/1302)). |
+| *(fix, unpublished on PyPI)* | **`.250`** | Oracle discovery skips `AUDSYS` + 12c+ system schemas ([#1316](https://github.com/DataBoar/data-boar/pull/1316) / [#1315](https://github.com/DataBoar/data-boar/issues/1315); field Podman 2026-07-23). |
+| **`1.7.4.post8`** | **`.250`** | Published **2026-07-23 13:52:06 UTC** — post7 baseline `b5054d55` + `N=5` `fix(`; see [1.7.4.post8.md](1.7.4.post8.md). |
+| *(fix, unpublished on PyPI)* | **`.251`** | CLI pre-flight output dirs + `--regenerate-report` from SQLite ([#1339](https://github.com/DataBoar/data-boar/pull/1339) / [#1324](https://github.com/DataBoar/data-boar/issues/1324), [#1325](https://github.com/DataBoar/data-boar/issues/1325)). |
+| *(fix, unpublished on PyPI)* | **`.252`** | SQL sampling: deduplicate column values before `sample_limit` cap ([#1343](https://github.com/DataBoar/data-boar/pull/1343) / [#1337](https://github.com/DataBoar/data-boar/issues/1337)). |
+| *(fix, unpublished on PyPI)* | **`.253`** | Production engine wires `BoarThrottler` adaptive rate limiting ([#1344](https://github.com/DataBoar/data-boar/pull/1344) / [#1320](https://github.com/DataBoar/data-boar/issues/1320)). |
+| *(fix, unpublished on PyPI)* | **`.254`** | Learned-patterns audit anti-generic blocklist ([#1345](https://github.com/DataBoar/data-boar/pull/1345) / [#1327](https://github.com/DataBoar/data-boar/issues/1327)). |
+| *(fix, unpublished on PyPI)* | **`.255`** | Unified session report export CLI + per-format wrappers ([#1346](https://github.com/DataBoar/data-boar/pull/1346) / [#1326](https://github.com/DataBoar/data-boar/issues/1326)). |
+| *(fix, unpublished on PyPI)* | **`.256`** | Live scan progress lines + remote DB latency operator docs ([#1347](https://github.com/DataBoar/data-boar/pull/1347) / [#1328](https://github.com/DataBoar/data-boar/issues/1328), [#1323](https://github.com/DataBoar/data-boar/issues/1323)). |
+| *(fix, unpublished on PyPI)* | **`.257`** | `pypdf` `6.13.3` → `6.14.2` — CVE-2026-59935/59936/59937/59938 (DoS via PDF scan path) ([#1336](https://github.com/DataBoar/data-boar/pull/1336)). |
+| **`1.7.4.post9`** | **`.257`** | Published **2026-07-28 10:34:16 UTC** — post8 baseline `8527b0a4` + `N=7` discrete fixes; see [1.7.4.post9.md](1.7.4.post9.md). |
+| *(fix, unpublished on PyPI)* | **`.258`** | Executive PDF/DOCX render Markdown inline (`report/executive_markdown_render.py`, `executive_*.py`) ([#1353](https://github.com/DataBoar/data-boar/issues/1353), [#1357](https://github.com/DataBoar/data-boar/pull/1357)). |
+| *(fix, unpublished on PyPI)* | **`.259`** | Redis: distinguish `WRONGTYPE` from connection failure; per-type value-not-sampled counts ([#1348](https://github.com/DataBoar/data-boar/issues/1348) Part A, [#1357](https://github.com/DataBoar/data-boar/pull/1357)). |
+| *(fix, unpublished on PyPI)* | **`.260`** | `archive_type_mismatch` when compressed extension and magic disagree ([#1354](https://github.com/DataBoar/data-boar/issues/1354) Part A, [#1357](https://github.com/DataBoar/data-boar/pull/1357)). |
+| *(fix, unpublished on PyPI)* | **`.261`** | `pypdf` floor `>=6.14.2` in `pyproject.toml` (future resolve cannot slip below patched pin) ([#1340](https://github.com/DataBoar/data-boar/issues/1340), [#1357](https://github.com/DataBoar/data-boar/pull/1357)). |
+| **`1.7.4.post10`** | **`.261`** | Published **2026-07-28 16:37:23 UTC** — post9 baseline `9fa991c2` + `N=4` discrete fixes; see [1.7.4.post10.md](1.7.4.post10.md). |
+| **`1.7.4.post11`** | **`.262`** | Pending PyPI — post10 baseline `.261` + `N=1` (#1370 Oracle sampling identifiers); see this file. |
+
+---
+
+## Appendix — Fix set used for `N` (`N=1`) (git-literal)
+
+**Boundary:** post10 release commit `62592003` (`chore(release): 1.7.4.post10 PyPI publish counter`).
+
+```bash
+git log 62592003..2de28989 --format='%h %s' -- connectors/sql_connector.py connectors/sql_sampling.py
+# COUNT=1 discrete product fix  →  maturity_build = 261 + 1 = 262
+```
+
+Commits / issues counted toward **`N=1`** (wheel-affecting packages only):
+
+1. **`.262` — [#1370](https://github.com/DataBoar/data-boar/issues/1370):** Oracle sampling SQL used lowercase quoted identifiers (`"lab_smoke"."lab_customers"`); Oracle normalizes unquoted identifiers to UPPERCASE, so every column sample raised `ORA-00942` while discovery succeeded — zero findings vs 20 on peer engines ([#1372](https://github.com/DataBoar/data-boar/pull/1372), `2de28989`).
+
+**Not counted toward `N`:** merge commits; release-prep for post11; [#1369](https://github.com/DataBoar/data-boar/issues/1369) lab-smoke MSSQL/Oracle init sidecars; [#1371](https://github.com/DataBoar/data-boar/issues/1371) `#1332` CREDIT_CARD FP fixture (`xfail`); [#1368](https://github.com/DataBoar/data-boar/issues/1368) compat-matrix config-ref harness; [#1365](https://github.com/DataBoar/data-boar/issues/1365) wheelhouse v1 troubleshooting docs; [#1367](https://github.com/DataBoar/data-boar/issues/1367) / [#1377](https://github.com/DataBoar/data-boar/pull/1377) mariadb glibc recipe in PLAN; [#1379](https://github.com/DataBoar/data-boar/issues/1379) / [#1380](https://github.com/DataBoar/data-boar/pull/1380) wheelhouse recipe CI (not in the PyPI wheel).
+
+---
+
+## Highlights (why post11)
+
+- **Oracle targets find PII again:** sampling identifiers match Oracle’s uppercase fold — validated against lab-smoke: Postgres/MariaDB/MSSQL/Oracle **20** each; Redis **5**; `scan_failures` none ([#1370](https://github.com/DataBoar/data-boar/issues/1370)).
+- Without [#1140](https://github.com/DataBoar/data-boar/issues/1140)/[#1144](https://github.com/DataBoar/data-boar/issues/1144)-class visibility, this class of defect looks like *"this database has no PII"* — a compliance conclusion that is formally tidy and factually wrong.
+
+---
+
+## Install
+
+```bash
+pip install 'data-boar==1.7.4.post11'
+```
+
+See [USAGE.md](../USAGE.md), [QUICKSTART.md](../QUICKSTART.md), and [TROUBLESHOOTING.md](../TROUBLESHOOTING.md).
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-boar"
-version = "1.7.4.post10"
+version = "1.7.4.post11"
 description = "Data Boar — compliance-aware discovery and mapping of personal and sensitive data across databases, files, and APIs (LGPD, GDPR, CCPA, and configurable frameworks)."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -318,6 +318,6 @@ dev = [
 ]
 
 # Operator-only maturity octet (ADR-0073). Never copy into [project].version.
-# postN <-> maturity_build map: docs/releases/1.7.4.post10.md (canonical; includes post1–post9 rows).
+# postN <-> maturity_build map: docs/releases/1.7.4.post11.md (canonical; includes post1–post10 rows).
 [tool.databoar]
-maturity_build = 261
+maturity_build = 262

--- a/tests/test_maturity_build_accounting.py
+++ b/tests/test_maturity_build_accounting.py
@@ -20,6 +20,8 @@ POST9_FIX_COUNT = 7
 POST9_MATURITY_BUILD = 257
 POST10_FIX_COUNT = 4
 POST10_MATURITY_BUILD = 261
+POST11_FIX_COUNT = 1
+POST11_MATURITY_BUILD = 262
 
 
 def _load_pyproject() -> dict:
@@ -35,10 +37,11 @@ def test_post5_maturity_build_accounting_uses_post4_publish_row_not_225() -> Non
     assert (POST5_MATURITY_BUILD - 225) != POST5_FIX_COUNT
 
 
-def test_pyproject_maturity_build_matches_post10_canonical_map() -> None:
+def test_pyproject_maturity_build_matches_post11_canonical_map() -> None:
     data = _load_pyproject()
     maturity = data.get("tool", {}).get("databoar", {}).get("maturity_build")
-    assert maturity == POST10_MATURITY_BUILD
+    assert maturity == POST11_MATURITY_BUILD
+    assert POST10_MATURITY_BUILD + POST11_FIX_COUNT == POST11_MATURITY_BUILD
     assert POST9_MATURITY_BUILD + POST10_FIX_COUNT == POST10_MATURITY_BUILD
     assert POST8_MATURITY_BUILD + POST9_FIX_COUNT == POST9_MATURITY_BUILD
     assert POST7_MATURITY_BUILD + POST8_FIX_COUNT == POST8_MATURITY_BUILD

--- a/tests/test_pyproject_sql_extras.py
+++ b/tests/test_pyproject_sql_extras.py
@@ -64,11 +64,11 @@ def test_sql_optional_extras_present() -> None:
 def test_maturity_build_bumped_for_packaging_fix() -> None:
     data = _load_pyproject()
     maturity = data.get("tool", {}).get("databoar", {}).get("maturity_build")
-    assert maturity == 261
+    assert maturity == 262
 
 
 def test_version_is_174_post_release_not_semver_bump() -> None:
     version = _load_pyproject().get("project", {}).get("version")
-    assert version == "1.7.4.post10"
+    assert version == "1.7.4.post11"
     assert not str(version).startswith("1.7.5")
     assert not str(version).startswith("1.8.")

--- a/uv.lock
+++ b/uv.lock
@@ -809,7 +809,7 @@ validation = [
 
 [[package]]
 name = "data-boar"
-version = "1.7.4.post10"
+version = "1.7.4.post11"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-doc" },


### PR DESCRIPTION
## Summary
- Bump **`1.7.4.post11`** / **`maturity_build = 262`** (`N=1`: [#1370](https://github.com/DataBoar/data-boar/issues/1370) Oracle sampling identifiers).
- CHANGELOG + `docs/releases/1.7.4.post11.md` map; accounting tests updated.
- Notes (not in `N`): #1369, #1371, #1368, #1365, Refs #1367, #1379.
- Small follow-up: wheelhouse canary args via `env` (clears zizmor template-injection that failed local `check-all`).

## Test plan
- [x] `./scripts/check-all.sh` green locally
- [x] `tests/test_maturity_build_accounting.py` + version guards
- [ ] CI green on this PR
- [ ] After merge: TestPyPI → verify → PyPI → stamp