### PR TITLE
chore(docker): python 3.14-slim + VEX CVE-2026-15308 for post12 Hub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,13 @@
 #   - `fail-fast: false` on the matrix means Python-3.12/3.13/3.14 jobs
 #     run to completion even if one fails, so all error logs are collected.
 #     It does NOT mean "pass when there are errors" — just parallel visibility.
-#   - Python 3.14 is SIGNAL-ONLY (#551): it runs the full test suite for the
-#     future no-GIL Enterprise runtime but uses `continue-on-error: true` so an
-#     ecosystem gap (missing wheels, dep incompatibility) does not block merges.
-#     The runtime / Docker base image stays 3.12/3.13 until the licensing
-#     enforcement gate is green (rationale in #551).
+#   - Python 3.14 is SIGNAL-ONLY in the CI matrix (#551): it runs the full test
+#     suite for the no-GIL Enterprise runtime but uses `continue-on-error: true`
+#     so an ecosystem gap (missing wheels, dep incompatibility) does not block
+#     merges. The Docker release base image is now python:3.14-slim (licensing
+#     enforcement gate green — #551 worker cap + closed cluster #704/#717–#722/#856;
+#     field matrix Alpine/Void cp314). Matrix continue-on-error for 3.14 is a
+#     separate CI posture decision from the image base pin.
 #
 # Third-party Actions use full commit SHAs (major tag noted in comment). Refresh via Dependabot
 # (github-actions) or deliberately after reading upstream release notes. astral-sh/setup-uv `version`

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -7,10 +7,21 @@
 #
 # REVIEW: re-run full grype and revisit every rule when bumping:
 #   - gcr.io/distroless/cc-debian13:nonroot digest (Dockerfile stage 3)
-#   - python:3.13-slim digest (builder / runtime-assembler)
+#   - python:3.14-slim digest (builder / runtime-assembler)
 # See ADR-0074, PLAN_IMAGE_HARDENING (completed), docs/ops/evidence/GRYPE_DISTROLESS_GATE_SAMPLE.md
 
 ignore:
+  # --- CPython binary (builder/runtime; no stable vendor fix yet) ---
+  - vulnerability: CVE-2026-15308
+    package:
+      name: python
+      type: binary
+    reason: >-
+      CPython no builder/runtime. Unico fix declarado e 3.15.0, que NAO existe como release
+      estavel — remediacao indisponivel, nao acionavel. Afeta identicamente 3.13.14 e 3.14.6
+      (medido). NAO subir para 3.15.0a6/b3: Python pre-release em imagem de release esta
+      PROIBIDO pelo operador. Revisar quando 3.15.0 sair estavel ou houver backport.
+
   # --- glibc (distroless cc-debian13 runtime) ---
   - package:
       name: libc6

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,10 @@
 # -----------------------------------------------------------------------------
 # Stage 1: build Python extensions and install dependencies
 # -----------------------------------------------------------------------------
-# Rolling 3.13 slim (Debian 13 / trixie): aligns with CI, requires-python >=3.12.
+# Rolling 3.14 slim (Debian 13 / trixie): aligns with CI matrix + field-tested
+# wheelhouse cells; licensing enforcement gate green (#551 / cluster closed).
 # Digest pin (ADR-0074 / #988): Dependabot docker ecosystem proposes digest bumps.
-FROM python:3.13-slim@sha256:3a2c25932e66f706172de831a1b283d491c53ef876cd7fc55a62bcf9a6dd2c61 AS builder
+FROM python:3.14-slim@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6 AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential gcc g++ pkg-config curl ca-certificates binutils \
@@ -31,14 +32,15 @@ RUN pip uninstall -y wheel || true && \
         "psycopg2-binary>=2.9.11" "pymysql>=1.2.0" "mariadb>=1.1.14" \
         "pyodbc>=5.3.0" "oracledb>=4.0.1" && \
     WHEELHOUSE_TAG="${WHEELHOUSE_TAG}" bash /app/scripts/docker/apply_wheelhouse_v1.sh && \
