### PR TITLE
fix(tests): route collector must walk nested include_router (FastAPI 0.139+)

### DIFF
--- a/tests/test_api_route_matrix_plan_sync.py
+++ b/tests/test_api_route_matrix_plan_sync.py
@@ -7,15 +7,37 @@ EXPECTED_HTTP_ROUTES below to match `api.routes.app`.
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
+from typing import Any
+
 from starlette.routing import Mount
 
 from api.routes import app
 from fastapi.routing import APIRoute
 
 
-def _registered_http_routes() -> list[str]:
-    rows: list[str] = []
-    for route in app.routes:
+def _nested_route_list(route: Any) -> Sequence[Any] | None:
+    """Child routes for nested/include_router wrappers (version-agnostic).
+
+    FastAPI 0.139+ stores ``include_router`` as ``_IncludedRouter`` with
+    ``original_router.routes`` instead of flattening ``APIRoute`` onto ``app.routes``.
+    Older FastAPI already flattens; those nodes have no nested list here.
+    """
+    if isinstance(route, (APIRoute, Mount)):
+        return None
+    original = getattr(route, "original_router", None)
+    if original is not None:
+        nested = getattr(original, "routes", None)
+        if nested is not None:
+            return nested
+    nested = getattr(route, "routes", None)
+    if nested is not None:
+        return nested
+    return None
+
+
+def _collect_http_routes(routes: Iterable[Any], rows: list[str]) -> None:
+    for route in routes:
         if isinstance(route, APIRoute):
             for method in sorted(route.methods):
                 if method == "HEAD":
@@ -23,6 +45,15 @@ def _registered_http_routes() -> list[str]:
                 rows.append(f"{method} {route.path}")
         elif isinstance(route, Mount):
             rows.append(f"MOUNT {route.path}")
+        else:
+            nested = _nested_route_list(route)
+            if nested is not None:
+                _collect_http_routes(nested, rows)
+
+
+def _registered_http_routes() -> list[str]:
+    rows: list[str] = []
+    _collect_http_routes(app.routes, rows)
     return sorted(rows)
 
 


### PR DESCRIPTION
## Summary

- Fix the HTTP route matrix collector in `tests/test_api_route_matrix_plan_sync.py` so it recursively walks nested `include_router` wrappers (`_IncludedRouter` / `original_router.routes`) as well as top-level `APIRoute` and `Mount`.
- **Does not** change `EXPECTED_HTTP_ROUTES` — that snapshot remains the endpoint-loss net (ADR-0049: no brittle snapshot rewrite to “pass”).
- Latent defect on `main`: revealed by Dependabot FastAPI **0.136.3 → 0.139.2** (#1389 / #1423), not caused by product route registration (WebAuthn `register_webauthn_routes(app)` stays unconditional).

## RCA (ADR-0047 Decision 4)

| Observation | Evidence |
|-------------|----------|
| Registration unconditional | `api/routes.py` imports + calls `register_webauthn_routes(app)` with no try/flag |
| Endpoints still present on 0.139.2 | OpenAPI lists 6 `/auth/webauthn/*` paths; handler reachable |
| Old collector blind on 0.139.2 | Flat `isinstance(APIRoute)` only — misses `_IncludedRouter` |
| Cross-version collector after fix | **0.136.3:** total **38**, webauthn **6**, `== EXPECTED`; **0.139.2:** total **38**, webauthn **6**, `== EXPECTED` |
| `_IncludedRouter` | Exists on FastAPI **0.139.2**; absent on **0.136.3** |

Root cause: collector assumed FastAPI always flattens `include_router` into top-level `APIRoute` entries. FastAPI 0.139 changed representation; product routes did not disappear. Dependabot bump only revealed the latent test gap.

Hold / sequence: land this on `main` first; Dependabot FastAPI bump (#1423) should then pass without touching the expected route snapshot.

## Test plan

- [x] Collector vs `EXPECTED_HTTP_ROUTES` on FastAPI 0.136.3 and 0.139.2 (venvs `/tmp/fastapi-route-repro/v136` + `v139`): 38 / 6 / match both
- [x] `./scripts/check-all.sh --enforced` green on this branch
- [x] Operator review + merge decision (do not merge via automation)