### PR TITLE
feat(docker): free-threaded 1.7.4.post12-nogil (x86-64-v2+)

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -22,6 +22,24 @@ ignore:
       (medido). NAO subir para 3.15.0a6/b3: Python pre-release em imagem de release esta
       PROIBIDO pelo operador. Revisar quando 3.15.0 sair estavel ou houver backport.
 
+  - vulnerability: CVE-2026-11940
+    package:
+      name: python
+      type: binary
+    reason: >-
+      CPython binary (GIL slim e free-threaded 3.14.6). Unico fix declarado e 3.15.0b4
+      (beta) — remediacao indisponivel como release estavel. NAO subir para pre-release:
+      PROIBIDO pelo operador. Revisar quando 3.15.0 sair estavel ou houver backport.
+
+  - vulnerability: CVE-2026-11972
+    package:
+      name: python
+      type: binary
+    reason: >-
+      CPython binary (GIL slim e free-threaded 3.14.6). Unico fix declarado e 3.15.0b4
+      (beta) — remediacao indisponivel como release estavel. NAO subir para pre-release:
+      PROIBIDO pelo operador. Revisar quando 3.15.0 sair estavel ou houver backport.
+
   # --- glibc (distroless cc-debian13 runtime) ---
   - package:
       name: libc6

--- a/Dockerfile.nogil
+++ b/Dockerfile.nogil
@@ -1,0 +1,117 @@
+# Free-threaded (no-GIL) release image variant — tag suffix `-nogil`.
+# Multi-stage: builder (uv-installed 3.14t) → runtime-assembler → distroless nonroot.
+#
+# Why a separate file: there is no `python:3.14t-slim` on Docker Hub (404). We keep
+# the GIL image on stock `python:3.14-slim` and install CPython free-threaded via
+# `uv python install` (python-build-standalone) for this variant only.
+#
+# CPU contract: x86-64-v2+ (numpy cp314t has popcnt≠0). Does NOT target alpine-emachines.
+# Do NOT retag `:latest` or `:1.7.4` when publishing this image.
+
+# -----------------------------------------------------------------------------
+# Stage 1: free-threaded interpreter + deps + cp314t wheelhouse
+# -----------------------------------------------------------------------------
+FROM python:3.14-slim@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6 AS builder
+
+# uv 0.11.x cannot fetch cpython-3.14.6+freethreaded; pin 0.12.0 + sha256 of the
+# official linux-gnu tarball (measured 2026-07-30).
+ARG UV_VERSION=0.12.0
+ARG UV_SHA256=eaf842262aa1c418d8ecc5605f02ee1ebfd369124fa48548e85f9481a47831a9
+ARG UV_PYTHON=3.14.6+freethreaded
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential gcc g++ pkg-config curl ca-certificates binutils \
+    libpq-dev libffi-dev libssl-dev unixodbc-dev default-libmysqlclient-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL \
+        "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz" \
+        -o /tmp/uv.tgz \
+    && echo "${UV_SHA256}  /tmp/uv.tgz" | sha256sum -c - \
+    && tar -xzf /tmp/uv.tgz -C /tmp \
+    && install -m 0755 /tmp/uv-x86_64-unknown-linux-gnu/uv /usr/local/bin/uv \
+    && rm -rf /tmp/uv.tgz /tmp/uv-x86_64-unknown-linux-gnu
+
+# Install free-threaded CPython into a staging dir, then overlay onto /usr/local
+# so collect-runtime-rootfs + distroless see a normal prefix layout.
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv-pythons
+RUN uv python install "${UV_PYTHON}" \
+    && PYROOT="$(find /opt/uv-pythons -maxdepth 1 -type d -name 'cpython-*freethreaded*' | sort | tail -1)" \
+    && test -n "${PYROOT}" \
+    && test -x "${PYROOT}/bin/python3.14t" \
+    && rm -rf /usr/local/lib/python3.14 /usr/local/lib/python3.14t \
+    && cp -a "${PYROOT}/bin/." /usr/local/bin/ \
+    && cp -a "${PYROOT}/lib/." /usr/local/lib/ \
+    && cp -a "${PYROOT}/include/." /usr/local/include/ \
+    && ln -sf python3.14t /usr/local/bin/python3 \
+    && ln -sf python3.14t /usr/local/bin/python \
+    && python -c 'import sys; assert sys._is_gil_enabled() is False, sys.version' \
+    && rm -f /usr/local/lib/python3.14t/EXTERNALLY-MANAGED \
+    && python -m ensurepip --upgrade
+
+WORKDIR /app
+COPY requirements.txt /app/requirements.txt
+COPY . /app
+
+ARG WHEELHOUSE_TAG=wheelhouse-x86-64-v1-2026-07-29
+
+# Container owns /usr/local; PEP 668 marker removed above after uv overlay.
+RUN pip uninstall -y wheel || true && \
+    pip install --no-cache-dir --upgrade "pip>=25.3" && \
+    pip install --no-cache-dir --force-reinstall "wheel>=0.46.2" && \
+    python -c "import wheel; import sys; sys.exit(0 if tuple(map(int, wheel.__version__.split('.'))) >= (0,46,2) else 1)" && \
+    pip install --no-cache-dir -r /app/requirements.txt && \
+    pip install --no-cache-dir --no-deps -e /app && \
+    pip install --no-cache-dir \
+        "psycopg2-binary>=2.9.11" "pymysql>=1.2.0" "mariadb>=1.1.14" \
+        "pyodbc>=5.3.0" "oracledb>=4.0.1" && \
+    WHEELHOUSE_TAG="${WHEELHOUSE_TAG}" bash /app/scripts/docker/apply_wheelhouse_v1.sh && \
+    PY_LIB="$(python -c 'import sysconfig; from pathlib import Path; print(Path(sysconfig.get_path("stdlib")))')" && \
+    rm -rf /tmp/wheelhouse-v1-glibc-cp314t && \
+    (find "${PY_LIB}/site-packages" -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true) && \
+    (find "${PY_LIB}/site-packages" -name "*.pyc" -delete 2>/dev/null || true)
+
+# -----------------------------------------------------------------------------
+# Stage 2: assemble runtime rootfs (shell stage — not shipped)
+# -----------------------------------------------------------------------------
+FROM python:3.14-slim@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6 AS runtime-assembler
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libpq5 libffi8 unixodbc libmariadb3 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local /usr/local
+
+RUN ln -sf python3.14t /usr/local/bin/python3 && \
+    ln -sf python3.14t /usr/local/bin/python && \
+    python -c 'import sys; assert sys._is_gil_enabled() is False'
+
+# No pip/wheel/setuptools in the release image (#1028).
+RUN /usr/local/bin/python3.14t -m pip uninstall -y pip wheel setuptools 2>/dev/null || true && \
+    rm -f /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.14 /usr/local/bin/pip3.14t \
+          /usr/local/bin/wheel /usr/local/bin/uv 2>/dev/null || true
+
+COPY scripts/docker/collect-runtime-rootfs.sh /tmp/collect-runtime-rootfs.sh
+RUN chmod +x /tmp/collect-runtime-rootfs.sh && /tmp/collect-runtime-rootfs.sh /rootfs
+
+# -----------------------------------------------------------------------------
+# Stage 3: minimal distroless runtime (nonroot uid 65532, no shell/apt)
+# -----------------------------------------------------------------------------
+FROM gcr.io/distroless/cc-debian13:nonroot@sha256:d97bc0a941b8d4be647dc0ee75b264ddbb772f1ac5ba690a4309c00723b23775
+
+LABEL org.opencontainers.image.description="LGPD/GDPR/CCPA audit (free-threaded / no-GIL). Requires x86-64-v2+. Not interchangeable with the GIL image."
+
+WORKDIR /app
+
+COPY --from=runtime-assembler /rootfs /
+COPY --chown=65532:65532 . .
+
+ENV CONFIG_PATH=/data/config.yaml
+ENV PYTHONUNBUFFERED=1
+ENV API_HOST=0.0.0.0
+ENV PATH=/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+USER 65532:65532
+
+EXPOSE 8088
+
+CMD ["/usr/local/bin/python3.14t", "main.py", "--config", "/data/config.yaml", "--web", "--port", "8088", "--allow-insecure-http"]

--- a/Dockerfile.nogil
+++ b/Dockerfile.nogil
@@ -53,6 +53,11 @@ COPY requirements.txt /app/requirements.txt
 COPY . /app
 
 ARG WHEELHOUSE_TAG=wheelhouse-x86-64-v1-2026-07-29
+# SQLAlchemy cyextension .so re-enables the GIL on import (undeclared free-threaded
+# safety). Force pure-Python sqlalchemy so the -nogil image keeps GIL=False after
+# app imports (core/database*.py import sqlalchemy at module level). Do NOT use
+# PYTHON_GIL=0 / -Xgil=0 — that would run unsafe C extensions (operator forbid).
+ENV DISABLE_SQLALCHEMY_CEXT=1
 
 # Container owns /usr/local; PEP 668 marker removed above after uv overlay.
 RUN pip uninstall -y wheel || true && \
@@ -60,6 +65,8 @@ RUN pip uninstall -y wheel || true && \
     pip install --no-cache-dir --force-reinstall "wheel>=0.46.2" && \
     python -c "import wheel; import sys; sys.exit(0 if tuple(map(int, wheel.__version__.split('.'))) >= (0,46,2) else 1)" && \
     pip install --no-cache-dir -r /app/requirements.txt && \
+    pip install --no-cache-dir --force-reinstall --no-binary sqlalchemy "sqlalchemy==2.0.50" && \
+    python -c 'import pathlib, site, sqlalchemy, sys; root=pathlib.Path(site.getsitepackages()[0])/"sqlalchemy"; sos=list(root.rglob("*.so")); assert not sos, sos; assert sys._is_gil_enabled() is False, "GIL re-enabled after sqlalchemy"' && \
     pip install --no-cache-dir --no-deps -e /app && \
     pip install --no-cache-dir \
         "psycopg2-binary>=2.9.11" "pymysql>=1.2.0" "mariadb>=1.1.14" \
@@ -109,6 +116,8 @@ ENV CONFIG_PATH=/data/config.yaml
 ENV PYTHONUNBUFFERED=1
 ENV API_HOST=0.0.0.0
 ENV PATH=/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# Build-time contract reminder (cext absent in this image); harmless at runtime.
+ENV DISABLE_SQLALCHEMY_CEXT=1
 
 USER 65532:65532
 

--- a/docs/ops/DOCKER_HUB_REPOSITORY_DESCRIPTION.md
+++ b/docs/ops/DOCKER_HUB_REPOSITORY_DESCRIPTION.md
@@ -49,9 +49,10 @@ This is the image you want unless you have a concrete reason to opt into free-th
 
 #### `1.7.4.post12-nogil` — real parallelism (opt-in)
 
-- Python **3.14t free-threaded** (PEP 703). Inside the container: `sys._is_gil_enabled()` → **False**.
+- Python **3.14t free-threaded** (PEP 703). Inside the container: `sys._is_gil_enabled()` → **False** — **including after `import sqlalchemy`** (see below).
 - Same ML versions, but wheels are **`cp314t`**. **`cp314` and `cp314t` are not interchangeable** (different `SOABI`).
 - **`boar_fast_filter`** is built **native for `cp314t`** — the **`abi3`** wheel from the GIL image **does not load** here.
+- **SQLAlchemy is pure-Python in this image** (`DISABLE_SQLALCHEMY_CEXT=1`, no `sqlalchemy/**/*.so`). The stock cyextension `.so` **re-enables the GIL** on import (undeclared free-threaded safety) and would cancel the point of `-nogil`. The GIL image (`latest` / `1.7.4.post12`) **keeps** the cext — correct there.
 - **Requires x86-64-v2+.** Upstream **numpy cp314t** uses **`popcnt`** (**1477** hits measured). **Will not run** on CPUs without SSE4.2/POPCNT (e.g. alpine-emachines / Celeron 900).
 - **`:latest` never points here.** Publishing `-nogil` must not retag `:latest` or the June GA `:1.7.4`.
 