-    rm -rf /tmp/wheelhouse-v1-glibc-cp313 && \
-    (find /usr/local/lib/python3.13/site-packages -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true) && \
-    (find /usr/local/lib/python3.13/site-packages -name "*.pyc" -delete 2>/dev/null || true)
+    PY_XY="$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')" && \
+    rm -rf "/tmp/wheelhouse-v1-glibc-cp$(python -c 'import sys; print(f"{sys.version_info.major}{sys.version_info.minor}")')" && \
+    (find "/usr/local/lib/python${PY_XY}/site-packages" -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true) && \
+    (find "/usr/local/lib/python${PY_XY}/site-packages" -name "*.pyc" -delete 2>/dev/null || true)
 
 # -----------------------------------------------------------------------------
 # Stage 2: assemble runtime rootfs (shell stage — not shipped)
 # -----------------------------------------------------------------------------
-FROM python:3.13-slim@sha256:3a2c25932e66f706172de831a1b283d491c53ef876cd7fc55a62bcf9a6dd2c61 AS runtime-assembler
+FROM python:3.14-slim@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6 AS runtime-assembler
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq5 libffi8 unixodbc libmariadb3 \
@@ -46,11 +48,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --from=builder /usr/local /usr/local
 
-RUN ln -sf python3.13 /usr/local/bin/python3 && ln -sf python3.13 /usr/local/bin/python
+RUN PY_XY="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')" && \
+    ln -sf "python${PY_XY}" /usr/local/bin/python3 && \
+    ln -sf "python${PY_XY}" /usr/local/bin/python
 
 # No pip/wheel/setuptools in the release image (app does not install packages at runtime, #1028).
-RUN /usr/local/bin/python3.13 -m pip uninstall -y pip wheel setuptools 2>/dev/null || true && \
-    rm -f /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.13 /usr/local/bin/wheel 2>/dev/null || true
+RUN PY_XY="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')" && \
+    "/usr/local/bin/python${PY_XY}" -m pip uninstall -y pip wheel setuptools 2>/dev/null || true && \
+    rm -f /usr/local/bin/pip /usr/local/bin/pip3 "/usr/local/bin/pip${PY_XY}" /usr/local/bin/wheel 2>/dev/null || true
 
 COPY scripts/docker/collect-runtime-rootfs.sh /tmp/collect-runtime-rootfs.sh
 RUN chmod +x /tmp/collect-runtime-rootfs.sh && /tmp/collect-runtime-rootfs.sh /rootfs
@@ -58,7 +63,7 @@ RUN chmod +x /tmp/collect-runtime-rootfs.sh && /tmp/collect-runtime-rootfs.sh /r
 # -----------------------------------------------------------------------------
 # Stage 3: minimal distroless runtime (nonroot uid 65532, no shell/apt)
 # -----------------------------------------------------------------------------
-# gcr.io/distroless/cc-debian13:nonroot — Debian 13 matches python:3.13-slim glibc (not cc-debian12).
+# gcr.io/distroless/cc-debian13:nonroot — Debian 13 matches python:3.14-slim (trixie) glibc.
 # Human tag comment: cc-debian13:nonroot (#1028 / PLAN_IMAGE_HARDENING.md).
 FROM gcr.io/distroless/cc-debian13:nonroot@sha256:d97bc0a941b8d4be647dc0ee75b264ddbb772f1ac5ba690a4309c00723b23775
 
@@ -78,4 +83,4 @@ USER 65532:65532
 
 EXPOSE 8088
 
-CMD ["/usr/local/bin/python3.13", "main.py", "--config", "/data/config.yaml", "--web", "--port", "8088", "--allow-insecure-http"]
+CMD ["/usr/local/bin/python3.14", "main.py", "--config", "/data/config.yaml", "--web", "--port", "8088", "--allow-insecure-http"]

--- a/scripts/docker/apply_wheelhouse_v1.sh
+++ b/scripts/docker/apply_wheelhouse_v1.sh
@@ -6,8 +6,9 @@
 # SSSE3-only, gate #821). `--find-links` alone does not prefer wheelhouse —
 # force-reinstall with --no-index is required (same contract as pipx path).
 #
-# Image is glibc (python:3.13-slim → distroless cc-debian13): use manylinux
-# cp313 cells from DataBoar/data-boar-site release wheelhouse-x86-64-v1-*.
+# Image is glibc (python:*-slim → distroless cc-debian13): use manylinux
+# cpXXX cells matching the builder interpreter ABI from
+# DataBoar/data-boar-site release wheelhouse-x86-64-v1-*.
 #
 # Usage (inside builder stage, after pip install -r requirements.txt):
 #   bash scripts/docker/apply_wheelhouse_v1.sh
