### PR TITLE
docs(release): mark 1.7.4.post12 published on PyPI (2026-07-30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Human-readable summary of user-facing changes. **Detailed release notes:** [docs
 
 ---
 
-## 1.7.4.post12 (release prep — PyPI upload pending)
+## 1.7.4.post12 (published PyPI **2026-07-30 00:42:09 UTC**)
 
 > Post-release on the **`1.7.4`** public line. **`[project] version = 1.7.4.post12`** and **`[tool.databoar] maturity_build = 263`** (`N=1` discrete fix since post11 baseline `.262`, ADR-0073). **PyPI-only** — no Git tag, no GitHub Release, no container. Operator runs **`publish-pypi`** after merge.
 

--- a/docs/releases/1.7.4.post12.md
+++ b/docs/releases/1.7.4.post12.md
@@ -1,6 +1,6 @@
 # Release 1.7.4.post12 (PyPI publish counter)
 
-**Status:** Pending PyPI upload after merge (operator **`publish-pypi`** `workflow_dispatch`: build → TestPyPI → PyPI).
+**Status:** Published on PyPI (**2026-07-30 00:42:09 UTC**). Operator **`publish-pypi`** `workflow_dispatch`: build → TestPyPI → PyPI.
 
 **Public line (marketing):** **`1.7.4`** — README, man pages, stakeholder copy unchanged.
 
@@ -83,7 +83,7 @@ Per ADR-0073: **`postN`** counts **PyPI uploads**; **`maturity_build`** counts *
 | *(fix, unpublished on PyPI)* | **`.261`** | `pypdf` floor `>=6.14.2` in `pyproject.toml` (future resolve cannot slip below patched pin) ([#1340](https://github.com/DataBoar/data-boar/issues/1340), [#1357](https://github.com/DataBoar/data-boar/pull/1357)). |
 | **`1.7.4.post10`** | **`.261`** | Published **2026-07-28 16:37:23 UTC** — post9 baseline `9fa991c2` + `N=4` discrete fixes; see [1.7.4.post10.md](1.7.4.post10.md). |
 | **`1.7.4.post11`** | **`.262`** | Published **2026-07-29 21:32:58 UTC** — post10 baseline `.261` + `N=1` (#1370 Oracle sampling identifiers); see [1.7.4.post11.md](1.7.4.post11.md). |
-| **`1.7.4.post12`** | **`.263`** | Pending PyPI — post11 baseline `.262` + `N=1` (gitpython `>=3.1.55` floor on `[grc-dashboard]`); see this file. |
+| **`1.7.4.post12`** | **`.263`** | Published **2026-07-30 00:42:09 UTC** — post11 baseline `.262` + `N=1` (gitpython `>=3.1.55` floor on `[grc-dashboard]`); see this file. |
 
 ---
 


### PR DESCRIPTION
## Summary
- Stamp release paperwork after PyPI upload of **1.7.4.post12** (wheel `upload_time` **2026-07-30 00:42:09 UTC**).
- Updates `**Status:**`, the `postN` ↔ `maturity_build` map row, and the CHANGELOG heading (pending → published).

## Test plan
- [x] Diff limited to the three stamp lines in `docs/releases/1.7.4.post12.md` + `CHANGELOG.md`
- [x] Matches post11 stamp pattern (#1382)
- [x] `./scripts/check-all.sh` green locally
- [ ] CI green on this PR