### PR TITLE
fix(docker): x86-64-v1 wheelhouse image + distroless libsqlite3 (#1387)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,10 +15,17 @@ docs/private.example/**
 .gitignore
 .github
 .venv
+**/.venv
 venv
+**/venv
 env
 __pycache__
+**/__pycache__
 *.pyc
+rust/**/target
+**/.ruff_cache
+**/.mypy_cache
+**/.pytest_cache
 .pytest_cache
 .ruff_cache
 .mypy_cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,16 @@
 FROM python:3.13-slim@sha256:3a2c25932e66f706172de831a1b283d491c53ef876cd7fc55a62bcf9a6dd2c61 AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential gcc g++ pkg-config curl ca-certificates \
+    build-essential gcc g++ pkg-config curl ca-certificates binutils \
     libpq-dev libffi-dev libssl-dev unixodbc-dev default-libmysqlclient-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 COPY requirements.txt /app/requirements.txt
 COPY . /app
+
+# Hosted x86-64-v1 wheelhouse (DataBoar/data-boar-site). Override for offline builds.
+ARG WHEELHOUSE_TAG=wheelhouse-x86-64-v1-2026-07-29
 
 RUN pip uninstall -y wheel || true && \
     pip install --no-cache-dir --upgrade "pip>=25.3" && \
@@ -27,18 +30,10 @@ RUN pip uninstall -y wheel || true && \
     pip install --no-cache-dir \
         "psycopg2-binary>=2.9.11" "pymysql>=1.2.0" "mariadb>=1.1.14" \
         "pyodbc>=5.3.0" "oracledb>=4.0.1" && \
+    WHEELHOUSE_TAG="${WHEELHOUSE_TAG}" bash /app/scripts/docker/apply_wheelhouse_v1.sh && \
+    rm -rf /tmp/wheelhouse-v1-glibc-cp313 && \
     (find /usr/local/lib/python3.13/site-packages -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true) && \
     (find /usr/local/lib/python3.13/site-packages -name "*.pyc" -delete 2>/dev/null || true)
-
-# boar_fast_filter (PyO3): build against glibc in builder; wheel lands in site-packages (#1028 PR-A).
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable \
-    && . /root/.cargo/env \
-    && pip install --no-cache-dir "maturin>=1.14.0" \
-    && cd /app/rust/boar_fast_filter \
-    && maturin build --release -o /tmp/boar-wheels \
-    && pip install --no-cache-dir /tmp/boar-wheels/boar_fast_filter*.whl \
-    && python -c "import boar_fast_filter" \
-    && rm -rf /root/.cargo/registry /root/.cargo/git /tmp/boar-wheels
 
 # -----------------------------------------------------------------------------
 # Stage 2: assemble runtime rootfs (shell stage — not shipped)

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -13,6 +13,7 @@ All scripts assume the **repository root** is the parent of `scripts/` (run them
 | [../grype-image-gate.sh](../grype-image-gate.sh) / [../grype-image-gate.ps1](../grype-image-gate.ps1) | Grype gate (#1028): **`--fail-on high --only-fixed`** + repo [`.grype.yaml`](../../.grype.yaml) VEX; actionable High/Critical only. |
 | [docker-image-smoke.sh](docker-image-smoke.sh) / [docker-image-smoke.ps1](docker-image-smoke.ps1) | Post-build smoke (#1028): public version, no octet leak, `boar_fast_filter` import, **TLS** probe (`httpx` → `https://example.com`). |
 | [collect-runtime-rootfs.sh](collect-runtime-rootfs.sh) | Bundle `/usr/local`, DB/TLS `.so`, CA certs for distroless runtime (#1028). |
+| [apply_wheelhouse_v1.sh](apply_wheelhouse_v1.sh) | Builder helper (#1387): force-reinstall numpy/scipy/sklearn/pandas + `boar_fast_filter` from hosted **x86-64-v1** wheelhouse (`--no-index`), with `popcnt`/umath size gates. |
 | [DataBoarDockerCommon.ps1](DataBoarDockerCommon.ps1)                   | Shared helpers (dot-sourced only).                                                                                                                  |
 
 ## Typical flows

--- a/scripts/docker/apply_wheelhouse_v1.sh
+++ b/scripts/docker/apply_wheelhouse_v1.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Apply hosted x86-64-v1 wheelhouse ML wheels over a PyPI install (#1387).
+#
+# Why: `pip install -r requirements.txt` pulls PyPI numpy/scipy with x86-64-v2+
+# (popcnt). The published image must run on alpine-emachines (Celeron 900 /
+# SSSE3-only, gate #821). `--find-links` alone does not prefer wheelhouse —
+# force-reinstall with --no-index is required (same contract as pipx path).
+#
+# Image is glibc (python:3.13-slim → distroless cc-debian13): use manylinux
+# cp313 cells from DataBoar/data-boar-site release wheelhouse-x86-64-v1-*.
+#
+# Usage (inside builder stage, after pip install -r requirements.txt):
+#   bash scripts/docker/apply_wheelhouse_v1.sh
+#
+# Optional env:
+#   WHEELHOUSE_TAG   default wheelhouse-x86-64-v1-2026-07-29
+#   WHEELHOUSE_DIR   if set and non-empty, skip download and use that folder
+#   SKIP_POPCNT_GATE set to 1 to skip objdump gate (not for release builds)
+set -euo pipefail
+
+WHEELHOUSE_TAG="${WHEELHOUSE_TAG:-wheelhouse-x86-64-v1-2026-07-29}"
+BASE_URL="${WHEELHOUSE_BASE_URL:-https://github.com/DataBoar/data-boar-site/releases/download/${WHEELHOUSE_TAG}}"
+WORKDIR="${WHEELHOUSE_DIR:-/tmp/wheelhouse-v1-glibc-cp313}"
+
+# Filenames must match the hosted release assets (manylinux / cp313).
+WHEELS=(
+  "numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+  "scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+  "scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+  "pandas-3.0.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl"
+  "boar_fast_filter-0.1.0-cp38-abi3-manylinux_2_28_x86_64.whl"
+)
+
+# Expected sha256 from release SHA256SUMS (wheelhouse-x86-64-v1-2026-07-29).
+declare -A EXPECTED_SHA=(
+  ["numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"]="d301efd02e390bd2d135205c25cd7b7fc82ec353aa3985528745601bfb67c2d6"
+  ["scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"]="a9c3a1ae4de02b8eff37b87a7d5af19bfdbb029cc62b855fd8813acc2775c5bf"
+  ["scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"]="0d28c1b992d7a6c0951869560d0090c24ccfe44282fb2f5d7b3814b4232de418"
+  ["pandas-3.0.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl"]="4b11c36e218331d0387cbe3a0a5f75162357a1d92d57b2b08a336ff94b19b2be"
+  ["boar_fast_filter-0.1.0-cp38-abi3-manylinux_2_28_x86_64.whl"]="f664cb016fed2d530e94fa9946bb783c294e052ef19ceae4dd80bd6d12a9125a"
+)
+
+UMATH_MAX_BYTES="${NUMPY_UMATH_SO_MAX_BYTES:-8000000}"
+POPCNT_MAX="${NUMPY_POPCNT_MAX:-0}"
+
+mkdir -p "$WORKDIR"
+cd "$WORKDIR"
+
+need_download=0
+for whl in "${WHEELS[@]}"; do
+  if [[ ! -f "$whl" ]]; then
+    need_download=1
+    break
+  fi
+done
+
+if [[ "$need_download" -eq 1 ]]; then
+  echo "=== downloading ${WHEELHOUSE_TAG} manylinux cp313 wheels ==="
+  for whl in "${WHEELS[@]}"; do
+    if [[ ! -f "$whl" ]]; then
+      curl -fsSL -o "$whl" "${BASE_URL}/${whl}"
+    fi
+  done
+fi
+
+echo "=== verifying wheel sha256 ==="
+for whl in "${WHEELS[@]}"; do
+  got="$(sha256sum "$whl" | awk '{print $1}')"
+  want="${EXPECTED_SHA[$whl]}"
+  if [[ "$got" != "$want" ]]; then
+    echo "FATAL: sha256 mismatch for $whl" >&2
+    echo "  want $want" >&2
+    echo "  got  $got" >&2
+    exit 1
+  fi
+  echo "OK $whl"
+done
+
+echo "=== force-reinstall ML stack + boar_fast_filter from wheelhouse (--no-index) ==="
+# --no-deps: do not resolve from PyPI; pure deps already present from requirements.txt.
+python -m pip install --no-cache-dir --no-index --find-links "$WORKDIR" \
+  --force-reinstall --no-deps \
+  numpy scipy scikit-learn pandas boar_fast_filter
+
+python - <<'PY'
+import boar_fast_filter
+import numpy
+import pandas
+import scipy
+import sklearn
+
+print(
+    "imports_ok",
+    "numpy",
+    numpy.__version__,
+    "scipy",
+    scipy.__version__,
+    "sklearn",
+    sklearn.__version__,
+    "pandas",
+    pandas.__version__,
+    "boar_fast_filter",
+    boar_fast_filter.__file__,
+)
+PY
+
+# rapidfuzz ships baseline + *_avx2*.so CPU-dispatch siblings. The AVX2 modules
+# contain popcnt and would fail the all-.so gate; runtime selects by CPU feature
+# detector, so removing AVX2 leaves the baseline modules (same pattern as not
+# shipping an ISA we refuse to execute on alpine-emachines / #821).
+SITE="$(python -c 'import site; print(site.getsitepackages()[0])')"
+echo "=== strip rapidfuzz *_avx2*.so under ${SITE} ==="
+find "$SITE" -type f -name '*_avx2*.so' -print -delete
+
+if [[ "${SKIP_POPCNT_GATE:-0}" == "1" ]]; then
+  echo "SKIP_POPCNT_GATE=1 — skipping ISA gate (not for release)"
+  exit 0
+fi
+
+if ! command -v objdump >/dev/null 2>&1; then
+  echo "FATAL: objdump required for popcnt gate (install binutils)" >&2
+  exit 1
+fi
+
+echo "=== ISA gate: umath size + popcnt==0 on ALL site-packages .so ==="
+mapfile -t SOS < <(find "$SITE" -type f -name '*.so' | sort)
+
+umath=""
+nonzero=0
+for so in "${SOS[@]}"; do
+  base="$(basename "$so")"
+  if [[ "$base" == _multiarray_umath*.so ]]; then
+    umath="$so"
+  fi
+  count="$(objdump -d "$so" 2>/dev/null | grep -c popcnt || true)"
+  if [[ "$count" -gt "$POPCNT_MAX" ]]; then
+    echo "FATAL: popcnt=$count > max=$POPCNT_MAX in $so" >&2
+    nonzero=$((nonzero + 1))
+  fi
+done
+
+if [[ "$nonzero" -gt 0 ]]; then
+  echo "FATAL: ${nonzero} .so file(s) with popcnt above max=${POPCNT_MAX}" >&2
+  exit 1
+fi
+
+if [[ -z "$umath" ]]; then
+  echo "FATAL: _multiarray_umath*.so not found after wheelhouse install" >&2
+  exit 1
+fi
+
+sz="$(stat -c%s "$umath")"
+echo "umath=$umath size=$sz scanned_so=${#SOS[@]} popcnt_max=$POPCNT_MAX"
+if [[ "$sz" -ge "$UMATH_MAX_BYTES" ]]; then
+  echo "FATAL: umath size $sz >= max $UMATH_MAX_BYTES (PyPI AVX signature)" >&2
+  exit 1
+fi
+# Soft band from issue AC (~5.1–5.3 MB). Hard fail stays at UMATH_MAX_BYTES.
+if [[ "$sz" -lt 5000000 || "$sz" -gt 5500000 ]]; then
+  echo "WARN: umath size $sz outside expected ~5.1–5.3 MB band (still < $UMATH_MAX_BYTES)"
+fi
+
+# rapidfuzz must still import after AVX2 strip.
+python -c 'import rapidfuzz; print("rapidfuzz_ok", rapidfuzz.__version__)'
+
+echo "OK GATE: wheelhouse v1 applied — umath ${sz} B, popcnt=0 on ${#SOS[@]} site-packages .so"

--- a/scripts/docker/collect-runtime-rootfs.sh
+++ b/scripts/docker/collect-runtime-rootfs.sh
@@ -32,12 +32,24 @@ usrmerge_dest() {
 
 copy_lib_path() {
     local src="$1"
-    [[ -f "${src}" ]] || return 0
+    [[ -f "${src}" || -L "${src}" ]] || return 0
     local dest_path
     dest_path="$(usrmerge_dest "${src}")"
     local dest="${EXPORT}${dest_path}"
     mkdir -p "$(dirname "${dest}")"
     cp -a "${src}" "${dest}"
+    # ldd often reports the SONAME symlink; ship the real object too or the link is dangling in distroless.
+    if [[ -L "${src}" ]]; then
+        local real
+        real="$(readlink -f "${src}" || true)"
+        if [[ -n "${real}" && -f "${real}" && "${real}" != "${src}" ]]; then
+            local real_dest_path real_dest
+            real_dest_path="$(usrmerge_dest "${real}")"
+            real_dest="${EXPORT}${real_dest_path}"
+            mkdir -p "$(dirname "${real_dest}")"
+            cp -a "${real}" "${real_dest}"
+        fi
+    fi
 }
 
 # Python install + console scripts (pip/wheel already removed in Dockerfile RUN).
@@ -69,10 +81,13 @@ add_deps_from() {
     collect_ldd_paths "${target}" >> "${DEPS_FILE}"
 }
 
-# Extension modules and interpreter.
+# Extension modules and interpreter (site-packages + stdlib lib-dynload — e.g. _sqlite3 → libsqlite3).
 while IFS= read -r -d '' so; do
     add_deps_from "${so}"
-done < <(find /usr/local/lib/python3.13/site-packages -name '*.so' -print0 2>/dev/null || true)
+done < <(
+    find /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/lib-dynload \
+        -name '*.so' -print0 2>/dev/null || true
+)
 
 for py in /usr/local/bin/python3.13 /usr/local/bin/python3; do
     add_deps_from "${py}"
@@ -92,8 +107,9 @@ done < <(
     \) -print0 2>/dev/null || true
 )
 
-sort -u "${DEPS_FILE}" | while read -r lib; do
-    [[ -n "${lib}" && -f "${lib}" ]] || continue
+# Avoid pipe-subshell: copy every ldd dependency (and SONAME symlink targets) into EXPORT.
+while read -r lib; do
+    [[ -n "${lib}" && -e "${lib}" ]] || continue
     # Distroless cc-debian13 ships glibc; skip core libc to avoid clobbering the base.
     case "${lib}" in
         /lib/*/libc.so.*|/lib/*/libm.so.*|/lib/*/libpthread.so.*|/lib/*/libdl.so.*|/lib/*/librt.so.*|/lib/*/libresolv.so.*|/usr/lib/*/libc.so.*|/usr/lib/*/libm.so.*|/usr/lib/*/libpthread.so.*|/usr/lib/*/libdl.so.*|/usr/lib/*/librt.so.*|/usr/lib/*/libresolv.so.*)
@@ -101,7 +117,7 @@ sort -u "${DEPS_FILE}" | while read -r lib; do
             ;;
     esac
     copy_lib_path "${lib}"
-done
+done < <(sort -u "${DEPS_FILE}")
 
 # Writable data mount point (nonroot uid 65532 = distroless :nonroot).
 mkdir -p "${EXPORT}/data"
@@ -112,3 +128,27 @@ if [[ -d "${EXPORT}/lib" || -d "${EXPORT}/lib64" ]]; then
     echo "collect-runtime-rootfs: refusing usr-merge conflict (${EXPORT}/lib or lib64 is a directory)" >&2
     exit 1
 fi
+
+# Fail closed: CPython sqlite3 (integrity_anchor / data-boar --version) needs a resolvable libsqlite3.
+# SONAME symlink alone is not enough — the real object must be present (distroless has no apt).
+sqlite_link=""
+for candidate in \
+    "${EXPORT}/usr/lib/x86_64-linux-gnu/libsqlite3.so.0" \
+    "${EXPORT}/lib/x86_64-linux-gnu/libsqlite3.so.0"; do
+    if [[ -e "${candidate}" || -L "${candidate}" ]]; then
+        sqlite_link="${candidate}"
+        break
+    fi
+done
+if [[ -z "${sqlite_link}" ]]; then
+    echo "collect-runtime-rootfs: FATAL missing libsqlite3.so.0 (ldd lib-dynload/_sqlite3*.so)" >&2
+    exit 1
+fi
+if [[ -L "${sqlite_link}" ]]; then
+    sqlite_real="$(readlink -f "${sqlite_link}" || true)"
+    if [[ -z "${sqlite_real}" || ! -f "${sqlite_real}" ]]; then
+        echo "collect-runtime-rootfs: FATAL dangling libsqlite3.so.0 -> ${sqlite_real:-unresolved}" >&2
+        exit 1
+    fi
+fi
+echo "collect-runtime-rootfs: OK libsqlite3 via ${sqlite_link}"

--- a/tests/test_docker_image_hardening.py
+++ b/tests/test_docker_image_hardening.py
@@ -54,12 +54,28 @@ def test_collect_runtime_rootfs_script_bundles_tls_and_db_libs() -> None:
     assert "libmariadb.so" in text
     assert "usrmerge_dest" in text or "copy_lib_path" in text
     assert "refusing usr-merge conflict" in text
+    # stdlib extension deps (e.g. _sqlite3 → libsqlite3) live in lib-dynload, not site-packages.
+    assert "lib-dynload" in text
+    assert "libsqlite3" in text
+    assert (
+        "readlink" in text
+    )  # SONAME symlink → real .so (avoid dangling in distroless)
 
 
-def test_dockerfile_builds_boar_fast_filter_in_builder() -> None:
+def test_dockerfile_applies_wheelhouse_v1_in_builder() -> None:
+    """#1387: release image must force-reinstall ML stack from x86-64-v1 wheelhouse."""
     text = DOCKERFILE.read_text(encoding="utf-8")
-    assert "maturin build --release" in text
-    assert "import boar_fast_filter" in text
+    assert "apply_wheelhouse_v1.sh" in text
+    assert "WHEELHOUSE_TAG" in text
+    assert "binutils" in text  # objdump popcnt gate
+    script = REPO_ROOT / "scripts" / "docker" / "apply_wheelhouse_v1.sh"
+    assert script.is_file()
+    body = script.read_text(encoding="utf-8")
+    assert "--force-reinstall" in body
+    assert "--no-index" in body
+    assert "popcnt" in body
+    assert "boar_fast_filter" in body
+    assert "wheelhouse-x86-64-v1-2026-07-29" in body
 
 
 def test_grype_vex_config_has_documented_ignore_rules() -> None:


### PR DESCRIPTION
## Summary

- Rebuild the release image on hosted **x86-64-v1** wheelhouse (`apply_wheelhouse_v1.sh`): force-reinstall numpy/scipy/sklearn/pandas + `boar_fast_filter` with `--no-index`, strip rapidfuzz `*_avx2*.so`, gate `popcnt==0` on all site-packages `.so` and umath size.
- Fix distroless rootfs: `collect-runtime-rootfs.sh` now `ldd`s **lib-dynload + site-packages**, copies SONAME **symlink targets**, and fail-closes if `libsqlite3.so.0` is missing/dangling — unblocks `data-boar --version` / integrity_anchor.
- `.dockerignore`: exclude nested `**/.venv` / Rust `target` (previous local build leaked `rust/boar_fast_filter/.venv` and ballooned size).

Closes #1387

## Contabilidade

Dockerfile / `scripts/docker/*` / `.dockerignore` are **fora de N** (not in wheel `packages`). `version=1.7.4.post12` / `maturity_build=263` **unchanged**.

## Local validation (no push)

| Check | Result |
| --- | --- |
| Builder ISA gate | umath **5 098 313 B**, `popcnt=0` on **540** site-packages `.so` |
| `data-boar --version` | `Data Boar 1.7.4.post12` |
| `maturity_build` in image | **263** |
| `./scripts/docker/docker-image-smoke.sh data_boar:post12-wheelhouse-v1 1.7.4.post12` | **PASS** |
| APP-PY pins (lock) | pillow **12.3.0**, pypdf **6.14.2**, pyasn1 **0.6.4**, soupsieve **2.8.4** — none of the June 17 APP-PY findings remain |
| Image size (podman inspect) | local rebuild **~906 MB** vs Hub `latest` **~1.15 GB** (after dropping nested venv from context; earlier dirty build was 1.91 GB) |
| `./scripts/grype-image-gate.sh podman:localhost/data_boar:post12-wheelhouse-v1` | **FAIL** — see below |

### Grype gate — stop and report (no VEX added)

`grype-image-gate.sh` (`--fail-on high --only-fixed` + `.grype.yaml`) fails on **one** actionable High:

```
python  3.13.14  → fixed in 3.15.0  binary  CVE-2026-15308  High
```

- **Not** APP-PY / lock drift: pillow/pypdf/pyasn1/soupsieve are absent from `--only-fixed` High matches.
- Hub `python:3.13-slim` still ships `PYTHON_VERSION=3.13.14`; “fix in 3.15.0” is not a drop-in for the 3.13 line.
- Per issue baseline comment: interpreter CVEs are base-image class, not a `pyproject` floor. **Did not** add VEX to silence. Image is **not** Hub-push-ready until operator decides (wait for 3.13 security rebuild, document exception, or other).

## Test plan

- [x] `uv run pytest tests/test_docker_image_hardening.py`
- [x] `./scripts/check-all.sh` green locally
- [x] Local `podman build` + smoke + `--version`
- [ ] CI green on this PR
- [ ] Operator: decide on python-binary grype High, then Hub push (`1.7.4.post12` + `latest`) — **not** this PR