@@ -20,23 +21,34 @@ set -euo pipefail
 
 WHEELHOUSE_TAG="${WHEELHOUSE_TAG:-wheelhouse-x86-64-v1-2026-07-29}"
 BASE_URL="${WHEELHOUSE_BASE_URL:-https://github.com/DataBoar/data-boar-site/releases/download/${WHEELHOUSE_TAG}}"
-WORKDIR="${WHEELHOUSE_DIR:-/tmp/wheelhouse-v1-glibc-cp313}"
 
-# Filenames must match the hosted release assets (manylinux / cp313).
+# Derive ABI tag from the builder interpreter (cp313, cp314, …). Hardcoding
+# cp313 against a 3.14 base installs the wrong wheel or fails force-reinstall.
+PY_MM="$(python -c 'import sys; print(f"{sys.version_info.major}{sys.version_info.minor}")')"
+CP="cp${PY_MM}"
+WORKDIR="${WHEELHOUSE_DIR:-/tmp/wheelhouse-v1-glibc-${CP}}"
+
+# Filenames must match the hosted release assets (manylinux / ${CP}).
+# boar_fast_filter is abi3 (cp38) — same asset for all CPython 3.x builders.
 WHEELS=(
-  "numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
-  "scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
-  "scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
-  "pandas-3.0.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl"
+  "numpy-2.5.1-${CP}-${CP}-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+  "scipy-1.18.0-${CP}-${CP}-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+  "scikit_learn-1.9.0-${CP}-${CP}-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+  "pandas-3.0.5-${CP}-${CP}-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl"
   "boar_fast_filter-0.1.0-cp38-abi3-manylinux_2_28_x86_64.whl"
 )
 
 # Expected sha256 from release SHA256SUMS (wheelhouse-x86-64-v1-2026-07-29).
+# Keyed by full filename so cp313 and cp314 cells can coexist offline.
 declare -A EXPECTED_SHA=(
   ["numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"]="d301efd02e390bd2d135205c25cd7b7fc82ec353aa3985528745601bfb67c2d6"
   ["scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"]="a9c3a1ae4de02b8eff37b87a7d5af19bfdbb029cc62b855fd8813acc2775c5bf"
   ["scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"]="0d28c1b992d7a6c0951869560d0090c24ccfe44282fb2f5d7b3814b4232de418"
   ["pandas-3.0.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl"]="4b11c36e218331d0387cbe3a0a5f75162357a1d92d57b2b08a336ff94b19b2be"
+  ["numpy-2.5.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"]="0277af072c85878e95f14e6f5b5ac7f32b4376cfa007f0bf08bbeb9f09a6f600"
+  ["scipy-1.18.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"]="096c50481f7e78353d82ce1cdd01256ac379443d8b5b9a5b0a1408cbf990000a"
+  ["scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"]="1f2c048e96ad44db5775adc80d7d0c1f3db7c5c7e837950b4b0a42afa28ffdcb"
+  ["pandas-3.0.5-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl"]="9e94c2c5ca43bd3ca32bf64d32308887b65e5f9bfd8023ea52755107a999f93b"
   ["boar_fast_filter-0.1.0-cp38-abi3-manylinux_2_28_x86_64.whl"]="f664cb016fed2d530e94fa9946bb783c294e052ef19ceae4dd80bd6d12a9125a"
 )
 
@@ -55,7 +67,7 @@ for whl in "${WHEELS[@]}"; do
 done
 
 if [[ "$need_download" -eq 1 ]]; then
-  echo "=== downloading ${WHEELHOUSE_TAG} manylinux cp313 wheels ==="
+  echo "=== downloading ${WHEELHOUSE_TAG} manylinux ${CP} wheels ==="
   for whl in "${WHEELS[@]}"; do
     if [[ ! -f "$whl" ]]; then
       curl -fsSL -o "$whl" "${BASE_URL}/${whl}"
@@ -66,7 +78,11 @@ fi
 echo "=== verifying wheel sha256 ==="
 for whl in "${WHEELS[@]}"; do
   got="$(sha256sum "$whl" | awk '{print $1}')"