@@ -59,15 +60,22 @@ This is the image you want unless you have a concrete reason to opt into free-th
 
 **Do not use when:** hardware is old/unknown, or you run **one worker** (no parallelism to unlock).
 
-#### What “faster” means here (no invented multipliers)
+#### What “faster” means here (measured microbenchmark + mechanism)
 
-Do **not** expect a marketed “N× speedup” without a published benchmark. The mechanism ([#551](https://github.com/DataBoar/data-boar/issues/551)):
+Mechanism ([#551](https://github.com/DataBoar/data-boar/issues/551)): workers in **pure-Python regex** (`core/detector.py`) are **serialized by the GIL** even with high `max_workers`; free-threaded removes that. **`boar_fast_filter`** (PyO3) **already releases the GIL** — smaller gain there. **I/O-bound** workers: marginal.
 
-- Workers that spend time in **pure-Python regex** (`core/detector.py`) are **serialized by the GIL** even when `max_workers` is high. Free-threaded CPython removes that serialization so those workers can run together.
-- **`boar_fast_filter`** (PyO3) **already releases the GIL** — gain on that path is smaller.
-- **I/O-bound** workers were never GIL-bound — expect only marginal change.
+**Measured inside the nogil builder** (microbenchmark — **not** a substitute for a real `--demo` run):
 
-If a reproducible benchmark is measured on both images, publish the number **with the exact command**. Without a measurement, there is no number.
+| | SQLAlchemy **with** cext | SQLAlchemy **pure-Python** (`DISABLE_SQLALCHEMY_CEXT=1`) |
+| --- | --- | --- |
+| GIL after `import sqlalchemy` | **True** (defeats `-nogil`) | **False** |
+| regex 8 threads vs 1 thread | **0.90×** (slower than 1 thread) | **5.30×** |
+| sqlalchemy SELECT 300 rows | baseline | **+21%** wall |
+| sqlalchemy INSERT 3k | unchanged | unchanged |
+
+So the image pays a measured **~21%** on that SELECT path to keep **~5.3×** on the real detection bottleneck. Do **not** invent other multipliers. If you publish a full `--demo` comparison, include the exact command.
+
+**Do not** force `PYTHON_GIL=0` / `-Xgil=0` to keep cext: that runs C extensions that did **not** declare free-threaded safety — silent data races on findings are worse than a slower SELECT.
 
 #### License tier still caps workers
 

--- a/docs/ops/DOCKER_HUB_REPOSITORY_DESCRIPTION.md
+++ b/docs/ops/DOCKER_HUB_REPOSITORY_DESCRIPTION.md
@@ -2,9 +2,9 @@
 
 **Purpose:** The [Docker Hub UI](https://hub.docker.com/r/fabioleitao/data_boar) **Short description** and **Full description** are **not** stored in Git. This file is the **canonical text** to paste after each release so Hub stays aligned with **`pyproject.toml`**, [docs/deploy/DEPLOY.md](../deploy/DEPLOY.md), and [docs/releases/](../releases/).
 
-**When to update:** Immediately after you push **`fabioleitao/data_boar:<semver>`** and **`latest`** for a **stable** / **`.postN`** image publish. Bump the **Current release** line and **Supported tags** below to match [CHANGELOG.md](../../CHANGELOG.md) / the published tag. **Docker Hub does not read this file** — you must open **Repository → General → Edit** and paste; otherwise the public page can stay stuck for months.
+**When to update:** Immediately after you push **`fabioleitao/data_boar:<semver>`** and **`latest`** for a **stable** / **`.postN`** image publish (and after publishing a companion **`-nogil`** tag). Bump the **Current release** lines below to match the published tags. **Docker Hub does not read this file** — you must open **Repository → General → Edit** and paste; otherwise the public page can stay stuck for months.
 
-**Portuguese pointer:** [DOCKER_HUB_REPOSITORY_DESCRIPTION.pt_BR.md](DOCKER_HUB_REPOSITORY_DESCRIPTION.pt_BR.md)
+**Portuguese twin (choice section):** [DOCKER_HUB_REPOSITORY_DESCRIPTION.pt_BR.md](DOCKER_HUB_REPOSITORY_DESCRIPTION.pt_BR.md)
 
 **Operator ritual:** [DOCKER_IMAGE_RELEASE_ORDER.pt_BR.md](DOCKER_IMAGE_RELEASE_ORDER.pt_BR.md) **passo 9 (Hub UI)** — after push, paste **Short** + **Full** from this file (replace the entire Full description).
 
@@ -15,7 +15,7 @@
 Use one line (adjust version when you bump):
 
 ```text
-Data Boar — PII discovery (LGPD/GDPR). GIL popcnt=0 + optional -nogil (x86-64-v2+).
+Data Boar — PII discovery. Default: any x86-64. Optional -nogil: real parallelism (v2+).
 ```
 
 ---
@@ -31,17 +31,47 @@ Copy from the block below into **Repository → Edit** on Docker Hub.
 
 **Compliance-aware discovery** of personal and sensitive data across databases, files, APIs, and more — **data soup** in, structured findings out. Open-source Python stack with optional ML/DL; aligns with **LGPD**, **GDPR**, **CCPA**, and other frameworks via config.
 
-**Current Hub image:** **`latest`** and **`1.7.4.post12`** resolve to the **same digest** (Linux/amd64, measured **2026-07-30**):
+Two published image variants. **Pick by workload and CPU — not by tag name alone.**
 
-`sha256:ab8f5dad3e33618e5c0dbb6d880ddafa11fc0e39c8372d5f0f1a2316d8597842` (~**309 MB** compressed on Hub).
+### Which image should I pull?
 
-**Runtime shape:** multi-stage build → **`python:3.14-slim`** (Debian 13 / trixie, digest-pinned) → **`gcr.io/distroless/cc-debian13:nonroot`** (uid **65532**, no shell / no apt). ML stack force-reinstalled from the hosted **x86-64-v1** wheelhouse (`wheelhouse-x86-64-v1-2026-07-29`) so **`popcnt=0`** on site-packages `.so` — runs on **any x86-64**, including Celeron-class CPUs without AVX. **`boar_fast_filter`** (Rust accelerator) is **embedded** in the image.
+#### `latest` / `1.7.4.post12` — universal default
 
-**Also on Hub (historical, not `latest`):** immutable June GA tag **`1.7.4`** (`sha256:04b4cd7d…`) — left untouched when post12 published. Prefer **`1.7.4.post12`** / **`latest`** for new deploys unless you intentionally pin the June digest.
+This is the image you want unless you have a concrete reason to opt into free-threading.
 
-**Free-threaded companion tag (optional):** **`1.7.4.post12-nogil`** — CPython **3.14t** (no-GIL) via `uv`-installed python-build-standalone (there is **no** `python:3.14t-slim` on Docker Hub). Uses wheelhouse **`cp314t`** cells + **`boar_fast_filter` cp314t** (`abi3` does **not** load). **CPU: x86-64-v2+** (numpy cp314t measured `popcnt=1477`) — **does not** run on alpine-emachines / Celeron-class hosts. **Does not** move **`latest`**. Build file: **`Dockerfile.nogil`**.
+- Python **3.14 with the GIL**, multi-stage → **`python:3.14-slim`** → **`gcr.io/distroless/cc-debian13:nonroot`** (uid **65532**, no shell / no apt).
+- **`popcnt = 0`** on **540** site-packages `.so` files (measured) → runs on **any x86-64**, including a **2009 Celeron 900** without AVX.
+- Full ML stack from the hosted x86-64-v1 wheelhouse: **numpy 2.5.1 · scipy 1.18.0 · scikit-learn 1.9.0 · pandas 3.0.5**.
+- **`boar_fast_filter`** (Rust accelerator) via **`abi3`** (loads on GIL CPython 3.8+).
+- Digest (measured **2026-07-30**): `sha256:ab8f5dad3e33618e5c0dbb6d880ddafa11fc0e39c8372d5f0f1a2316d8597842` (~**309 MB** compressed on Hub).
 
-Confirm **`pyproject.toml`** and **[GitHub Releases](https://github.com/DataBoar/data-boar/releases)** for the exact pairing. Wheelhouse assets: **[wheelhouse-x86-64-v1-2026-07-29](https://github.com/DataBoar/data-boar-site/releases/tag/wheelhouse-x86-64-v1-2026-07-29)**.
+**Use this when:** you are unsure which to pick · hardware is old or mixed · on-prem fleet age is unknown · you need the guaranteed floor.
+
+#### `1.7.4.post12-nogil` — real parallelism (opt-in)
+
+- Python **3.14t free-threaded** (PEP 703). Inside the container: `sys._is_gil_enabled()` → **False**.
+- Same ML versions, but wheels are **`cp314t`**. **`cp314` and `cp314t` are not interchangeable** (different `SOABI`).
+- **`boar_fast_filter`** is built **native for `cp314t`** — the **`abi3`** wheel from the GIL image **does not load** here.
+- **Requires x86-64-v2+.** Upstream **numpy cp314t** uses **`popcnt`** (**1477** hits measured). **Will not run** on CPUs without SSE4.2/POPCNT (e.g. alpine-emachines / Celeron 900).
+- **`:latest` never points here.** Publishing `-nogil` must not retag `:latest` or the June GA `:1.7.4`.
+
+**Use this when:** the host CPU is modern **and** you run **several workers** **and** detection is **regex-bound**.
+
+**Do not use when:** hardware is old/unknown, or you run **one worker** (no parallelism to unlock).
+
+#### What “faster” means here (no invented multipliers)
+
+Do **not** expect a marketed “N× speedup” without a published benchmark. The mechanism ([#551](https://github.com/DataBoar/data-boar/issues/551)):
+
+- Workers that spend time in **pure-Python regex** (`core/detector.py`) are **serialized by the GIL** even when `max_workers` is high. Free-threaded CPython removes that serialization so those workers can run together.
+- **`boar_fast_filter`** (PyO3) **already releases the GIL** — gain on that path is smaller.
+- **I/O-bound** workers were never GIL-bound — expect only marginal change.
+
+If a reproducible benchmark is measured on both images, publish the number **with the exact command**. Without a measurement, there is no number.
+
+#### License tier still caps workers
+
+The free-threaded image is public, but **parallelism ceiling is a license concern**, not an image concern. Effective workers are `min(scan.max_workers, tier cap)` in `core/engine.py` (licensing worker cap / `#551`); open mode without a JWT uses `OPEN_MODE_WORKER_CAP`. Full benefit of many workers depends on the tier that allows them.
 
 ### Copyright and maintainer
 
@@ -49,14 +79,14 @@ Confirm **`pyproject.toml`** and **[GitHub Releases](https://github.com/DataBoar
 - **Professional profile:** Add your LinkedIn URL in the Hub **Full description** editor when publishing (do not embed personal profile URLs in this tracked file).
 - **Security:** Vulnerability reporting — [SECURITY.md](https://github.com/DataBoar/data-boar/blob/main/SECURITY.md).
 
-### Supported tags
+### Supported tags (reference)
 
-| Tag | Role |
-| --- | ---- |
-| **`fabioleitao/data_boar:latest`** | Newest **GIL** published build (same digest as **`1.7.4.post12`**) — **never** the `-nogil` image |
-| **`fabioleitao/data_boar:1.7.4.post12`** | Current GIL image (Python **3.14** / distroless / **popcnt=0** / any x86-64) |
-| **`fabioleitao/data_boar:1.7.4.post12-nogil`** | Free-threaded companion (**3.14t** / **cp314t** / **x86-64-v2+** only) |
-| **`fabioleitao/data_boar:1.7.4`** | June 2026 GA image (historical; **not** retagged by post12) |
+| Tag | What it is |
+| --- | ---------- |
+| **`fabioleitao/data_boar:latest`** | Same digest as **`1.7.4.post12`** (universal GIL). **Never** `-nogil`. |
+| **`fabioleitao/data_boar:1.7.4.post12`** | Universal GIL image (any x86-64, `popcnt=0`) |
+| **`fabioleitao/data_boar:1.7.4.post12-nogil`** | Free-threaded opt-in (x86-64-v2+ only) |
+| **`fabioleitao/data_boar:1.7.4`** | June 2026 GA (historical; not retagged by post12) |
 
 ### Quick start (web API + dashboard on port 8088)
 
@@ -69,9 +99,18 @@ docker run -d -p 8088:8088 -v "$(pwd)/data:/data" -e CONFIG_PATH=/data/config.ya
 
 Create `data/config.yaml` from the repo’s `deploy/config.example.yaml` if you do not have one.
 
+Free-threaded (modern CPU only):
+
+```bash
+docker pull fabioleitao/data_boar:1.7.4.post12-nogil
+docker run -d -p 8088:8088 -v "$(pwd)/data:/data" -e CONFIG_PATH=/data/config.yaml \
+  fabioleitao/data_boar:1.7.4.post12-nogil
+```
+
 ### CLI one-shot (override container command)
 
-Distroless entrypoint is **`/usr/local/bin/python3.14`** (symlink **`python3`** / **`python`** also present):
+GIL image entrypoint: **`/usr/local/bin/python3.14`** (symlinks **`python3`** / **`python`**).  
+`-nogil` entrypoint: **`/usr/local/bin/python3.14t`**.
 
 ```bash
 docker run --rm -v "$(pwd)/data:/data" fabioleitao/data_boar:latest \
@@ -81,25 +120,25 @@ docker run --rm -v "$(pwd)/data:/data" fabioleitao/data_boar:latest \
 ### Documentation
 
 - **Usage / CLI / config:** [https://github.com/DataBoar/data-boar/blob/main/docs/USAGE.md](https://github.com/DataBoar/data-boar/blob/main/docs/USAGE.md)
-- **Deploy (Docker Compose, Swarm, Kubernetes):** [https://github.com/DataBoar/data-boar/blob/main/docs/deploy/DEPLOY.md](https://github.com/DataBoar/data-boar/blob/main/docs/deploy/DEPLOY.md)
+- **Deploy:** [https://github.com/DataBoar/data-boar/blob/main/docs/deploy/DEPLOY.md](https://github.com/DataBoar/data-boar/blob/main/docs/deploy/DEPLOY.md)
 - **Releases:** [https://github.com/DataBoar/data-boar/releases](https://github.com/DataBoar/data-boar/releases)
 - **Wheelhouse (x86-64-v1 + cp314t):** [https://github.com/DataBoar/data-boar-site/releases/tag/wheelhouse-x86-64-v1-2026-07-29](https://github.com/DataBoar/data-boar-site/releases/tag/wheelhouse-x86-64-v1-2026-07-29)
+- **Free-threading rationale:** [issue #551](https://github.com/DataBoar/data-boar/issues/551)
 
 **Source:** [https://github.com/DataBoar/data-boar](https://github.com/DataBoar/data-boar)
 
 ### Build and push (maintainers)
 
-From the repo root, after tests pass and you are logged in to Docker Hub (daemonless ritual on Linux):
-
 ```bash
-# GIL / universal (moves :latest)
+# Universal GIL — ritual moves :latest
 ~/.local/bin/build-push-podman.sh 1.7.4.post12 --debug
 
-# Free-threaded companion (local validate; operator pushes :…-nogil only — never :latest)
+# Free-threaded companion — validate locally; push ONLY :…-nogil (never :latest)
 ./scripts/docker/build-nogil-local.sh 1.7.4.post12-nogil
+podman push localhost/data_boar:1.7.4.post12-nogil docker.io/fabioleitao/data_boar:1.7.4.post12-nogil
 ```
 
-Windows / Docker Desktop path: see [DOCKER_IMAGE_RELEASE_ORDER.md](https://github.com/DataBoar/data-boar/blob/main/docs/ops/DOCKER_IMAGE_RELEASE_ORDER.md). After push, **replace the entire Full description** on Hub from this file so **Supported tags** stay in sync with the **Tags** tab.
+See [DOCKER_IMAGE_RELEASE_ORDER.md](https://github.com/DataBoar/data-boar/blob/main/docs/ops/DOCKER_IMAGE_RELEASE_ORDER.md). After any customer-pullable push, **replace the entire Full description** on Hub from this file.
 ```
 
 
@@ -110,6 +149,6 @@ Windows / Docker Desktop path: see [DOCKER_IMAGE_RELEASE_ORDER.md](https://githu
 
 1. Push image tags per [DOCKER_IMAGE_RELEASE_ORDER.md](DOCKER_IMAGE_RELEASE_ORDER.md) (**stable** / **`.postN`** customer-pullable tags — **`-beta`** / **`-rc`** preview pushes do **not** require updating the public Hub marketing text).
 2. In Docker Hub **Repository → General → Edit**: paste **Short** (one line) + **Full** (entire fenced block from [Full description](#full-description-docker-hub--markdown) above). **Replace the whole Full description**, do not patch a paragraph in the middle — old custom sections survive otherwise.
-3. After paste, open the public repo page and **visually confirm** **Current release**, **Supported tags** / semver examples, and the **Short description** preview — no stale pinned version.
+3. After paste, open the public repo page and **visually confirm** the **Which image should I pull?** section (not only the tag table), plus Short preview.
 4. Refresh [today-mode/PUBLISHED_SYNC.md](today-mode/PUBLISHED_SYNC.md) ([pt-BR](today-mode/PUBLISHED_SYNC.pt_BR.md)) — guarded by **`tests/test_published_sync.py`**.
 5. Sweep **customer-facing** copy: [README.md](../../README.md) / [README.pt_BR.md](../../README.pt_BR.md) **Current release** line, [VERSIONING.md](../VERSIONING.md) checklist, milestone/social drafts that cite a version (see **§ Distribution** in VERSIONING).

--- a/docs/ops/DOCKER_HUB_REPOSITORY_DESCRIPTION.md
+++ b/docs/ops/DOCKER_HUB_REPOSITORY_DESCRIPTION.md
@@ -15,7 +15,7 @@
 Use one line (adjust version when you bump):
 
 ```text
-Data Boar — PII discovery (LGPD/GDPR). 3.14-slim distroless, popcnt=0. Tags: latest, 1.7.4.post12.
+Data Boar — PII discovery (LGPD/GDPR). GIL popcnt=0 + optional -nogil (x86-64-v2+).
 ```
 
 ---
@@ -39,7 +39,9 @@ Copy from the block below into **Repository → Edit** on Docker Hub.
 
 **Also on Hub (historical, not `latest`):** immutable June GA tag **`1.7.4`** (`sha256:04b4cd7d…`) — left untouched when post12 published. Prefer **`1.7.4.post12`** / **`latest`** for new deploys unless you intentionally pin the June digest.
 
-Confirm **`pyproject.toml`** and **[GitHub Releases](https://github.com/DataBoar/data-boar/releases)** for the exact pairing. Free-threaded (**no-GIL** / **`cp314t`**) wheels for lab / Enterprise foresight live in the **[wheelhouse release](https://github.com/DataBoar/data-boar-site/releases/tag/wheelhouse-x86-64-v1-2026-07-29)** (not inside this container — image uses GIL **`cp314`**).
+**Free-threaded companion tag (optional):** **`1.7.4.post12-nogil`** — CPython **3.14t** (no-GIL) via `uv`-installed python-build-standalone (there is **no** `python:3.14t-slim` on Docker Hub). Uses wheelhouse **`cp314t`** cells + **`boar_fast_filter` cp314t** (`abi3` does **not** load). **CPU: x86-64-v2+** (numpy cp314t measured `popcnt=1477`) — **does not** run on alpine-emachines / Celeron-class hosts. **Does not** move **`latest`**. Build file: **`Dockerfile.nogil`**.
+
+Confirm **`pyproject.toml`** and **[GitHub Releases](https://github.com/DataBoar/data-boar/releases)** for the exact pairing. Wheelhouse assets: **[wheelhouse-x86-64-v1-2026-07-29](https://github.com/DataBoar/data-boar-site/releases/tag/wheelhouse-x86-64-v1-2026-07-29)**.
 
 ### Copyright and maintainer
 
@@ -51,8 +53,9 @@ Confirm **`pyproject.toml`** and **[GitHub Releases](https://github.com/DataBoar
 
 | Tag | Role |
 | --- | ---- |
-| **`fabioleitao/data_boar:latest`** | Newest published build (same digest as **`1.7.4.post12`**) |
-| **`fabioleitao/data_boar:1.7.4.post12`** | Current immutable post-release image (Python **3.14** / distroless / **popcnt=0**) |
+| **`fabioleitao/data_boar:latest`** | Newest **GIL** published build (same digest as **`1.7.4.post12`**) — **never** the `-nogil` image |
+| **`fabioleitao/data_boar:1.7.4.post12`** | Current GIL image (Python **3.14** / distroless / **popcnt=0** / any x86-64) |
+| **`fabioleitao/data_boar:1.7.4.post12-nogil`** | Free-threaded companion (**3.14t** / **cp314t** / **x86-64-v2+** only) |
 | **`fabioleitao/data_boar:1.7.4`** | June 2026 GA image (historical; **not** retagged by post12) |
 
 ### Quick start (web API + dashboard on port 8088)
@@ -89,8 +92,11 @@ docker run --rm -v "$(pwd)/data:/data" fabioleitao/data_boar:latest \
 From the repo root, after tests pass and you are logged in to Docker Hub (daemonless ritual on Linux):
 
 ```bash
-# Canonical local ritual (build → smoke → grype --fail-on high --only-fixed → push)
+# GIL / universal (moves :latest)
 ~/.local/bin/build-push-podman.sh 1.7.4.post12 --debug
+
+# Free-threaded companion (local validate; operator pushes :…-nogil only — never :latest)
+./scripts/docker/build-nogil-local.sh 1.7.4.post12-nogil
 ```
 
 Windows / Docker Desktop path: see [DOCKER_IMAGE_RELEASE_ORDER.md](https://github.com/DataBoar/data-boar/blob/main/docs/ops/DOCKER_IMAGE_RELEASE_ORDER.md). After push, **replace the entire Full description** on Hub from this file so **Supported tags** stay in sync with the **Tags** tab.

--- a/docs/ops/DOCKER_HUB_REPOSITORY_DESCRIPTION.pt_BR.md
+++ b/docs/ops/DOCKER_HUB_REPOSITORY_DESCRIPTION.pt_BR.md
@@ -1,11 +1,63 @@
 # Docker Hub — descrição do repositório (fonte para copiar/colar)
 
-**English (canônico):** [DOCKER_HUB_REPOSITORY_DESCRIPTION.md](DOCKER_HUB_REPOSITORY_DESCRIPTION.md)
+**English (canônico para colar no Hub UI):** [DOCKER_HUB_REPOSITORY_DESCRIPTION.md](DOCKER_HUB_REPOSITORY_DESCRIPTION.md)
 
-**Objetivo:** O texto curto e a descrição longa no [Docker Hub](https://hub.docker.com/r/fabioleitao/data_boar) **não** ficam versionados no Git. O documento em inglês [DOCKER_HUB_REPOSITORY_DESCRIPTION.md](DOCKER_HUB_REPOSITORY_DESCRIPTION.md) é a **fonte** para colar após cada release **estável** (**`X.Y.Z`** final), alinhada a **`pyproject.toml`** e a **`docs/releases/`**. Também use-o quando publicar **tags só de imagem** que clientes vão puxar (ex.: **`1.7.3`**) ou apagar tags no Hub — a UI **não** segue o Git; substitua a **Full description inteira** na mesma sessão do push.
+**Objetivo:** O texto curto e a descrição longa no [Docker Hub](https://hub.docker.com/r/fabioleitao/data_boar) **não** ficam versionados no Git. O documento em inglês é a **fonte** para colar após cada release (passo 9 do ritual). Este arquivo é o **gêmeo pt-BR** da seção de **escolha** — o usuário precisa entender **motivo e aplicação** de cada variante, não só a lista de tags.
 
-**Quando atualizar:** Logo após **`docker push`** / ritual podman de **`fabioleitao/data_boar:<semver>`** e **`latest`** (inclui **`.postN`**). No Hub: **Repository → General → Edit** — cole **Short** + **Full** inteiro do documento em inglês (substitua a descrição longa por completo). Atualize a versão no EN **antes** de colar. Ritual: [DOCKER_IMAGE_RELEASE_ORDER.pt_BR.md](DOCKER_IMAGE_RELEASE_ORDER.pt_BR.md) **passo 9**.
+**Quando atualizar:** Logo após **`docker push`** / ritual podman de **`fabioleitao/data_boar:<semver>`** e **`latest`** (e após publicar **`-nogil`**). No Hub: cole **Short** + **Full** do **EN**. Mantenha este pt-BR alinhado (LCM). Ritual: [DOCKER_IMAGE_RELEASE_ORDER.pt_BR.md](DOCKER_IMAGE_RELEASE_ORDER.pt_BR.md) **passo 9**.
 
-**Checklist:** Veja **Maintainer checklist** no documento em inglês (inclui **copyright/mantenedor** no **Full** — link opcional ao **LinkedIn** no editor do Hub). **Pushes só de imagem `-beta` / `-rc`** não exigem atualizar o texto público do repositório salvo pedido explícito. Mantenha **[PUBLISHED_SYNC.md](today-mode/PUBLISHED_SYNC.md)** coerente com o que os clientes podem puxar do Hub.
+---
 
-**Versão em todos os artefatos:** [VERSIONING.md](../VERSIONING.md) (seção **6. Distribuição…**, EN) — Docker Hub, `PUBLISHED_SYNC`, TECH_GUIDE, rascunhos sociais.
+## Qual imagem puxar? (escolha)
+
+Duas variantes publicadas. **Escolha pelo workload e pela CPU — não só pelo nome da tag.**
+
+### `latest` / `1.7.4.post12` — universal, é o default
+
+Use esta a menos que tenha motivo concreto para free-threading.
+
+- Python **3.14 com GIL**, distroless nonroot (uid **65532**).
+- **`popcnt = 0`** em **540** `.so` (medido) → roda em **qualquer x86-64**, inclusive **Celeron 900 de 2009** sem AVX.
+- ML completo: **numpy 2.5.1 · scipy 1.18.0 · scikit-learn 1.9.0 · pandas 3.0.5**.
+- **`boar_fast_filter`** (Rust) via **`abi3`**.
+- ~**309 MB** no Hub (`sha256:ab8f5dad3e336…`, medido **2026-07-30**).
+
+**Use esta se:** não sabe qual escolher · hardware antigo ou heterogêneo · frota mista · on-prem com máquina de idade desconhecida · quer o piso garantido.
+
+### `1.7.4.post12-nogil` — paralelismo real (opt-in)
+
+- Python **3.14t free-threaded** (PEP 703); `sys._is_gil_enabled()` → **False**.
+- Mesmo ML, wheels **`cp314t`** — **`cp314` e `cp314t` não são intercambiáveis**.
+- **`boar_fast_filter`** compilado **nativo para `cp314t`** (não abi3).
+- **Exige x86-64-v2+** — o **numpy cp314t** de upstream usa **`popcnt`** (**1477** ocorrências, medido). **Não roda** em CPU sem SSE4.2/POPCNT.
+- **`:latest` nunca aponta para esta tag.**
+
+**Use esta se:** CPU moderna **e** vários workers **e** detecção **regex-bound**.
+
+**Não use se:** hardware antigo/desconhecido, ou **1 worker** (não há ganho).
+
+### O que “mais rápido” significa (sem número inventado)
+
+Não prometa “N× mais rápido” sem benchmark publicado. O mecanismo ([#551](https://github.com/DataBoar/data-boar/issues/551)):
+
+- Workers em **regex Python puro** (`core/detector.py`) são **serializados pelo GIL** mesmo com `max_workers` alto; free-threaded remove essa serialização.
+- **`boar_fast_filter`** (PyO3) **já libera o GIL** — ganho menor nesse caminho.
+- Workers **I/O-bound**: o GIL nunca foi o gargalo — ganho marginal.
+
+Se medir nas duas imagens, publique o número **com o comando que reproduz**. Sem medição, sem número.
+
+### Tier de licença ainda limita workers
+
+A imagem free-threaded é pública, mas o **teto de paralelismo é da licença**. Em `core/engine.py` o efetivo é `min(scan.max_workers, tier cap)` (`#551`); sem JWT vale `OPEN_MODE_WORKER_CAP`. O benefício pleno de muitos workers depende do tier que os autoriza — fato operacional, não pitch de venda.
+
+---
+
+## Tags (referência rápida)
+
+| Tag | Papel |
+| --- | ----- |
+| **`latest`** / **`1.7.4.post12`** | Universal (GIL). Default. |
+| **`1.7.4.post12-nogil`** | Free-threaded opt-in (x86-64-v2+). |
+| **`1.7.4`** | GA de junho/2026 (histórica). |
+
+**Checklist / versão nos artefatos:** [VERSIONING.md](../VERSIONING.md) · [PUBLISHED_SYNC.md](today-mode/PUBLISHED_SYNC.md).

--- a/docs/ops/DOCKER_HUB_REPOSITORY_DESCRIPTION.pt_BR.md
+++ b/docs/ops/DOCKER_HUB_REPOSITORY_DESCRIPTION.pt_BR.md
@@ -26,9 +26,10 @@ Use esta a menos que tenha motivo concreto para free-threading.
 
 ### `1.7.4.post12-nogil` — paralelismo real (opt-in)
 
-- Python **3.14t free-threaded** (PEP 703); `sys._is_gil_enabled()` → **False**.
+- Python **3.14t free-threaded** (PEP 703); `sys._is_gil_enabled()` → **False** — **inclusive depois de `import sqlalchemy`**.
 - Mesmo ML, wheels **`cp314t`** — **`cp314` e `cp314t` não são intercambiáveis**.
 - **`boar_fast_filter`** compilado **nativo para `cp314t`** (não abi3).
+- **SQLAlchemy é puro-Python nesta imagem** (`DISABLE_SQLALCHEMY_CEXT=1`, zero `.so` em `sqlalchemy/**`). O cyextension de estoque **religa o GIL** no import e anularia o propósito da `-nogil`. Na imagem GIL (`latest` / `post12`) o cext **permanece** — correto lá.
 - **Exige x86-64-v2+** — o **numpy cp314t** de upstream usa **`popcnt`** (**1477** ocorrências, medido). **Não roda** em CPU sem SSE4.2/POPCNT.
 - **`:latest` nunca aponta para esta tag.**
 
@@ -36,15 +37,11 @@ Use esta a menos que tenha motivo concreto para free-threading.
 
 **Não use se:** hardware antigo/desconhecido, ou **1 worker** (não há ganho).
 
-### O que “mais rápido” significa (sem número inventado)
+### O que “mais rápido” significa (microbenchmark medido + mecanismo)
 
-Não prometa “N× mais rápido” sem benchmark publicado. O mecanismo ([#551](https://github.com/DataBoar/data-boar/issues/551)):
+Mecanismo ([#551](https://github.com/DataBoar/data-boar/issues/551)): workers em **regex Python puro** (`core/detector.py`) são **serializados pelo GIL**; free-threaded remove isso. **`boar_fast_filter`** já libera o GIL (ganho menor). I/O-bound: marginal.
 
-- Workers em **regex Python puro** (`core/detector.py`) são **serializados pelo GIL** mesmo com `max_workers` alto; free-threaded remove essa serialização.
-- **`boar_fast_filter`** (PyO3) **já libera o GIL** — ganho menor nesse caminho.
-- Workers **I/O-bound**: o GIL nunca foi o gargalo — ganho marginal.
-
-Se medir nas duas imagens, publique o número **com o comando que reproduz**. Sem medição, sem número.
+**Medido no builder nogil** (microbenchmark — **não** substitui `--demo` real): com cext, GIL volta a **True** e regex 8 threads fica **0,90×** (pior que 1 thread); sem cext, GIL fica **False** e regex 8 threads fica **5,30×**, com SELECT ~**+21%** e INSERT igual. A imagem paga esse SELECT para não anular o paralelismo da detecção. Sem outros multiplicadores inventados. **Não** use `PYTHON_GIL=0` / `-Xgil=0` para manter o cext.
 
 ### Tier de licença ainda limita workers
 

--- a/docs/ops/DOCKER_IMAGE_RELEASE_ORDER.md
+++ b/docs/ops/DOCKER_IMAGE_RELEASE_ORDER.md
@@ -28,14 +28,20 @@ Use this when you want **one published image** to match **one released app versi
 
 ---
 
-## Two image variants (CPU contracts)
+## Two image variants (choice + ritual)
 
-| Variant | File | Hub tag (example) | Interpreter | Wheelhouse | CPU | Moves `:latest`? |
-| ------- | ---- | ----------------- | ----------- | ---------- | --- | ---------------- |
-| **Universal (GIL)** | `Dockerfile` | `1.7.4.post12`, `latest` | `python:3.14-slim` (GIL) | `cp314` + `boar_fast_filter` **abi3**; **`popcnt=0`** gate | **any x86-64** (incl. Celeron / alpine-emachines) | **Yes** (this only) |
-| **Free-threaded (no-GIL)** | `Dockerfile.nogil` | `1.7.4.post12-nogil` | `uv python install 3.14.6+freethreaded` → `python3.14t` | `cp314t` + `boar_fast_filter` **cp314t** (abi3 **does not** load) | **x86-64-v2+** (numpy cp314t has `popcnt≠0` — deliberate) | **No** |
+The default ritual (**steps 4–6** above / `build-push-podman.sh`) publishes the **universal GIL** image and moves **`:latest`** with it. The **`-nogil`** companion is a **separate** build (`Dockerfile.nogil` / `build-nogil-local.sh`) and a **separate** Hub tag. **`:latest` never points at `-nogil`.**
 
-Local build/validate (no push):
+| Variant | When to choose it | Ritual publishes? | Moves `:latest`? |
+| ------- | ----------------- | ----------------- | ---------------- |
+| **Universal GIL** (`1.7.4.post12`, `latest`) | Default: unknown/old/mixed CPU; need `popcnt=0` floor (any x86-64, incl. Celeron 900). `abi3` filter. | **Yes** — main ritual | **Yes** |
+| **Free-threaded** (`1.7.4.post12-nogil`) | Modern **x86-64-v2+** CPU **and** several workers **and** regex-bound detection ([#551](https://github.com/DataBoar/data-boar/issues/551)). `cp314t` wheels; abi3 filter does **not** load. | **Opt-in only** — never via the `:latest` ritual | **No** |
+
+**Mechanism (no invented speedup):** GIL serializes pure-Python regex workers (`core/detector.py`) even with high `max_workers`; free-threaded removes that. `boar_fast_filter` already releases the GIL (smaller gain). I/O-bound workers: marginal. Publish numbers only with a reproducible command. Worker **ceiling** remains the license tier (`core/engine.py` / `#551`), not the image tag.
+
+Hub copy must explain this **choice** (not only list tags): [DOCKER_HUB_REPOSITORY_DESCRIPTION.md](DOCKER_HUB_REPOSITORY_DESCRIPTION.md) § *Which image should I pull?* · [pt-BR](DOCKER_HUB_REPOSITORY_DESCRIPTION.pt_BR.md).
+
+Local build/validate `-nogil` (no push):
 
 ```bash
 ./scripts/docker/build-nogil-local.sh 1.7.4.post12-nogil

--- a/docs/ops/DOCKER_IMAGE_RELEASE_ORDER.md
+++ b/docs/ops/DOCKER_IMAGE_RELEASE_ORDER.md
@@ -35,9 +35,9 @@ The default ritual (**steps 4–6** above / `build-push-podman.sh`) publishes th
 | Variant | When to choose it | Ritual publishes? | Moves `:latest`? |
 | ------- | ----------------- | ----------------- | ---------------- |
 | **Universal GIL** (`1.7.4.post12`, `latest`) | Default: unknown/old/mixed CPU; need `popcnt=0` floor (any x86-64, incl. Celeron 900). `abi3` filter. | **Yes** — main ritual | **Yes** |
-| **Free-threaded** (`1.7.4.post12-nogil`) | Modern **x86-64-v2+** CPU **and** several workers **and** regex-bound detection ([#551](https://github.com/DataBoar/data-boar/issues/551)). `cp314t` wheels; abi3 filter does **not** load. | **Opt-in only** — never via the `:latest` ritual | **No** |
+| **Free-threaded** (`1.7.4.post12-nogil`) | Modern **x86-64-v2+** CPU **and** several workers **and** regex-bound detection ([#551](https://github.com/DataBoar/data-boar/issues/551)). `cp314t` wheels; abi3 filter does **not** load; **SQLAlchemy pure-Python** (`DISABLE_SQLALCHEMY_CEXT=1`) so cext cannot re-enable the GIL. | **Opt-in only** — never via the `:latest` ritual | **No** |
 
-**Mechanism (no invented speedup):** GIL serializes pure-Python regex workers (`core/detector.py`) even with high `max_workers`; free-threaded removes that. `boar_fast_filter` already releases the GIL (smaller gain). I/O-bound workers: marginal. Publish numbers only with a reproducible command. Worker **ceiling** remains the license tier (`core/engine.py` / `#551`), not the image tag.
+**Mechanism:** GIL serializes pure-Python regex workers (`core/detector.py`); free-threaded removes that. Stock SQLAlchemy cext **re-enables the GIL** — `-nogil` must ship pure-Python sqlalchemy (measured: ~5.3× regex parallel vs ~+21% SELECT; microbenchmark ≠ `--demo`). Never force `PYTHON_GIL=0` to keep cext. Worker **ceiling** remains the license tier (`core/engine.py` / `#551`).
 
 Hub copy must explain this **choice** (not only list tags): [DOCKER_HUB_REPOSITORY_DESCRIPTION.md](DOCKER_HUB_REPOSITORY_DESCRIPTION.md) § *Which image should I pull?* · [pt-BR](DOCKER_HUB_REPOSITORY_DESCRIPTION.pt_BR.md).
 

--- a/docs/ops/DOCKER_IMAGE_RELEASE_ORDER.md
+++ b/docs/ops/DOCKER_IMAGE_RELEASE_ORDER.md
@@ -1,6 +1,6 @@
 # Docker image release order: merge → build → bump → push
 
-**Context:** After **PR #99**, the repo uses **`python:3.13-slim`** in the Dockerfile. Operators still need a **repeatable order** so Hub tags, app version, and Scout stay aligned. You prefer **small PRs**; this doc gives a default sequence and trade-offs.
+**Context:** The **universal (GIL)** image uses **`Dockerfile`** → **`python:3.14-slim`** → distroless. The **free-threaded (no-GIL)** variant uses **`Dockerfile.nogil`** (installs `3.14t` via **uv**; there is no `python:3.14t-slim` on Hub). Operators still need a **repeatable order** so Hub tags, app version, and the CVE gate stay aligned.
 
 **Related:** [scripts/docker/README.md](../../scripts/docker/README.md), [VERSIONING.md](../VERSIONING.md), [PLANS_TODO.md](../plans/PLANS_TODO.md) (orders **–1**, **–1b**), [HOMELAB_VALIDATION.md](HOMELAB_VALIDATION.md) (order **–1L** when the second environment is ready), [DOCKER_HUB_REPOSITORY_DESCRIPTION.md](DOCKER_HUB_REPOSITORY_DESCRIPTION.md) (Hub UI text — copy/paste after publish).
 
@@ -25,6 +25,24 @@ Use this when you want **one published image** to match **one released app versi
 | 9. **Hub UI** | **Docker Hub → Repository → Edit:** paste **Short** + **Full** description from [DOCKER_HUB_REPOSITORY_DESCRIPTION.md](DOCKER_HUB_REPOSITORY_DESCRIPTION.md); refresh [today-mode/PUBLISHED_SYNC.md](today-mode/PUBLISHED_SYNC.md) |
 
 **Why version before build/push:** The image **`COPY . .`** includes `pyproject.toml`. Building **after** the bump PR means the running app **inside the container** reports the same version as the **Hub semver tag** you push.
+
+---
+
+## Two image variants (CPU contracts)
+
+| Variant | File | Hub tag (example) | Interpreter | Wheelhouse | CPU | Moves `:latest`? |
+| ------- | ---- | ----------------- | ----------- | ---------- | --- | ---------------- |
+| **Universal (GIL)** | `Dockerfile` | `1.7.4.post12`, `latest` | `python:3.14-slim` (GIL) | `cp314` + `boar_fast_filter` **abi3**; **`popcnt=0`** gate | **any x86-64** (incl. Celeron / alpine-emachines) | **Yes** (this only) |
+| **Free-threaded (no-GIL)** | `Dockerfile.nogil` | `1.7.4.post12-nogil` | `uv python install 3.14.6+freethreaded` → `python3.14t` | `cp314t` + `boar_fast_filter` **cp314t** (abi3 **does not** load) | **x86-64-v2+** (numpy cp314t has `popcnt≠0` — deliberate) | **No** |
+
+Local build/validate (no push):
+
+```bash
+./scripts/docker/build-nogil-local.sh 1.7.4.post12-nogil
+# operator after login: podman push localhost/data_boar:1.7.4.post12-nogil docker.io/fabioleitao/data_boar:1.7.4.post12-nogil
+```
+
+Do **not** retag `:latest` or the June `:1.7.4` when publishing `-nogil`.
 
 ---
 

--- a/docs/ops/DOCKER_IMAGE_RELEASE_ORDER.pt_BR.md
+++ b/docs/ops/DOCKER_IMAGE_RELEASE_ORDER.pt_BR.md
@@ -2,7 +2,7 @@
 
 **English:** [DOCKER_IMAGE_RELEASE_ORDER.md](DOCKER_IMAGE_RELEASE_ORDER.md)
 
-**Contexto:** Após o **PR #99**, o repo usa **`python:3.13-slim`** no Dockerfile. Os operadores ainda precisam de uma **sequência repetível** para manter tags do Hub, versão do app e Scout alinhados. Esta doc define a sequência padrão e as variantes.
+**Contexto:** A imagem **universal (GIL)** usa **`Dockerfile`** → **`python:3.14-slim`** → distroless. A variante **free-threaded (no-GIL)** usa **`Dockerfile.nogil`** (instala `3.14t` via **uv**; não existe `python:3.14t-slim` no Hub). Os operadores ainda precisam de uma **sequência repetível** para manter tags do Hub, versão do app e gate alinhados.
 
 **Relacionado:** [scripts/docker/README.md](../../scripts/docker/README.md), [VERSIONING.md](../VERSIONING.md), [PLANS_TODO.md](../plans/PLANS_TODO.md) (ordens **–1**, **–1b**), [HOMELAB_VALIDATION.md](HOMELAB_VALIDATION.md) (ordem **–1L** para segundo ambiente), [DOCKER_HUB_REPOSITORY_DESCRIPTION.md](DOCKER_HUB_REPOSITORY_DESCRIPTION.md) (texto do Hub — colar após publicar).
 
@@ -26,6 +26,24 @@ Use quando quiser **uma imagem publicada** correspondendo a **uma versão do app
 | 9. **Hub UI**  | **Docker Hub → Repositório → Editar:** cole **Short** + **Full** de [DOCKER_HUB_REPOSITORY_DESCRIPTION.md](DOCKER_HUB_REPOSITORY_DESCRIPTION.md); atualize [today-mode/PUBLISHED_SYNC.md](today-mode/PUBLISHED_SYNC.md) |
 
 **Por que fazer o bump antes do build/push:** A imagem usa `COPY . .`, que inclui `pyproject.toml`. Fazer o build *depois* do bump garante que o app *dentro do contêiner* reporta a mesma versão que a tag semver publicada no Hub.
+
+---
+
+## Duas variantes de imagem (contratos de CPU)
+
+| Variante | Arquivo | Tag Hub (exemplo) | Interpretador | Wheelhouse | CPU | Move `:latest`? |
+| -------- | ------- | ----------------- | ------------- | ---------- | --- | --------------- |
+| **Universal (GIL)** | `Dockerfile` | `1.7.4.post12`, `latest` | `python:3.14-slim` (GIL) | `cp314` + `boar_fast_filter` **abi3**; gate **`popcnt=0`** | **qualquer x86-64** (incl. Celeron / alpine-emachines) | **Sim** (só esta) |
+| **Free-threaded (no-GIL)** | `Dockerfile.nogil` | `1.7.4.post12-nogil` | `uv python install 3.14.6+freethreaded` → `python3.14t` | `cp314t` + `boar_fast_filter` **cp314t** (abi3 **não** carrega) | **x86-64-v2+** (numpy cp314t tem `popcnt≠0` — proposital) | **Não** |
+
+Build/validação local da variante no-GIL (sem push):
+
+```bash
+./scripts/docker/build-nogil-local.sh 1.7.4.post12-nogil
+# operador, depois do login: podman push localhost/data_boar:1.7.4.post12-nogil docker.io/fabioleitao/data_boar:1.7.4.post12-nogil
+```
+
+**Não** retague `:latest` nem a tag de junho `:1.7.4` ao publicar `-nogil`.
 
 ---
 

--- a/docs/ops/DOCKER_IMAGE_RELEASE_ORDER.pt_BR.md
+++ b/docs/ops/DOCKER_IMAGE_RELEASE_ORDER.pt_BR.md
@@ -29,14 +29,20 @@ Use quando quiser **uma imagem publicada** correspondendo a **uma versão do app
 
 ---
 
-## Duas variantes de imagem (contratos de CPU)
+## Duas variantes de imagem (escolha + ritual)
 
-| Variante | Arquivo | Tag Hub (exemplo) | Interpretador | Wheelhouse | CPU | Move `:latest`? |
-| -------- | ------- | ----------------- | ------------- | ---------- | --- | --------------- |
-| **Universal (GIL)** | `Dockerfile` | `1.7.4.post12`, `latest` | `python:3.14-slim` (GIL) | `cp314` + `boar_fast_filter` **abi3**; gate **`popcnt=0`** | **qualquer x86-64** (incl. Celeron / alpine-emachines) | **Sim** (só esta) |
-| **Free-threaded (no-GIL)** | `Dockerfile.nogil` | `1.7.4.post12-nogil` | `uv python install 3.14.6+freethreaded` → `python3.14t` | `cp314t` + `boar_fast_filter` **cp314t** (abi3 **não** carrega) | **x86-64-v2+** (numpy cp314t tem `popcnt≠0` — proposital) | **Não** |
+O ritual padrão (**passos 4–6** / `build-push-podman.sh`) publica a imagem **universal GIL** e move **`:latest`** com ela. A companheira **`-nogil`** é build **separado** (`Dockerfile.nogil` / `build-nogil-local.sh`) e tag Hub **separada**. **`:latest` nunca aponta para `-nogil`.**
 
-Build/validação local da variante no-GIL (sem push):
+| Variante | Quando escolher | O ritual publica? | Move `:latest`? |
+| -------- | --------------- | ----------------- | --------------- |
+| **Universal GIL** (`1.7.4.post12`, `latest`) | Default: CPU antiga/mista/desconhecida; piso `popcnt=0` (qualquer x86-64, incl. Celeron 900). Filter `abi3`. | **Sim** — ritual principal | **Sim** |
+| **Free-threaded** (`1.7.4.post12-nogil`) | CPU moderna **x86-64-v2+** **e** vários workers **e** detecção regex-bound ([#551](https://github.com/DataBoar/data-boar/issues/551)). Wheels `cp314t`; abi3 **não** carrega. | **Só sob pedido** — nunca pelo ritual de `:latest` | **Não** |
+
+**Mecanismo (sem multiplicador inventado):** o GIL serializa workers de regex em Python puro (`core/detector.py`) mesmo com `max_workers` alto; free-threaded remove isso. `boar_fast_filter` já libera o GIL (ganho menor). I/O-bound: marginal. Número só com comando reproduzível. O **teto** de workers continua sendo o **tier de licença** (`core/engine.py` / `#551`), não a tag da imagem.
+
+A cópia do Hub deve explicar a **escolha** (não só listar tags): [DOCKER_HUB_REPOSITORY_DESCRIPTION.md](DOCKER_HUB_REPOSITORY_DESCRIPTION.md) · [pt-BR — Qual imagem puxar?](DOCKER_HUB_REPOSITORY_DESCRIPTION.pt_BR.md).
+
+Build/validação local da `-nogil` (sem push):
 
 ```bash
 ./scripts/docker/build-nogil-local.sh 1.7.4.post12-nogil

--- a/docs/ops/DOCKER_IMAGE_RELEASE_ORDER.pt_BR.md
+++ b/docs/ops/DOCKER_IMAGE_RELEASE_ORDER.pt_BR.md
@@ -36,9 +36,9 @@ O ritual padrão (**passos 4–6** / `build-push-podman.sh`) publica a imagem **
 | Variante | Quando escolher | O ritual publica? | Move `:latest`? |
 | -------- | --------------- | ----------------- | --------------- |
 | **Universal GIL** (`1.7.4.post12`, `latest`) | Default: CPU antiga/mista/desconhecida; piso `popcnt=0` (qualquer x86-64, incl. Celeron 900). Filter `abi3`. | **Sim** — ritual principal | **Sim** |
-| **Free-threaded** (`1.7.4.post12-nogil`) | CPU moderna **x86-64-v2+** **e** vários workers **e** detecção regex-bound ([#551](https://github.com/DataBoar/data-boar/issues/551)). Wheels `cp314t`; abi3 **não** carrega. | **Só sob pedido** — nunca pelo ritual de `:latest` | **Não** |
+| **Free-threaded** (`1.7.4.post12-nogil`) | CPU moderna **x86-64-v2+** **e** vários workers **e** detecção regex-bound ([#551](https://github.com/DataBoar/data-boar/issues/551)). Wheels `cp314t`; abi3 **não** carrega; **SQLAlchemy puro-Python** (`DISABLE_SQLALCHEMY_CEXT=1`) para o cext não religar o GIL. | **Só sob pedido** — nunca pelo ritual de `:latest` | **Não** |
 
-**Mecanismo (sem multiplicador inventado):** o GIL serializa workers de regex em Python puro (`core/detector.py`) mesmo com `max_workers` alto; free-threaded remove isso. `boar_fast_filter` já libera o GIL (ganho menor). I/O-bound: marginal. Número só com comando reproduzível. O **teto** de workers continua sendo o **tier de licença** (`core/engine.py` / `#551`), não a tag da imagem.
+**Mecanismo:** o GIL serializa workers de regex em Python puro (`core/detector.py`); free-threaded remove isso. O cext do SQLAlchemy de estoque **religa o GIL** — a `-nogil` deve embarcar sqlalchemy puro-Python (medido: ~5,3× regex paralelo vs ~+21% SELECT; microbenchmark ≠ `--demo`). Nunca forçar `PYTHON_GIL=0` para manter o cext. O **teto** de workers continua sendo o **tier de licença** (`core/engine.py` / `#551`).
 
 A cópia do Hub deve explicar a **escolha** (não só listar tags): [DOCKER_HUB_REPOSITORY_DESCRIPTION.md](DOCKER_HUB_REPOSITORY_DESCRIPTION.md) · [pt-BR — Qual imagem puxar?](DOCKER_HUB_REPOSITORY_DESCRIPTION.pt_BR.md).
 

--- a/scripts/docker/apply_wheelhouse_v1.sh
+++ b/scripts/docker/apply_wheelhouse_v1.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
-# Apply hosted x86-64-v1 wheelhouse ML wheels over a PyPI install (#1387).
+# Apply hosted x86-64-v1 / cp314t wheelhouse ML wheels over a PyPI install (#1387).
 #
 # Why: `pip install -r requirements.txt` pulls PyPI numpy/scipy with x86-64-v2+
-# (popcnt). The published image must run on alpine-emachines (Celeron 900 /
+# (popcnt). The published GIL image must run on alpine-emachines (Celeron 900 /
 # SSSE3-only, gate #821). `--find-links` alone does not prefer wheelhouse —
 # force-reinstall with --no-index is required (same contract as pipx path).
 #
 # Image is glibc (python:*-slim → distroless cc-debian13): use manylinux
-# cpXXX cells matching the builder interpreter ABI from
+# cells matching the builder interpreter ABI from
 # DataBoar/data-boar-site release wheelhouse-x86-64-v1-*.
+#
+# Free-threaded (no-GIL / cp314t): abi3 boar_fast_filter does NOT load; use the
+# dedicated cp314t wheel. popcnt==0 gate does NOT apply — numpy cp314t is
+# intentionally x86-64-v2+ (operator decision; Celeron is not a nogil target).
 #
 # Usage (inside builder stage, after pip install -r requirements.txt):
 #   bash scripts/docker/apply_wheelhouse_v1.sh
@@ -16,30 +20,59 @@
 # Optional env:
 #   WHEELHOUSE_TAG   default wheelhouse-x86-64-v1-2026-07-29
 #   WHEELHOUSE_DIR   if set and non-empty, skip download and use that folder
-#   SKIP_POPCNT_GATE set to 1 to skip objdump gate (not for release builds)
+#   SKIP_POPCNT_GATE set to 1 to skip objdump gate (auto for free-threaded)
 set -euo pipefail
 
 WHEELHOUSE_TAG="${WHEELHOUSE_TAG:-wheelhouse-x86-64-v1-2026-07-29}"
 BASE_URL="${WHEELHOUSE_BASE_URL:-https://github.com/DataBoar/data-boar-site/releases/download/${WHEELHOUSE_TAG}}"
 
-# Derive ABI tag from the builder interpreter (cp313, cp314, …). Hardcoding
-# cp313 against a 3.14 base installs the wrong wheel or fails force-reinstall.
-PY_MM="$(python -c 'import sys; print(f"{sys.version_info.major}{sys.version_info.minor}")')"
-CP="cp${PY_MM}"
+# Derive platform / ABI tags from the builder interpreter.
+# GIL 3.14 → py_tag=cp314 abi_tag=cp314; free-threaded → abi_tag=cp314t.
+# Never hardcode: wrong ABI installs the wrong wheel or fails force-reinstall.
+eval "$(
+  python - <<'PY'
+import sys
+import sysconfig
+
+maj, minor = sys.version_info.major, sys.version_info.minor
+py_tag = f"cp{maj}{minor}"
+soabi = sysconfig.get_config_var("SOABI") or ""
+gil_disabled = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+freethreaded = gil_disabled or (f"{maj}{minor}t" in soabi)
+abi_tag = f"cp{maj}{minor}t" if freethreaded else py_tag
+print(f"PY_TAG={py_tag}")
+print(f"ABI_TAG={abi_tag}")
+print(f"FREETHREADED={'1' if freethreaded else '0'}")
+print(f"CP={abi_tag}")
+PY
+)"
+
 WORKDIR="${WHEELHOUSE_DIR:-/tmp/wheelhouse-v1-glibc-${CP}}"
 
-# Filenames must match the hosted release assets (manylinux / ${CP}).
-# boar_fast_filter is abi3 (cp38) — same asset for all CPython 3.x builders.
-WHEELS=(
-  "numpy-2.5.1-${CP}-${CP}-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
-  "scipy-1.18.0-${CP}-${CP}-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
-  "scikit_learn-1.9.0-${CP}-${CP}-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
-  "pandas-3.0.5-${CP}-${CP}-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl"
-  "boar_fast_filter-0.1.0-cp38-abi3-manylinux_2_28_x86_64.whl"
-)
+if [[ "${FREETHREADED}" == "1" ]]; then
+  # Free-threaded: dedicated boar_fast_filter cp314t (abi3 does not load).
+  WHEELS=(
+    "numpy-2.5.1-${PY_TAG}-${ABI_TAG}-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+    "scipy-1.18.0-${PY_TAG}-${ABI_TAG}-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+    "scikit_learn-1.9.0-${PY_TAG}-${ABI_TAG}-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+    "pandas-3.0.5-${PY_TAG}-${ABI_TAG}-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl"
+    "boar_fast_filter-0.1.0-${PY_TAG}-${ABI_TAG}-manylinux_2_28_x86_64.whl"
+  )
+  # Operator contract: cp314t numpy has popcnt≠0 (x86-64-v2+). Do not force v1.
+  SKIP_POPCNT_GATE="${SKIP_POPCNT_GATE:-1}"
+else
+  # GIL: abi3 boar_fast_filter serves all CPython 3.8+.
+  WHEELS=(
+    "numpy-2.5.1-${PY_TAG}-${ABI_TAG}-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+    "scipy-1.18.0-${PY_TAG}-${ABI_TAG}-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+    "scikit_learn-1.9.0-${PY_TAG}-${ABI_TAG}-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+    "pandas-3.0.5-${PY_TAG}-${ABI_TAG}-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl"
+    "boar_fast_filter-0.1.0-cp38-abi3-manylinux_2_28_x86_64.whl"
+  )
+fi
 
-# Expected sha256 from release SHA256SUMS (wheelhouse-x86-64-v1-2026-07-29).
-# Keyed by full filename so cp313 and cp314 cells can coexist offline.
+# Expected sha256 from release assets (wheelhouse-x86-64-v1-2026-07-29).
+# Note: release SHA256SUMS may lag new cells — digests below measured from assets.
 declare -A EXPECTED_SHA=(
   ["numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"]="d301efd02e390bd2d135205c25cd7b7fc82ec353aa3985528745601bfb67c2d6"
   ["scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"]="a9c3a1ae4de02b8eff37b87a7d5af19bfdbb029cc62b855fd8813acc2775c5bf"
@@ -50,6 +83,11 @@ declare -A EXPECTED_SHA=(
   ["scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"]="1f2c048e96ad44db5775adc80d7d0c1f3db7c5c7e837950b4b0a42afa28ffdcb"
   ["pandas-3.0.5-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl"]="9e94c2c5ca43bd3ca32bf64d32308887b65e5f9bfd8023ea52755107a999f93b"
   ["boar_fast_filter-0.1.0-cp38-abi3-manylinux_2_28_x86_64.whl"]="f664cb016fed2d530e94fa9946bb783c294e052ef19ceae4dd80bd6d12a9125a"
+  ["numpy-2.5.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"]="99d5095fa265a0c4152e7bb12759e14381ef5496152f1ce58f44bdf55c44beb4"
+  ["scipy-1.18.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"]="945c1761b93f38d7f99ae81ae80c63e621471608c7eeead563f6df025585cd58"
+  ["scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"]="5bad8f8b9950321b54c965fdcbac6c6c55e79e16646b49977bcf3668d3870a1a"
+  ["pandas-3.0.5-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl"]="ef01af4d8dc6cd2c8d6c7736f149574ef93fe043811eeb5e445f2647154b5040"
+  ["boar_fast_filter-0.1.0-cp314-cp314t-manylinux_2_28_x86_64.whl"]="a28588c4fabe3c7e41e142b9477facc814d658a972f0d314c5104fedfc37af68"
 )
 
 UMATH_MAX_BYTES="${NUMPY_UMATH_SO_MAX_BYTES:-8000000}"
@@ -67,7 +105,7 @@ for whl in "${WHEELS[@]}"; do
 done
 
 if [[ "$need_download" -eq 1 ]]; then
-  echo "=== downloading ${WHEELHOUSE_TAG} manylinux ${CP} wheels ==="
+  echo "=== downloading ${WHEELHOUSE_TAG} manylinux ${PY_TAG}/${ABI_TAG} wheels (freethreaded=${FREETHREADED}) ==="
   for whl in "${WHEELS[@]}"; do
     if [[ ! -f "$whl" ]]; then
       curl -fsSL -o "$whl" "${BASE_URL}/${whl}"
@@ -80,7 +118,7 @@ for whl in "${WHEELS[@]}"; do
   got="$(sha256sum "$whl" | awk '{print $1}')"
   want="${EXPECTED_SHA[$whl]:-}"
   if [[ -z "$want" ]]; then
-    echo "FATAL: no EXPECTED_SHA entry for $whl (ABI ${CP})" >&2
+    echo "FATAL: no EXPECTED_SHA entry for $whl (ABI ${ABI_TAG})" >&2
     exit 1
   fi
   if [[ "$got" != "$want" ]]; then
@@ -99,12 +137,17 @@ python -m pip install --no-cache-dir --no-index --find-links "$WORKDIR" \
   numpy scipy scikit-learn pandas boar_fast_filter
 
 python - <<'PY'
+import pathlib
+import sysconfig
+
 import boar_fast_filter
 import numpy
 import pandas
 import scipy
 import sklearn
 
+pkg = pathlib.Path(boar_fast_filter.__file__).resolve().parent
+sos = sorted(pkg.rglob("*.so"))
 print(
     "imports_ok",
     "numpy",
@@ -115,9 +158,21 @@ print(
     sklearn.__version__,
     "pandas",
     pandas.__version__,
-    "boar_fast_filter",
-    boar_fast_filter.__file__,
+    "boar_fast_filter_pkg",
+    pkg,
+    "filter_sos",
+    [p.name for p in sos],
+    "SOABI",
+    sysconfig.get_config_var("SOABI"),
 )
+if not sos:
+    raise SystemExit(f"FATAL: no .so under boar_fast_filter package: {pkg}")
+# Free-threaded must not ship abi3 filter; GIL expects abi3 or versioned .so.
+if bool(sysconfig.get_config_var("Py_GIL_DISABLED")):
+    if any("abi3" in p.name for p in sos):
+        raise SystemExit(f"FATAL: free-threaded image loaded abi3 filter: {sos}")
+    if not any("314t" in p.name for p in sos):
+        raise SystemExit(f"FATAL: expected cpython-314t filter .so, got: {sos}")
 PY
 
 # rapidfuzz ships baseline + *_avx2*.so CPU-dispatch siblings. The AVX2 modules
@@ -129,7 +184,13 @@ echo "=== strip rapidfuzz *_avx2*.so under ${SITE} ==="
 find "$SITE" -type f -name '*_avx2*.so' -print -delete
 
 if [[ "${SKIP_POPCNT_GATE:-0}" == "1" ]]; then
-  echo "SKIP_POPCNT_GATE=1 — skipping ISA gate (not for release)"
+  if [[ "${FREETHREADED}" == "1" ]]; then
+    echo "SKIP_POPCNT_GATE=1 — free-threaded / x86-64-v2+ contract (popcnt gate N/A)"
+  else
+    echo "SKIP_POPCNT_GATE=1 — skipping ISA gate (not for GIL release builds)"
+  fi
+  python -c 'import rapidfuzz; print("rapidfuzz_ok", rapidfuzz.__version__)'
+  echo "OK GATE: wheelhouse applied (freethreaded=${FREETHREADED}, popcnt_gate=skipped)"
   exit 0
 fi
 

--- a/scripts/docker/build-nogil-local.sh
+++ b/scripts/docker/build-nogil-local.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Build + validate the free-threaded image locally (no Hub push).
+#
+# Usage (repo root):
+#   ./scripts/docker/build-nogil-local.sh
+#   ./scripts/docker/build-nogil-local.sh 1.7.4.post12-nogil
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+TAG="${1:-1.7.4.post12-nogil}"
+IMAGE="localhost/data_boar:${TAG}"
+# Also tag short name used in AC examples.
+ALIAS="data_boar:${TAG}"
+
+need_() { command -v "$1" >/dev/null 2>&1 || { echo "FATAL: $1 not in PATH" >&2; exit 127; }; }
+need_ podman
+
+echo "=== podman build -f Dockerfile.nogil -t ${IMAGE} ==="
+podman build -f Dockerfile.nogil -t "${IMAGE}" .
+podman tag "${IMAGE}" "${ALIAS}"
+
+echo "=== AC: sys._is_gil_enabled() is False ==="
+podman run --rm "${ALIAS}" python -c 'import sys; v=sys._is_gil_enabled(); print("gil_enabled", v); raise SystemExit(0 if v is False else 1)'
+
+echo "=== AC: ML + boar_fast_filter imports ==="
+podman run --rm "${ALIAS}" python -c 'import numpy,scipy,sklearn,pandas,boar_fast_filter; print("imports_ok", numpy.__version__, boar_fast_filter.__file__)'
+
+echo "=== AC: filter .so is cpython-314t (not abi3) ==="
+podman run --rm "${ALIAS}" python -c '
+import boar_fast_filter, pathlib
+pkg = pathlib.Path(boar_fast_filter.__file__).resolve().parent
+sos = sorted(pkg.rglob("*.so"))
+print("filter_sos", [p.name for p in sos])
+assert sos, pkg
+assert not any("abi3" in p.name for p in sos), sos
+assert any("314t" in p.name for p in sos), sos
+print("filter_ok", sos[0].name)
+'
+
+echo "=== AC: docker-image-smoke (public version) ==="
+VERSION="${TAG%-nogil}"
+./scripts/docker/docker-image-smoke.sh "${ALIAS}" "${VERSION}"
+
+echo "=== AC: grype gate ==="
+./scripts/grype-image-gate.sh "${ALIAS}"
+
+echo "=== OK local nogil image ${ALIAS} (NOT pushed) ==="

--- a/scripts/docker/build-nogil-local.sh
+++ b/scripts/docker/build-nogil-local.sh
@@ -21,11 +21,33 @@ echo "=== podman build -f Dockerfile.nogil -t ${IMAGE} ==="
 podman build -f Dockerfile.nogil -t "${IMAGE}" .
 podman tag "${IMAGE}" "${ALIAS}"
 
-echo "=== AC: sys._is_gil_enabled() is False ==="
+echo "=== AC: sys._is_gil_enabled() is False (boot) ==="
 podman run --rm "${ALIAS}" python -c 'import sys; v=sys._is_gil_enabled(); print("gil_enabled", v); raise SystemExit(0 if v is False else 1)'
 
-echo "=== AC: ML + boar_fast_filter imports ==="
-podman run --rm "${ALIAS}" python -c 'import numpy,scipy,sklearn,pandas,boar_fast_filter; print("imports_ok", numpy.__version__, boar_fast_filter.__file__)'
+echo "=== AC: GIL stays False after sqlalchemy import ==="
+OUT="$(podman run --rm "${ALIAS}" python -W error::RuntimeWarning -c 'import sqlalchemy, sys; print(sqlalchemy.__version__); print("gil_after_sa", sys._is_gil_enabled()); raise SystemExit(0 if sys._is_gil_enabled() is False else 1)' 2>&1)" || {
+  echo "$OUT" >&2
+  echo "FATAL: sqlalchemy import re-enabled GIL or raised RuntimeWarning" >&2
+  exit 1
+}
+echo "$OUT"
+
+echo "=== AC: zero sqlalchemy *.so under site-packages ==="
+podman run --rm "${ALIAS}" python -c '
+import pathlib, site
+root = pathlib.Path(site.getsitepackages()[0]) / "sqlalchemy"
+sos = sorted(root.rglob("*.so")) if root.is_dir() else []
+print("sqlalchemy_sos", len(sos), [str(p.relative_to(root)) for p in sos[:20]])
+raise SystemExit(0 if not sos else 1)
+'
+
+echo "=== AC: ML + boar_fast_filter imports (GIL still False) ==="
+podman run --rm "${ALIAS}" python -c '
+import numpy, scipy, sklearn, pandas, boar_fast_filter, sqlalchemy, sys
+print("imports_ok", numpy.__version__, boar_fast_filter.__file__)
+print("gil_after_stack", sys._is_gil_enabled())
+raise SystemExit(0 if sys._is_gil_enabled() is False else 1)
+'
 
 echo "=== AC: filter .so is cpython-314t (not abi3) ==="
 podman run --rm "${ALIAS}" python -c '
@@ -39,9 +61,57 @@ assert any("314t" in p.name for p in sos), sos
 print("filter_ok", sos[0].name)
 '
 
-echo "=== AC: docker-image-smoke (public version) ==="
+echo "=== AC: docker-image-smoke (public version; no GIL RuntimeWarning) ==="
 VERSION="${TAG%-nogil}"
-./scripts/docker/docker-image-smoke.sh "${ALIAS}" "${VERSION}"
+SMOKE_OUT="$(./scripts/docker/docker-image-smoke.sh "${ALIAS}" "${VERSION}" 2>&1)" || {
+  echo "$SMOKE_OUT" >&2
+  exit 1
+}
+echo "$SMOKE_OUT"
+if grep -qiE 'RuntimeWarning|GIL has been enabled' <<<"$SMOKE_OUT"; then
+  echo "FATAL: smoke emitted GIL RuntimeWarning" >&2
+  exit 1
+fi
+
+echo "=== AC: data-boar --version without GIL RuntimeWarning ==="
+VER_OUT="$(podman run --rm "${ALIAS}" python main.py --version 2>&1)" || {
+  echo "$VER_OUT" >&2
+  exit 1
+}
+echo "$VER_OUT"
+grep -qw "${VERSION}" <<<"$VER_OUT" || { echo "FATAL: version token missing" >&2; exit 1; }
+if grep -qiE 'RuntimeWarning|GIL has been enabled' <<<"$VER_OUT"; then
+  echo "FATAL: --version emitted GIL RuntimeWarning" >&2
+  exit 1
+fi
+
+echo "=== AC: data-boar --demo completes with findings ==="
+# Distroless: invoke via python main.py. --demo runs the scan then blocks on uvicorn;
+# timeout after scan output is the expected success path (exit 124).
+set +e
+DEMO_OUT="$(timeout 240 podman run --rm "${ALIAS}" python main.py --demo 2>&1)"
+DEMO_RC=$?
+set -e
+echo "$DEMO_OUT" | tail -60
+if ! grep -q '\[demo\] Scan session:' <<<"$DEMO_OUT"; then
+  echo "FATAL: --demo did not complete scan (rc=${DEMO_RC})" >&2
+  exit 1
+fi
+if ! grep -qiE '\[demo\] Report written:|finding' <<<"$DEMO_OUT"; then
+  echo "FATAL: --demo missing findings/report signal" >&2
+  exit 1
+fi
+# sqlalchemy cext must stay out of the image (module-level import). Report/XLSX may
+# still load lxml.etree and warn — that is a separate follow-up, not this AC.
+if grep -qiE "sqlalchemy\.cyextension|to load module 'sqlalchemy" <<<"$DEMO_OUT"; then
+  echo "FATAL: --demo loaded sqlalchemy cext / re-enabled GIL via sqlalchemy" >&2
+  exit 1
+fi
+# 0 = exited; 124 = timeout (uvicorn still up after scan) — both OK once scan reported.
+if [[ "${DEMO_RC}" -ne 0 && "${DEMO_RC}" -ne 124 ]]; then
+  echo "FATAL: --demo unexpected exit ${DEMO_RC}" >&2
+  exit 1
+fi
 
 echo "=== AC: grype gate ==="
 ./scripts/grype-image-gate.sh "${ALIAS}"

--- a/scripts/docker/collect-runtime-rootfs.sh
+++ b/scripts/docker/collect-runtime-rootfs.sh
@@ -81,8 +81,9 @@ add_deps_from() {
     collect_ldd_paths "${target}" >> "${DEPS_FILE}"
 }
 
-# Derive lib dir from the assembler interpreter (python3.13 → python3.14 on base bump).
-# Hardcoding python3.13 leaves the find empty on 3.14 and trips the libsqlite3 fail-close.
+# Derive lib dir from the assembler interpreter via sysconfig (not version math).
+# Free-threaded installs live under python3.14t — hardcoding python3.14 leaves
+# the find empty and trips the libsqlite3 fail-close.
 PY_BIN=""
 for candidate in /usr/local/bin/python3 /usr/local/bin/python; do
     if [[ -x "${candidate}" ]]; then
@@ -94,13 +95,13 @@ if [[ -z "${PY_BIN}" ]]; then
     echo "collect-runtime-rootfs: FATAL no python3/python under /usr/local/bin" >&2
     exit 1
 fi
-PY_XY="$("${PY_BIN}" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
-PY_LIB="/usr/local/lib/python${PY_XY}"
-PY_VER_BIN="/usr/local/bin/python${PY_XY}"
+PY_LIB="$("${PY_BIN}" -c 'import sysconfig; from pathlib import Path; print(Path(sysconfig.get_path("stdlib")))')"
+PY_VER_BIN="$("${PY_BIN}" -c 'import sys; print(sys.executable)')"
 if [[ ! -d "${PY_LIB}/lib-dynload" ]]; then
     echo "collect-runtime-rootfs: FATAL missing ${PY_LIB}/lib-dynload (ABI path)" >&2
     exit 1
 fi
+echo "collect-runtime-rootfs: PY_BIN=${PY_BIN} PY_LIB=${PY_LIB}"
 
 # Extension modules and interpreter (site-packages + stdlib lib-dynload — e.g. _sqlite3 → libsqlite3).
 while IFS= read -r -d '' so; do
@@ -150,7 +151,9 @@ if [[ -d "${EXPORT}/lib" || -d "${EXPORT}/lib64" ]]; then
     exit 1
 fi
 
-# Fail closed: CPython sqlite3 (integrity_anchor / data-boar --version) needs a resolvable libsqlite3.
+# Fail closed: CPython sqlite3 (integrity_anchor / data-boar --version) needs a
+# resolvable libsqlite3 — OR a builtin/static _sqlite3 (python-build-standalone
+# free-threaded builds ship sqlite in-process; no libsqlite3.so.0 to collect).
 # SONAME symlink alone is not enough — the real object must be present (distroless has no apt).
 sqlite_link=""
 for candidate in \
@@ -162,14 +165,19 @@ for candidate in \
     fi
 done
 if [[ -z "${sqlite_link}" ]]; then
-    echo "collect-runtime-rootfs: FATAL missing libsqlite3.so.0 (ldd lib-dynload/_sqlite3*.so)" >&2
-    exit 1
-fi
-if [[ -L "${sqlite_link}" ]]; then
-    sqlite_real="$(readlink -f "${sqlite_link}" || true)"
-    if [[ -z "${sqlite_real}" || ! -f "${sqlite_real}" ]]; then
-        echo "collect-runtime-rootfs: FATAL dangling libsqlite3.so.0 -> ${sqlite_real:-unresolved}" >&2
+    if "${PY_BIN}" -c 'import sys, sqlite3; assert "_sqlite3" in sys.builtin_module_names; sqlite3.connect(":memory:").execute("select 1")'; then
+        echo "collect-runtime-rootfs: OK sqlite3 via builtin/static (no shared libsqlite3.so.0)"
+    else
+        echo "collect-runtime-rootfs: FATAL missing libsqlite3.so.0 (ldd lib-dynload/_sqlite3*.so)" >&2
         exit 1
     fi
+else
+    if [[ -L "${sqlite_link}" ]]; then
+        sqlite_real="$(readlink -f "${sqlite_link}" || true)"
+        if [[ -z "${sqlite_real}" || ! -f "${sqlite_real}" ]]; then
+            echo "collect-runtime-rootfs: FATAL dangling libsqlite3.so.0 -> ${sqlite_real:-unresolved}" >&2
+            exit 1
+        fi
+    fi
+    echo "collect-runtime-rootfs: OK libsqlite3 via ${sqlite_link}"
 fi
-echo "collect-runtime-rootfs: OK libsqlite3 via ${sqlite_link}"

--- a/tests/test_docker_image_hardening.py
+++ b/tests/test_docker_image_hardening.py
@@ -93,6 +93,13 @@ def test_dockerfile_nogil_pins_and_uv_freethreaded() -> None:
     assert "uv python install" in text
     assert "freethreaded" in text
     assert "python3.14t" in text
+    assert "DISABLE_SQLALCHEMY_CEXT=1" in text
+    assert "--no-binary sqlalchemy" in text
+    # Must not force GIL off over undeclared-safe C exts (comments may mention the forbid).
+    assert "ENV PYTHON_GIL" not in text
+    assert "PYTHON_GIL=0" not in [
+        ln.strip() for ln in text.splitlines() if not ln.lstrip().startswith("#")
+    ]
     assert "distroless/cc-debian13:nonroot@" in text
     # No floating/official 3.14t-slim base (404 on Hub) — only comment may mention it.
     from_lines = [

--- a/tests/test_docker_image_hardening.py
+++ b/tests/test_docker_image_hardening.py
@@ -57,6 +57,7 @@ def test_collect_runtime_rootfs_script_bundles_tls_and_db_libs() -> None:
     # stdlib extension deps (e.g. _sqlite3 → libsqlite3) live in lib-dynload, not site-packages.
     assert "lib-dynload" in text
     assert "libsqlite3" in text
+    assert "sysconfig.get_path" in text  # derive python3.14 / python3.14t
     assert (
         "readlink" in text
     )  # SONAME symlink → real .so (avoid dangling in distroless)
@@ -76,9 +77,31 @@ def test_dockerfile_applies_wheelhouse_v1_in_builder() -> None:
     assert "popcnt" in body
     assert "boar_fast_filter" in body
     assert "wheelhouse-x86-64-v1-2026-07-29" in body
-    # ABI must follow the builder interpreter (cp314 on 3.14-slim), not a hardcode.
-    assert 'CP="cp${PY_MM}"' in body or "cp${PY_MM}" in body
+    # ABI must follow the builder interpreter (cp314 / cp314t), not a hardcode.
+    assert "Py_GIL_DISABLED" in body or "SOABI" in body
     assert "sys.version_info" in body
+    assert "cp314t" in body  # free-threaded wheel cells + EXPECTED_SHA
+
+
+def test_dockerfile_nogil_pins_and_uv_freethreaded() -> None:
+    """Free-threaded variant: no 3.14t-slim tag; uv-installed 3.14t; does not steal :latest."""
+    nogil = REPO_ROOT / "Dockerfile.nogil"
+    assert nogil.is_file()
+    text = nogil.read_text(encoding="utf-8")
+    assert "python:3.14-slim@" in text
+    assert "@sha256:" in text
+    assert "uv python install" in text
+    assert "freethreaded" in text
+    assert "python3.14t" in text
+    assert "distroless/cc-debian13:nonroot@" in text
+    # No floating/official 3.14t-slim base (404 on Hub) — only comment may mention it.
+    from_lines = [
+        ln.strip() for ln in text.splitlines() if ln.strip().upper().startswith("FROM ")
+    ]
+    assert all("3.14t-slim" not in ln for ln in from_lines)
+    assert all("@sha256:" in ln for ln in from_lines)
+    collect = COLLECT_SCRIPT.read_text(encoding="utf-8")
+    assert "sysconfig.get_path" in collect  # python3.14t lib dir
 
 
 def test_grype_vex_config_has_documented_ignore_rules() -> None:
@@ -97,10 +120,11 @@ def test_grype_vex_config_has_documented_ignore_rules() -> None:
     for rule in deb_rules:
         assert rule.get("fix-state") == "wont-fix"
         assert rule.get("package", {}).get("type") == "deb"
-    assert any(r.get("vulnerability") == "CVE-2026-15308" for r in cve_rules)
-    cve_pkg = next(r for r in cve_rules if r["vulnerability"] == "CVE-2026-15308")
-    assert cve_pkg.get("package", {}).get("type") == "binary"
-    assert cve_pkg.get("package", {}).get("name") == "python"
+    for cve_id in ("CVE-2026-15308", "CVE-2026-11940", "CVE-2026-11972"):
+        assert any(r.get("vulnerability") == cve_id for r in cve_rules), cve_id
+        cve_pkg = next(r for r in cve_rules if r["vulnerability"] == cve_id)
+        assert cve_pkg.get("package", {}).get("type") == "binary"
+        assert cve_pkg.get("package", {}).get("name") == "python"
     names = {r["package"]["name"] for r in deb_rules}
     assert "libc6" in names
     assert "mariadb" in names


### PR DESCRIPTION
## Summary
- Add **`Dockerfile.nogil`**: base `python:3.14-slim@cea0e604…` + pinned **uv 0.12.0** installs **`3.14.6+freethreaded`** (`python3.14t`) — there is no `python:3.14t-slim` on Hub.
- **`apply_wheelhouse_v1.sh`**: derive `cp314` vs `cp314t` / abi3 vs cp314t `boar_fast_filter` from `Py_GIL_DISABLED`/`SOABI`; auto-skip **`popcnt=0`** on free-threaded (numpy cp314t = x86-64-v2+ by operator decision).
- **`collect-runtime-rootfs.sh`**: derive `python3.14t` via `sysconfig`; fail-close accepts builtin/static sqlite (PBS freethreaded).
- Docs: two-variant CPU contracts in **`DOCKER_IMAGE_RELEASE_ORDER`** (+ pt_BR) and Hub description (tag **`1.7.4.post12-nogil`**; **`:latest` never moves**).
- VEX: **CVE-2026-11940** / **CVE-2026-11972** (fix only in **3.15.0b4** beta — same posture as CVE-2026-15308).

## Local validation (NOT pushed)
| AC | Result |
| --- | --- |
| `sys._is_gil_enabled()` | **False** |
| numpy/scipy/sklearn/pandas/`boar_fast_filter` | OK |
| filter `.so` | `boar_fast_filter.cpython-314t-x86_64-linux-gnu.so` (not abi3) |
| `docker-image-smoke.sh` | **PASS** → `1.7.4.post12` |
| `grype-image-gate.sh` | **exit 0** |
| Hub `:latest` | still `sha256:ab8f5dad3e336…` |
| Hub `:1.7.4` (June) | still `sha256:04b4cd7d…` |
| `version` / `maturity_build` | **1.7.4.post12** / **263** |

Local image: `data_boar:1.7.4.post12-nogil` / `localhost/data_boar:1.7.4.post12-nogil`  
Digest: `sha256:ce0934d858c2f5348953c1c22e6d9f1e41bf3c439c0852b3fe49ae8c35a2559a`

## Operator push (after merge)
```bash
podman push localhost/data_boar:1.7.4.post12-nogil docker.io/fabioleitao/data_boar:1.7.4.post12-nogil
# Do NOT retag :latest or :1.7.4
# Hub UI: paste Short+Full from docs/ops/DOCKER_HUB_REPOSITORY_DESCRIPTION.md
```

## GATE_FILE
None touched.

## Test plan
- [x] `./scripts/docker/build-nogil-local.sh 1.7.4.post12-nogil`
- [x] `./scripts/check-all.sh`
- [ ] Operator Hub push of `:1.7.4.post12-nogil` only