### PR TITLE
chore(release): 1.7.4.post12 — gitpython floor + CI Action pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libmariadb-dev pkg-config
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -108,7 +108,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libmariadb-dev pkg-config
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 
@@ -134,7 +134,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libmariadb-dev pkg-config
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 
@@ -162,7 +162,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libmariadb-dev pkg-config
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 
@@ -228,7 +228,7 @@ jobs:
 
       - name: Set up Python
         if: steps.sonar_token.outputs.present == 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: ${{ matrix.language }}
           # Keep broad default coverage for "just in case" findings.
@@ -48,6 +48,6 @@ jobs:
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/operator-gated-reopen.yml
+++ b/.github/workflows/operator-gated-reopen.yml
@@ -34,7 +34,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.13"
 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -48,7 +48,7 @@ jobs:
       # PyO3 needs a Python interpreter visible at link time; setup-python
       # exports PYO3_PYTHON-compatible env via PATH so cargo builds find it.
       - name: Set up Python (for PyO3 link)
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -49,7 +49,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/wheelhouse-recipe.yml
+++ b/.github/workflows/wheelhouse-recipe.yml
@@ -48,7 +48,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 
@@ -74,7 +74,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 
@@ -115,7 +115,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ Human-readable summary of user-facing changes. **Detailed release notes:** [docs
 
 ---
 
+## 1.7.4.post12 (release prep — PyPI upload pending)
+
+> Post-release on the **`1.7.4`** public line. **`[project] version = 1.7.4.post12`** and **`[tool.databoar] maturity_build = 263`** (`N=1` discrete fix since post11 baseline `.262`, ADR-0073). **PyPI-only** — no Git tag, no GitHub Release, no container. Operator runs **`publish-pypi`** after merge.
+
+### Fixed / hardened (post12, N=1)
+
+- **`gitpython` floor on `[grc-dashboard]` (#1383):** add `gitpython>=3.1.55` next to streamlit/plotly so the nine Dependabot HIGH advisories (runtime via streamlit) cannot resolve below the last patched version — one advisory is only fixed in **3.1.55** (not 3.1.54). Streamlit’s declared range `gitpython!=3.1.19,<4,>=3.0.7` accepts 3.1.55+ (measured). Lock resolves to **3.1.57**. Base install without the extra is unchanged.
+
+### Notes (post12 — not in N)
+
+- **CI Action pins (SHA-exact):** `github/codeql-action` init/analyze → `99df26d4f13ea111d4ec1a7dddef6063f76b97e9` (v4.37.0) — [#1269](https://github.com/DataBoar/data-boar/pull/1269) / [#1268](https://github.com/DataBoar/data-boar/pull/1268); `actions/setup-python` → `ece7cb06caefa5fff74198d8649806c4678c61a1` (v6.3.0) — [#1107](https://github.com/DataBoar/data-boar/pull/1107). Dependabot could not rebase those PRs under the `non_fast_forward` ruleset (#1376).
+- **Not absorbed:** [#1378](https://github.com/DataBoar/data-boar/pull/1378) uv-minor-patch group (47 updates) — keep bulk lockfile churn out of this security floor post.
+- Full `N=1` fix set and `postN` ↔ `maturity_build` map: [docs/releases/1.7.4.post12.md](docs/releases/1.7.4.post12.md).
+
+---
+
 ## 1.7.4.post11 (published PyPI **2026-07-29 21:32:58 UTC**)
 
 > Post-release on the **`1.7.4`** public line. **`[project] version = 1.7.4.post11`** and **`[tool.databoar] maturity_build = 262`** (`N=1` discrete fix since post10 baseline `.261`, ADR-0073). **PyPI-only** — no Git tag, no GitHub Release, no container. Operator runs **`publish-pypi`** after merge.

--- a/core/about.py
+++ b/core/about.py
@@ -11,7 +11,7 @@ def _package_version() -> str:
 
         return version("data-boar")
     except Exception:
-        return "1.7.4.post11"
+        return "1.7.4.post12"
 
 
 def get_http_user_agent() -> str:

--- a/docs/releases/1.7.4.post12.md
+++ b/docs/releases/1.7.4.post12.md
@@ -1,0 +1,120 @@
+# Release 1.7.4.post12 (PyPI publish counter)
+
+**Status:** Pending PyPI upload after merge (operator **`publish-pypi`** `workflow_dispatch`: build → TestPyPI → PyPI).
+
+**Public line (marketing):** **`1.7.4`** — README, man pages, stakeholder copy unchanged.
+
+**Build / PyPI / About:** **`1.7.4.post12`** — PEP 440 post-release (publish counter per [ADR-0073](../adr/ADR-0073-version-scheme-octet-maturity-and-roadmap.md) § *PyPI dual counters*).
+
+**Not in this drop:** Git tag · GitHub Release · Docker / container image (PyPI-only `.postN`).
+
+**Theme:** **Supply-chain floor for `gitpython`** via optional extra `[grc-dashboard]` (`N=1`). Nine Dependabot HIGH alerts on the runtime lockfile path; one advisory is only fixed in **3.1.55** (Dependabot PR #1335 stopped at 3.1.54). Streamlit declares `gitpython!=3.1.19,<4,>=3.0.7` — compatible with `>=3.1.55` (measured against streamlit 1.58.0 and 1.60.0 on PyPI).
+
+---
+
+## Mandatory map: `postN` ↔ `maturity_build`
+
+Per ADR-0073: **`postN`** counts **PyPI uploads**; **`maturity_build`** counts **discrete fixes** and may run ahead. This map is the mandatory audit trail.
+
+| PyPI / `[project] version` | `maturity_build` (octet) | Notes |
+| --- | --- | --- |
+| **`1.7.4`** | **`.201`** | GA on PyPI (immutable); release PR **#1024** |
+| **`1.7.4.post1`** | **`.202`** | SQL drivers → optional extras ([#1047](https://github.com/DataBoar/data-boar/issues/1047)) — published |
+| *(fix, unpublished on PyPI)* | **`.203`** | [#1026](https://github.com/DataBoar/data-boar/pull/1026) |
+| *(fix, unpublished on PyPI)* | **`.204`** | [#1028](https://github.com/DataBoar/data-boar/pull/1028) |
+| *(fix, unpublished on PyPI)* | **`.205`** | Deploy / packaging fix train |
+| *(fix, unpublished on PyPI)* | **`.206`** | `main.py --version` without config |
+| *(fix, unpublished on PyPI)* | **`.207`** | `fix(connectors)` symlink / reparse-point loop guard ([#1080](https://github.com/DataBoar/data-boar/pull/1080)) |
+| **`1.7.4.post2`** | **`.208`** | Prior upload on this line |
+| *(fix, unpublished on PyPI)* | **`.209`** | SQL sampling failures now surface in `scan_failures` ([#1140](https://github.com/DataBoar/data-boar/issues/1140), [#1144](https://github.com/DataBoar/data-boar/pull/1144)) |
+| *(fix, unpublished on PyPI)* | **`.210`** | Encrypted/corrupt archive members now surface in `scan_failures` (open-core slice of [#828](https://github.com/DataBoar/data-boar/issues/828), [#1146](https://github.com/DataBoar/data-boar/pull/1146)) |
+| **`1.7.4.post3`** | **`.211`** | Published with `soupsieve` CVE fix ([#1177](https://github.com/DataBoar/data-boar/pull/1177)) |
+| *(fix, unpublished on PyPI)* | **`.212`** | RBAC now defaults to deny on the full route map (#1133). |
+| *(fix, unpublished on PyPI)* | **`.213`** | API key comparison now uses UTF-8 byte-safe `compare_digest` (#1150). |
+| *(fix, unpublished on PyPI)* | **`.214`** | Operator-gated reopen workflow pins were restored to keep governance automation stable. |
+| *(fix, unpublished on PyPI)* | **`.215`** | SQL sampling transaction scope is now isolated per connection (#1194). |
+| *(fix, unpublished on PyPI)* | **`.216`** | One-class compliance profiles now preserve declared-term detections (#1195). |
+| *(fix, unpublished on PyPI)* | **`.217`** | XLSX exports now neutralize formula-leading cells to prevent spreadsheet injection (#1201). |
+| *(fix, unpublished on PyPI)* | **`.218`** | Web exposure defaults now enforce a safe-by-default posture for remote surface (#1202). |
+| *(fix, unpublished on PyPI)* | **`.219`** | Follow-up CodeQL logging and import-cycle hardening landed on the web-exposure path (#1202). |
+| *(fix, unpublished on PyPI)* | **`.220`** | Remaining routes-context import cycle was removed to stabilize route wiring. |
+| *(fix, unpublished on PyPI)* | **`.221`** | Config redaction now masks DSN/URL embedded credentials in `/config` (#1137). |
+| *(fix, unpublished on PyPI)* | **`.222`** | Prefilter now preserves recall parity with active profile terms/regexes (#1198). |
+| *(fix, unpublished on PyPI)* | **`.223`** | Help output now aligns dev invocation and installed command contract (#1130). |
+| *(fix, unpublished on PyPI)* | **`.224`** | Demo sessions now resolve audit trail correctly via `/logs/{session_id}` (#1218). |
+| *(fix, unpublished on PyPI)* | **`.225`** | Logs fallback hardening removed the CodeQL path-injection sink in demo retrieval (#1218, `4bd3e5bc`). |
+| **`1.7.4.post4`** | **`.226`** | Pillow `12.2.0` → `12.3.0` (PYSEC-2026-2253..2257); baseline post3 + `N=15`. |
+| *(fix, unpublished on PyPI)* | **`.227`** | Align ATS import footer skill path to private (#1191). |
+| *(fix, unpublished on PyPI)* | **`.228`** | Standalone HTML form CSRF without WebAuthn (#1231). |
+| *(fix, unpublished on PyPI)* | **`.229`** | Dataverse `org_url` / `token_url` SSRF guards (#1232). |
+| *(fix, unpublished on PyPI)* | **`.230`** | Aggregate archive decompression budgets (#1233). |
+| *(fix, unpublished on PyPI)* | **`.231`** | Reject non-finite `max_expansion_ratio` (nan/inf). |
+| *(fix, unpublished on PyPI)* | **`.232`** | Secret-by-identity lock + reachable JWT GRACE (#1210, #1212). |
+| *(fix, unpublished on PyPI)* | **`.233`** | Fail-closed on non-numeric license `exp` claim. |
+| *(fix, unpublished on PyPI)* | **`.234`** | Honest `build_digest_matched` (no `signature_ok` overclaim) (#1211). |
+| *(fix, unpublished on PyPI)* | **`.235`** | Zero legacy `build_digest_matched` bit on migrate (#1211). |
+| *(fix, unpublished on PyPI)* | **`.236`** | Drop `Invoke-Expression` from `external-review-pack.ps1` (#1192). |
+| *(fix, unpublished on PyPI)* | **`.237`** | Read `.7z` members via py7zr `BytesIOFactory` (#1250, #1248). |
+| *(fix, unpublished on PyPI)* | **`.238`** | Extract pre-budget `.7z` members on budget stop (#1250, #1248). |
+| *(fix, unpublished on PyPI)* | **`.239`** | Orphan session reaper (PID liveness) + interrupt → `interrupted` (#1251). |
+| **`1.7.4.post5`** | **`.240`** | Post5 wave (archives/sessions/security/integrity train); baseline post4 + `N=14` `fix(` — see [1.7.4.post5.md](1.7.4.post5.md). |
+| **`1.7.4.post6`** | **`.241`** | Integrity anchor re-baselines on legitimate release upgrade (#1262 / #1263); baseline `1.7.4.post5` + `N=1` `fix(` — see [1.7.4.post6.md](1.7.4.post6.md). |
+| *(fix, unpublished on PyPI)* | **`.242`** | `.7z` batch-extract / post-extract failures sanitized via `clean_error()` (#1257). |
+| *(fix, unpublished on PyPI)* | **`.243`** | WebAuthn session satisfies `require_api_key` on JSON routes (#1258). |
+| *(fix, unpublished on PyPI)* | **`.244`** | `learned_patterns`: skip bare filenames + anchor `output_file` to `report.output_dir` (#1259, #1260). |
+| **`1.7.4.post7`** | **`.245`** | Post6 baseline `6dc54642` + `N=4` discrete fixes (incl. MSSQL defect-fix #1290/#1289) — see [1.7.4.post7.md](1.7.4.post7.md). |
+| *(fix, unpublished on PyPI)* | **`.246`** | MSSQL pymssql `login_timeout` / `timeout` connect args (#1297, field-caught 2026-07-21). |
+| *(fix, unpublished on PyPI)* | **`.247`** | Integrity anchor: `CRITICAL_MODULES` globs + CLI trust surfacing (#1298, field-caught 2026-07-21). |
+| *(fix, unpublished on PyPI)* | **`.248`** | `pyasn1` → `0.6.4` (PYSEC-2026-3455/3456/3457) ([#1304](https://github.com/DataBoar/data-boar/pull/1304)). |
+| *(fix, unpublished on PyPI)* | **`.249`** | SQL `connect_args` branched per driver: `oracle+oracledb` → `tcp_connect_timeout`; `mssql+pyodbc` → `timeout` only ([#1310](https://github.com/DataBoar/data-boar/pull/1310) / [#1302](https://github.com/DataBoar/data-boar/issues/1302)). |
+| *(fix, unpublished on PyPI)* | **`.250`** | Oracle discovery skips `AUDSYS` + 12c+ system schemas ([#1316](https://github.com/DataBoar/data-boar/pull/1316) / [#1315](https://github.com/DataBoar/data-boar/issues/1315); field Podman 2026-07-23). |
+| **`1.7.4.post8`** | **`.250`** | Published **2026-07-23 13:52:06 UTC** — post7 baseline `b5054d55` + `N=5` `fix(`; see [1.7.4.post8.md](1.7.4.post8.md). |
+| *(fix, unpublished on PyPI)* | **`.251`** | CLI pre-flight output dirs + `--regenerate-report` from SQLite ([#1339](https://github.com/DataBoar/data-boar/pull/1339) / [#1324](https://github.com/DataBoar/data-boar/issues/1324), [#1325](https://github.com/DataBoar/data-boar/issues/1325)). |
+| *(fix, unpublished on PyPI)* | **`.252`** | SQL sampling: deduplicate column values before `sample_limit` cap ([#1343](https://github.com/DataBoar/data-boar/pull/1343) / [#1337](https://github.com/DataBoar/data-boar/issues/1337)). |
+| *(fix, unpublished on PyPI)* | **`.253`** | Production engine wires `BoarThrottler` adaptive rate limiting ([#1344](https://github.com/DataBoar/data-boar/pull/1344) / [#1320](https://github.com/DataBoar/data-boar/issues/1320)). |
+| *(fix, unpublished on PyPI)* | **`.254`** | Learned-patterns audit anti-generic blocklist ([#1345](https://github.com/DataBoar/data-boar/pull/1345) / [#1327](https://github.com/DataBoar/data-boar/issues/1327)). |
+| *(fix, unpublished on PyPI)* | **`.255`** | Unified session report export CLI + per-format wrappers ([#1346](https://github.com/DataBoar/data-boar/pull/1346) / [#1326](https://github.com/DataBoar/data-boar/issues/1326)). |
+| *(fix, unpublished on PyPI)* | **`.256`** | Live scan progress lines + remote DB latency operator docs ([#1347](https://github.com/DataBoar/data-boar/pull/1347) / [#1328](https://github.com/DataBoar/data-boar/issues/1328), [#1323](https://github.com/DataBoar/data-boar/issues/1323)). |
+| *(fix, unpublished on PyPI)* | **`.257`** | `pypdf` `6.13.3` → `6.14.2` — CVE-2026-59935/59936/59937/59938 (DoS via PDF scan path) ([#1336](https://github.com/DataBoar/data-boar/pull/1336)). |
+| **`1.7.4.post9`** | **`.257`** | Published **2026-07-28 10:34:16 UTC** — post8 baseline `8527b0a4` + `N=7` discrete fixes; see [1.7.4.post9.md](1.7.4.post9.md). |
+| *(fix, unpublished on PyPI)* | **`.258`** | Executive PDF/DOCX render Markdown inline (`report/executive_markdown_render.py`, `executive_*.py`) ([#1353](https://github.com/DataBoar/data-boar/issues/1353), [#1357](https://github.com/DataBoar/data-boar/pull/1357)). |
+| *(fix, unpublished on PyPI)* | **`.259`** | Redis: distinguish `WRONGTYPE` from connection failure; per-type value-not-sampled counts ([#1348](https://github.com/DataBoar/data-boar/issues/1348) Part A, [#1357](https://github.com/DataBoar/data-boar/pull/1357)). |
+| *(fix, unpublished on PyPI)* | **`.260`** | `archive_type_mismatch` when compressed extension and magic disagree ([#1354](https://github.com/DataBoar/data-boar/issues/1354) Part A, [#1357](https://github.com/DataBoar/data-boar/pull/1357)). |
+| *(fix, unpublished on PyPI)* | **`.261`** | `pypdf` floor `>=6.14.2` in `pyproject.toml` (future resolve cannot slip below patched pin) ([#1340](https://github.com/DataBoar/data-boar/issues/1340), [#1357](https://github.com/DataBoar/data-boar/pull/1357)). |
+| **`1.7.4.post10`** | **`.261`** | Published **2026-07-28 16:37:23 UTC** — post9 baseline `9fa991c2` + `N=4` discrete fixes; see [1.7.4.post10.md](1.7.4.post10.md). |
+| **`1.7.4.post11`** | **`.262`** | Published **2026-07-29 21:32:58 UTC** — post10 baseline `.261` + `N=1` (#1370 Oracle sampling identifiers); see [1.7.4.post11.md](1.7.4.post11.md). |
+| **`1.7.4.post12`** | **`.263`** | Pending PyPI — post11 baseline `.262` + `N=1` (gitpython `>=3.1.55` floor on `[grc-dashboard]`); see this file. |
+
+---
+
+## Appendix — Fix set used for `N` (`N=1`) (git-literal)
+
+**Boundary:** post11 release commit (published stamp on `main` after `1.7.4.post11` upload).
+
+Counted toward **`N=1`** (wheel-affecting packaging only):
+
+1. **`.263` — [#1383](https://github.com/DataBoar/data-boar/issues/1383):** raise `gitpython` floor to `>=3.1.55` on the `[grc-dashboard]` extra so streamlit’s transitive GitPython cannot resolve below the last patched version covering nine Dependabot HIGH advisories (GHSA-94p4-4cq8-9g67 first_patched **3.1.55**). Lock resolves to **3.1.57**.
+
+**Not counted toward `N`:**
+
+- CI Action pin bumps (SHA-exact): [#1269](https://github.com/DataBoar/data-boar/pull/1269) / [#1268](https://github.com/DataBoar/data-boar/pull/1268) `github/codeql-action` → `99df26d4f13ea111d4ec1a7dddef6063f76b97e9` (v4.37.0); [#1107](https://github.com/DataBoar/data-boar/pull/1107) `actions/setup-python` → `ece7cb06caefa5fff74198d8649806c4678c61a1` (v6.3.0).
+- [#1378](https://github.com/DataBoar/data-boar/pull/1378) uv-minor-patch group (47 updates) — **not** absorbed (undiagnosed CI failures on a stale base; keep security floor separate from bulk lockfile churn).
+
+---
+
+## Highlights (why post12)
+
+- **`[grc-dashboard]` installs cannot pull vulnerable GitPython:** explicit `gitpython>=3.1.55` beside streamlit/plotly (base install unchanged).
+- **Dependabot Action PRs unblocked in-repo:** SHA pins advanced where the bot cannot rebase under the `non_fast_forward` ruleset.
+
+---
+
+## Install
+
+```bash
+pip install 'data-boar==1.7.4.post12'
+# dashboard extra (pulls streamlit → gitpython>=3.1.55):
+pip install 'data-boar[grc-dashboard]==1.7.4.post12'
+```
+
+See [USAGE.md](../USAGE.md), [QUICKSTART.md](../QUICKSTART.md), and [TROUBLESHOOTING.md](../TROUBLESHOOTING.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-boar"
-version = "1.7.4.post11"
+version = "1.7.4.post12"
 description = "Data Boar — compliance-aware discovery and mapping of personal and sensitive data across databases, files, and APIs (LGPD, GDPR, CCPA, and configurable frameworks)."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -174,7 +174,9 @@ dataformats = ["pyarrow>=14.0.0", "fastavro>=1.9.0", "dbfread>=2.0.7"]
 # Legacy ".doc" samples: mammoth reads ZIP-based OOXML; binary Word 97-2003 often yields empty content (see docs/TROUBLESHOOTING.md).
 legacy-doc = ["mammoth>=1.6.0"]
 # GRC executive JSON dashboard (Streamlit + Plotly). Run: ``streamlit run app/dashboard.py``.
-grc-dashboard = ["streamlit>=1.58.0", "plotly>=6.8.0"]
+# gitpython floor: streamlit pulls GitPython; pin so resolves cannot slip below
+# 3.1.55 (nine Dependabot HIGH advisories; one only fixed in 3.1.55 — not 3.1.54).
+grc-dashboard = ["streamlit>=1.58.0", "plotly>=6.8.0", "gitpython>=3.1.55"]
 
 [tool.uv]
 # rpds-py is transitive (referencing -> jsonschema). Upstream pivoted to CalVer at
@@ -318,6 +320,6 @@ dev = [
 ]
 
 # Operator-only maturity octet (ADR-0073). Never copy into [project].version.
-# postN <-> maturity_build map: docs/releases/1.7.4.post11.md (canonical; includes post1–post10 rows).
+# postN <-> maturity_build map: docs/releases/1.7.4.post12.md (canonical; includes post1–post11 rows).
 [tool.databoar]
-maturity_build = 262
+maturity_build = 263

--- a/tests/test_maturity_build_accounting.py
+++ b/tests/test_maturity_build_accounting.py
@@ -22,6 +22,8 @@ POST10_FIX_COUNT = 4
 POST10_MATURITY_BUILD = 261
 POST11_FIX_COUNT = 1
 POST11_MATURITY_BUILD = 262
+POST12_FIX_COUNT = 1
+POST12_MATURITY_BUILD = 263
 
 
 def _load_pyproject() -> dict:
@@ -37,10 +39,11 @@ def test_post5_maturity_build_accounting_uses_post4_publish_row_not_225() -> Non
     assert (POST5_MATURITY_BUILD - 225) != POST5_FIX_COUNT
 
 
-def test_pyproject_maturity_build_matches_post11_canonical_map() -> None:
+def test_pyproject_maturity_build_matches_post12_canonical_map() -> None:
     data = _load_pyproject()
     maturity = data.get("tool", {}).get("databoar", {}).get("maturity_build")
-    assert maturity == POST11_MATURITY_BUILD
+    assert maturity == POST12_MATURITY_BUILD
+    assert POST11_MATURITY_BUILD + POST12_FIX_COUNT == POST12_MATURITY_BUILD
     assert POST10_MATURITY_BUILD + POST11_FIX_COUNT == POST11_MATURITY_BUILD
     assert POST9_MATURITY_BUILD + POST10_FIX_COUNT == POST10_MATURITY_BUILD
     assert POST8_MATURITY_BUILD + POST9_FIX_COUNT == POST9_MATURITY_BUILD

--- a/tests/test_pyproject_sql_extras.py
+++ b/tests/test_pyproject_sql_extras.py
@@ -64,11 +64,11 @@ def test_sql_optional_extras_present() -> None:
 def test_maturity_build_bumped_for_packaging_fix() -> None:
     data = _load_pyproject()
     maturity = data.get("tool", {}).get("databoar", {}).get("maturity_build")
-    assert maturity == 262
+    assert maturity == 263
 
 
 def test_version_is_174_post_release_not_semver_bump() -> None:
     version = _load_pyproject().get("project", {}).get("version")
-    assert version == "1.7.4.post11"
+    assert version == "1.7.4.post12"
     assert not str(version).startswith("1.7.5")
     assert not str(version).startswith("1.8.")

--- a/uv.lock
+++ b/uv.lock
@@ -809,7 +809,7 @@ validation = [
 
 [[package]]
 name = "data-boar"
-version = "1.7.4.post11"
+version = "1.7.4.post12"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-doc" },
@@ -899,6 +899,7 @@ dl = [
     { name = "sentence-transformers" },
 ]
 grc-dashboard = [
+    { name = "gitpython" },
     { name = "plotly" },
     { name = "streamlit" },
 ]
@@ -995,6 +996,7 @@ requires-dist = [
     { name = "flask", specifier = ">=3.1.3" },
     { name = "flask-sqlalchemy", specifier = ">=3.1.1" },
     { name = "fonttools", specifier = ">=4.63.0" },
+    { name = "gitpython", marker = "extra == 'grc-dashboard'", specifier = ">=3.1.55" },
     { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'", specifier = ">=3.5.1" },
     { name = "h11", specifier = ">=0.16.0" },
     { name = "httpcore", specifier = ">=1.0.9" },
@@ -1340,14 +1342,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.50"
+version = "3.1.57"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/0d/132ed135c871b6bf91adf16a0e43797cd535b81d4973b5d09291c54fc5ee/gitpython-3.1.57.tar.gz", hash = "sha256:c493ec57c0ef6b19743798b6a5af859c71814b524e7e6f97baa2f8e658961488", size = 225898, upload-time = "2026-07-26T07:33:26.351Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+    { url = "https://files.pythonhosted.org/packages/41/6e/2139de986d9c7c3ac86f1f8be43858ce90bdfe2f7175e6c80c650ba15242/gitpython-3.1.57-py3-none-any.whl", hash = "sha256:4ccf7d73c10f5c9e76043fbb2675ac5a1b3ff5b41e648f56bcbed5f63792ecaf", size = 217151, upload-time = "2026-07-26T07:33:24.838Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **N=1 (wheel):** floor `gitpython>=3.1.55` on `[grc-dashboard]` so streamlit’s transitive GitPython cannot resolve below the last patched version covering nine Dependabot HIGH advisories (one advisory only fixed in **3.1.55**, not 3.1.54). Streamlit range `!=3.1.19,<4,>=3.0.7` accepts 3.1.55+ (measured). Lock: **3.1.50 → 3.1.57**.
- **Out of N:** SHA-exact CI Action bumps — `github/codeql-action` init/analyze → `99df26d4…` (v4.37.0) [#1269](https://github.com/DataBoar/data-boar/pull/1269)/[#1268](https://github.com/DataBoar/data-boar/pull/1268); `actions/setup-python` → `ece7cb06…` (v6.3.0) [#1107](https://github.com/DataBoar/data-boar/pull/1107).
- **Release:** `1.7.4.post12` / `maturity_build=263` (post11 baseline `.262` + N=1), CHANGELOG + `docs/releases/1.7.4.post12.md`.
- **Not absorbed:** [#1378](https://github.com/DataBoar/data-boar/pull/1378) uv-minor-patch group (undiagnosed CI on stale base).

Closes #1383

## Dependabot verification

Pre-merge API still shows 9 open GitPython/gitpython HIGH on `uv.lock` (expected — default branch still resolves 3.1.50). After merge, re-check:

```bash
gh api repos/DataBoar/data-boar/dependabot/alerts --jq '[.[]|select(.state=="open")|.dependency.package.name]|unique'
```

Floor is `>=3.1.55` (not 3.1.54) because GHSA-94p4-4cq8-9g67 `first_patched_version` is **3.1.55**.

## Test plan

- [x] `uv run pytest tests/test_maturity_build_accounting.py tests/test_pyproject_sql_extras.py tests/test_about_version_matches_pyproject.py`
- [x] `./scripts/check-all.sh` green locally (ADR-0080)
- [x] CI green on this PR
- [x] After merge: Dependabot open package names no longer include GitPython/gitpython
- [x] Operator-only: `publish-pypi` (TestPyPI → PyPI → stamp) — **not** in this PR