-  want="${EXPECTED_SHA[$whl]}"
+  want="${EXPECTED_SHA[$whl]:-}"
+  if [[ -z "$want" ]]; then
+    echo "FATAL: no EXPECTED_SHA entry for $whl (ABI ${CP})" >&2
+    exit 1
+  fi
   if [[ "$got" != "$want" ]]; then
     echo "FATAL: sha256 mismatch for $whl" >&2
     echo "  want $want" >&2

--- a/scripts/docker/collect-runtime-rootfs.sh
+++ b/scripts/docker/collect-runtime-rootfs.sh
@@ -81,15 +81,36 @@ add_deps_from() {
     collect_ldd_paths "${target}" >> "${DEPS_FILE}"
 }
 
+# Derive lib dir from the assembler interpreter (python3.13 → python3.14 on base bump).
+# Hardcoding python3.13 leaves the find empty on 3.14 and trips the libsqlite3 fail-close.
+PY_BIN=""
+for candidate in /usr/local/bin/python3 /usr/local/bin/python; do
+    if [[ -x "${candidate}" ]]; then
+        PY_BIN="${candidate}"
+        break
+    fi
+done
+if [[ -z "${PY_BIN}" ]]; then
+    echo "collect-runtime-rootfs: FATAL no python3/python under /usr/local/bin" >&2
+    exit 1
+fi
+PY_XY="$("${PY_BIN}" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+PY_LIB="/usr/local/lib/python${PY_XY}"
+PY_VER_BIN="/usr/local/bin/python${PY_XY}"
+if [[ ! -d "${PY_LIB}/lib-dynload" ]]; then
+    echo "collect-runtime-rootfs: FATAL missing ${PY_LIB}/lib-dynload (ABI path)" >&2
+    exit 1
+fi
+
 # Extension modules and interpreter (site-packages + stdlib lib-dynload — e.g. _sqlite3 → libsqlite3).
 while IFS= read -r -d '' so; do
     add_deps_from "${so}"
 done < <(
-    find /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/lib-dynload \
+    find "${PY_LIB}/site-packages" "${PY_LIB}/lib-dynload" \
         -name '*.so' -print0 2>/dev/null || true
 )
 
-for py in /usr/local/bin/python3.13 /usr/local/bin/python3; do
+for py in "${PY_VER_BIN}" "${PY_BIN}"; do
     add_deps_from "${py}"
 done
 

--- a/scripts/docker/docker-image-smoke.sh
+++ b/scripts/docker/docker-image-smoke.sh
@@ -8,7 +8,8 @@ set -euo pipefail
 IMAGE="${1:?image ref required (e.g. data_boar:lab)}"
 VERSION="${2:-}"
 
-PYTHON="/usr/local/bin/python3.13"
+# Dockerfile assembler always symlinks python3 → versioned binary (3.14 / 3.13…).
+PYTHON="/usr/local/bin/python3"
 RUN=(podman run --rm "${IMAGE}" "${PYTHON}")
 
 if ! command -v podman >/dev/null 2>&1; then

--- a/tests/test_docker_image_hardening.py
+++ b/tests/test_docker_image_hardening.py
@@ -36,14 +36,14 @@ def test_dockerfile_pins_all_from_images_by_digest() -> None:
         assert "@sha256:" in line, f"expected digest pin in FROM line: {line!r}"
     joined = "\n".join(from_lines)
     assert "distroless/cc-debian13" in joined
-    assert "python:3.13-slim" in joined
+    assert "python:3.14-slim" in joined
 
 
 def test_dockerfile_distroless_nonroot_and_exec_cmd() -> None:
     text = DOCKERFILE.read_text(encoding="utf-8")
     assert "distroless/cc-debian13:nonroot@" in text
     assert "USER 65532:65532" in text
-    assert 'CMD ["/usr/local/bin/python3.13"' in text
+    assert 'CMD ["/usr/local/bin/python3.14"' in text
 
 
 def test_collect_runtime_rootfs_script_bundles_tls_and_db_libs() -> None:
@@ -76,19 +76,32 @@ def test_dockerfile_applies_wheelhouse_v1_in_builder() -> None:
     assert "popcnt" in body
     assert "boar_fast_filter" in body
     assert "wheelhouse-x86-64-v1-2026-07-29" in body
