### PR TITLE
fix: public version matches pyproject.toml string

### DIFF
--- a/core/about.py
+++ b/core/about.py
@@ -3,15 +3,26 @@ Application about information (name, version, author, license) for reports, API 
 Single source of truth aligned with LICENSE and README in the repository.
 """
 
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+# docs/VERSIONING.md checklist §2 — keep identical to pyproject.toml ``[project].version``.
+_FALLBACK_VERSION = "1.8.0-beta"
+
 
 def _package_version() -> str:
-    """Installed distribution version, or the same fallback string as get_about_info."""
+    """Return ``[project].version`` from ``pyproject.toml`` (VERSIONING.md source of truth)."""
+    path = Path(__file__).resolve().parents[1] / "pyproject.toml"
     try:
-        from importlib.metadata import version
-
-        return version("data-boar")
-    except Exception:
-        return "1.8.0-beta"
+        with path.open("rb") as handle:
+            ver = tomllib.load(handle).get("project", {}).get("version")
+        if ver:
+            return str(ver)
+    except (OSError, tomllib.TOMLDecodeError, TypeError, ValueError):
+        pass
+    return _FALLBACK_VERSION
 
 
 def get_http_user_agent() -> str:

--- a/docs/releases/1.8.0-beta.md
+++ b/docs/releases/1.8.0-beta.md
@@ -2,7 +2,7 @@
 
 **Kind:** **GitHub pre-release** (non-production) when tagged — use **Set as a pre-release** / `gh release create … --prerelease`.
 
-**Working version string:** **`1.8.0-beta`** in `pyproject.toml` (PEP 440 normalized form: `1.8.0b0` in some tooling).
+**Working version string:** **`1.8.0-beta`** in `pyproject.toml` and on public surfaces (`--version`, About, User-Agent).
 
 **Maturity octet (ADR-0073):** **`[tool.databoar] maturity_build = 1`** — **new public line** after **`1.7.4`**. Octet **resets** into the beta band (**1–126**); first beta on the line = **`.1`**. Does **not** continue from **`1.7.4.post12`** / **`.263`**. **`.postN`** does not apply on this pre-release line.
 

--- a/tests/test_about_version_matches_pyproject.py
+++ b/tests/test_about_version_matches_pyproject.py
@@ -18,23 +18,21 @@ def _project_version_from_pyproject() -> str:
 
 
 def _fallback_version_in_about_source() -> str:
-    """String used when importlib.metadata has no distribution (see docs/VERSIONING.md)."""
+    """``_FALLBACK_VERSION`` in core/about.py (see docs/VERSIONING.md)."""
     root = Path(__file__).resolve().parent.parent
     text = (root / "core" / "about.py").read_text(encoding="utf-8")
-    m = re.search(r"except Exception:\s*\n\s*return \"([^\"]+)\"", text)
-    assert m is not None, (
-        'expected fallback `return "..."` after `except Exception:` in core/about.py '
-        "(_package_version)"
-    )
+    m = re.search(r'_FALLBACK_VERSION\s*=\s*"([^"]+)"', text)
+    assert m is not None, 'expected _FALLBACK_VERSION = "..." in core/about.py'
     return m.group(1)
 
 
 def test_about_version_matches_pyproject() -> None:
-    """Installed/metadata path must agree with repo `version =` (see docs/VERSIONING.md)."""
-    from core.about import get_about_info
+    """Runtime version equals pyproject.toml ``[project].version`` (VERSIONING.md SSOT)."""
+    from core.about import _package_version, get_about_info
 
     expected = _project_version_from_pyproject()
-    # importlib.metadata returns PEP 440-normalized strings (e.g. 1.7.2b0 vs 1.7.2-beta in pyproject).
+    assert _package_version() == expected
+    assert get_about_info()["version"] == expected
     assert Version(get_about_info()["version"]) == Version(expected)
 
 

--- a/tests/test_main_version_cli.py
+++ b/tests/test_main_version_cli.py
@@ -8,8 +8,6 @@ import sys
 import tomllib
 from pathlib import Path
 
-from core.about import _package_version
-
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[1]
@@ -20,9 +18,15 @@ def _maturity_build_octet() -> int:
         return int(tomllib.load(f)["tool"]["databoar"]["maturity_build"])
 
 
+def _pyproject_version() -> str:
+    with (_repo_root() / "pyproject.toml").open("rb") as f:
+        return str(tomllib.load(f)["project"]["version"])
+
+
 def test_main_version_prints_public_version_exit_zero(tmp_path):
     """--version must not require config.yaml and must not leak maturity_build."""
     repo = _repo_root()
+    public = _pyproject_version()
     # Run from an empty dir so default config.yaml is absent.
     r = subprocess.run(
         [sys.executable, str(repo / "main.py"), "--version"],
@@ -33,7 +37,7 @@ def test_main_version_prints_public_version_exit_zero(tmp_path):
         check=False,
     )
     assert r.returncode == 0, r.stderr
-    expected = f"Data Boar {_package_version()}"
+    expected = f"Data Boar {public}"
     assert r.stdout.strip() == expected
     assert r.stderr == ""
 


### PR DESCRIPTION
## Summary
- `--version` / About / User-Agent read the exact `[project].version` from `pyproject.toml` (house SSOT).
- Stops leaking compact packaging form (`1.8.0b0`) from `importlib.metadata`.
- Tests assert CLI output equals the pyproject string; release note no longer implies `b0` is the public form.

## Test plan
- [x] `uv run ./main.py --version` → `Data Boar 1.8.0-beta`
- [x] `./scripts/check-all.sh --enforced` (exit 0)
- [x] `tests/test_about_version_matches_pyproject.py` + `tests/test_main_version_cli.py`