### PR TITLE
ci(sbom): attach provenance when Release is created (#1388)

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -12,7 +12,7 @@ permissions:
   push:
     tags: ["v*"]
   release:
-    types: [published]
+    types: [published, created]
   pull_request:
     branches: [main, master]
     paths:
@@ -138,7 +138,11 @@ jobs:
             TAG="${GITHUB_REF#refs/tags/}"
           fi
           if ! gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            echo "No GitHub Release for $TAG yet — artifacts remain on the workflow run only."
+            echo "::warning title=SBOM nao anexado::Release $TAG nao existe ainda; assets ficaram apenas no run. Crie a Release para disparar o upload."
+            {
+              echo "### SBOM nao anexado"
+              echo "Release \`$TAG\` inexistente no momento do push da tag."
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
           gh release upload "$TAG" sbom-python.cdx.json sbom-docker-image.cdx.json build-digest.txt release-manifest.json \


### PR DESCRIPTION
## Summary

- Add `release: types: [published, created]` so SBOM upload runs when the operator creates the GitHub Release (not only on lucky tag-then-release ordering).
- Replace the silent `exit 0` skip with `::warning::` + `$GITHUB_STEP_SUMMARY` when the Release does not exist yet (still non-fatal on tag push).
- Does **not** auto-create Releases — attach-only; create remains a human act.

Closes #1388

## Contabilidade

`.github/workflows/sbom.yml` is outside the wheel `packages` list — **fora de N**. `version` / `maturity_build` unchanged (`1.7.4.post12` / `263`).

## Test plan

- [x] Diff limited to `.github/workflows/sbom.yml`
- [x] `./scripts/check-all.sh` green (incl. zizmor on `sbom.yml`)
- [x] CI green on this PR
- [ ] After merge + operator creates `v1.7.4.post12` Release:  
  `gh release view v1.7.4.post12 --json assets --jq '[.assets[].name]|sort'`  
  → `["build-digest.txt","release-manifest.json","sbom-docker-image.cdx.json","sbom-python.cdx.json"]`