+    # ABI must follow the builder interpreter (cp314 on 3.14-slim), not a hardcode.
+    assert 'CP="cp${PY_MM}"' in body or "cp${PY_MM}" in body
+    assert "sys.version_info" in body
 
 
 def test_grype_vex_config_has_documented_ignore_rules() -> None:
-    """PR-B #1028: .grype.yaml documents wont-fix base classes with reason (audit posture)."""
+    """PR-B #1028: .grype.yaml documents wont-fix base classes + CVE VEX with reason."""
     assert GRYPE_CONFIG.is_file()
     data = yaml.safe_load(GRYPE_CONFIG.read_text(encoding="utf-8"))
     rules = data.get("ignore") or []
     assert len(rules) >= 5
+    cve_rules = [r for r in rules if r.get("vulnerability")]
+    deb_rules = [r for r in rules if not r.get("vulnerability")]
     for rule in rules:
         assert rule.get("reason"), f"ignore rule missing reason: {rule!r}"
+        assert rule.get("package", {}).get("name"), (
+            f"ignore rule missing package.name: {rule!r}"
+        )
+    for rule in deb_rules:
         assert rule.get("fix-state") == "wont-fix"
         assert rule.get("package", {}).get("type") == "deb"
-    names = {r["package"]["name"] for r in rules}
+    assert any(r.get("vulnerability") == "CVE-2026-15308" for r in cve_rules)
+    cve_pkg = next(r for r in cve_rules if r["vulnerability"] == "CVE-2026-15308")
+    assert cve_pkg.get("package", {}).get("type") == "binary"
+    assert cve_pkg.get("package", {}).get("name") == "python"
+    names = {r["package"]["name"] for r in deb_rules}
     assert "libc6" in names
     assert "mariadb" in names
 
@@ -135,7 +148,7 @@ def test_docker_image_smoke_script_passes_on_built_image() -> None:
                 "run",
                 "--rm",
                 image,
-                "/usr/local/bin/python3.13",
+                "/usr/local/bin/python3",
                 "-c",
                 "from core.about import _package_version; print(_package_version())",
             ],


### PR DESCRIPTION
## Summary
- Pin Docker builder/runtime-assembler to **`python:3.14-slim@sha256:cea0e604…`** (3.14.6, Debian 13/trixie — keeps `distroless/cc-debian13` glibc pairing).
- Derive wheelhouse **cpXXX** and `collect-runtime-rootfs` **pythonX.Y** paths from the interpreter (cp314 manylinux cells from `wheelhouse-x86-64-v1-2026-07-29`).
- Add Grype VEX ignore for **CVE-2026-15308** (`python` binary): declared fix is **3.15.0**, which is not a stable release; identical High on 3.13.14 and 3.14.6 (measured). Does **not** weaken `--fail-on high` / `--only-fixed`.
- Correct outdated `ci.yml` header that said the Docker base “stays 3.12/3.13 until licensing gate is green”.

## Why 3.14 is allowed now (measured)
- Licensing enforcement gate **green**: `core/licensing/` (`feature_gate`, `guard`, `fingerprint`, `integrity`, `tier_features`, `runtime_feature_tier`, `verify`) + `#551` worker cap in `core/engine.py`.
- Cluster **#704 #717 #718 #719 #720 #721 #722 #856** closed.
- Field matrix: Alpine 3.14 + Void musl cp314 cells green (`deploy/compat-matrix-config-ref`, `PLAN_WHEELHOUSE_DISTRIBUTION.md`).

## GATE_FILE (operator action required)
`.github/workflows/ci.yml` is a **GATE_FILE** (CODEOWNERS `@FabioLeitao`). Comment-only fix of a false statement about the Docker base — still requires **operator SSHSIG attestation** / Code Owner review before merge. Agent does not self-attest.

## Out of scope
- No `version` / `maturity_build` bump (stays **1.7.4.post12** / **263**).
- Hub tag **`1.7.4`** (June) untouched; publish targets **`:1.7.4.post12`** + **`:latest`**.

## Test plan
- [x] `uv run pytest tests/test_docker_image_hardening.py tests/test_github_workflows.py`
- [ ] `~/.local/bin/build-push-podman.sh 1.7.4.post12 --debug` (smoke + grype gate + push)
- [ ] Confirm grype exit 0 with cwd `.grype.yaml` (wrapper has no `--config`)
- [ ] Operator: SSHSIG / Code Owner approve for `ci.yml`