### PR TITLE
docs(adr): full pt-BR ADR index parity + CI gate

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,8 @@ Short, durable notes that capture **why** the project chose an approach—not on
 
 ## Index
 
+Canonical completeness of numbered ADR files is enforced for this table **and** the pt-BR mirror (`README.pt_BR.md` → `## Índice`) by `tests/test_adr_readme_index_sync.py`.
+
 | ADR   | Title                                                                                                                                                  | Status   |
 | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
 | 0000  | [Project origin, ADR baseline, and UMADR ecosystem regency](ADR-0000-project-origin-and-adr-baseline.md) (canonical mother; #994) | Accepted |
@@ -101,7 +103,6 @@ Short, durable notes that capture **why** the project chose an approach—not on
 | 0080 | [Local validation gate is inviolable: full check-all before any push or PR](ADR-0080-local-validation-gate-inviolable.md) | Proposed |
 | 0081 | [No silent ML confidence failures on single-class compliance profiles](ADR-0081-no-silent-ml-confidence-single-class-hardening.md) | Proposed |
 | 0082 | [Web exposure safe-by-default boundary controls](ADR-0082-web-exposure-safe-by-default-boundary-controls.md) | Proposed |
-
 | 0083 | [Rust regex stage: accept form B (findings superset)](ADR-0083-rust-regex-stage-superset-accept-form-b.md) | Accepted |
 | 0084 | [Native package: embed CPython by channel (Enterprise vs community)](ADR-0084-native-package-embedded-cpython-by-channel.md) | Proposed |
 

--- a/docs/adr/README.pt_BR.md
+++ b/docs/adr/README.pt_BR.md
@@ -16,71 +16,118 @@ Notas curtas e duradouras que registram **por que** o projeto escolheu um caminh
 
 ## Índice
 
-| ADR  | Título                                                                                                                        | Status |
-| ---- | ----------------------------------------------------------------------------------------------------------------              | ------ |
-| 0000 | [Project origin and ADR baseline](ADR-0000-project-origin-and-adr-baseline.md)                                                    | Aceito |
-| 0001 | [Markdown fix script, MD029, and semantic step lists](ADR-0001-markdown-fix-script-md029-and-semantic-step-lists.md)              | Aceito |
-| 0002 | [Operator-facing security and technical docs](ADR-0002-operator-facing-security-and-technical-docs.md)                            | Aceito |
-| 0003 | [SBOM roadmap — CycloneDX then Syft](ADR-0003-sbom-roadmap-cyclonedx-then-syft.md)                                                | Aceito |
-| 0004 | [Information architecture — external-tier docs must not link into `plans/`](ADR-0004-external-docs-no-markdown-links-to-plans.md) | Aceito |
-| 0005 | [CI and GitHub Actions supply chain — pinned SHAs and pinned uv CLI](ADR-0005-ci-github-actions-supply-chain-pins.md)              | Aceito |
-| 0006 | [Operator today-mode layout and published-release sync](ADR-0006-operator-today-mode-layout-and-published-sync.md)                 | Aceito |
-| 0083 | [Estágio regex Rust: aceite forma B (findings superset)](ADR-0083-rust-regex-stage-superset-accept-form-b.md) | Aceito |
-| 0084 | [Pacote nativo: CPython embarcado por canal (Enterprise vs comunidade)](ADR-0084-native-package-embedded-cpython-by-channel.md) | Proposto |
+Os títulos na tabela abaixo ficam em **inglês** (canônicos, iguais ao [README.md](README.md)); o status usa rótulos em pt-BR (**Aceito** / **Proposto** / **Deferido** / **Reservado**). A CI exige a mesma cobertura de arquivos ADR numerados no índice EN e neste índice pt-BR.
+
+| ADR  | Título                                                                                                                         | Status   |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------ | -------- |
+| 0000  | [Project origin, ADR baseline, and UMADR ecosystem regency](ADR-0000-project-origin-and-adr-baseline.md) (canonical mother; #994) | Aceito |
+| 0001  | [Markdown fix script, MD029, and semantic step lists](ADR-0001-markdown-fix-script-md029-and-semantic-step-lists.md) | Aceito |
+| 0002  | [Operator-facing security and technical docs](ADR-0002-operator-facing-security-and-technical-docs.md) | Aceito |
+| 0003  | [SBOM roadmap — CycloneDX then Syft](ADR-0003-sbom-roadmap-cyclonedx-then-syft.md) | Aceito |
+| 0004  | [Information architecture — external-tier docs must not link into `plans/`](ADR-0004-external-docs-no-markdown-links-to-plans.md) | Aceito |
+| 0005  | [CI and GitHub Actions supply chain — pinned SHAs and pinned uv CLI](ADR-0005-ci-github-actions-supply-chain-pins.md) | Aceito |
+| 0006  | [Operator today-mode layout and published-release sync](ADR-0006-operator-today-mode-layout-and-published-sync.md) | Aceito |
+| 0007  | [Synthetic data corpus as mandatory pre-requisite before real production data](ADR-0007-synthetic-data-corpus-before-real-data.md) | Aceito |
+| 0008  | [Docker CE (official repo) + Compose plugin + Swarm as primary lab container runtime](ADR-0008-docker-ce-swarm-over-docker-io-and-podman-only.md) | Aceito |
+| 0009  | [Ansible idempotent roles as single automation source for LAB-NODE-01 lab baseline](ADR-0009-ansible-idempotent-roles-as-single-automation-source.md) | Aceito |
+| 0010  | [IP Declaration as prior-art protection for Data Boar at CLT employment](ADR-0010-ip-declaration-prior-art-protection-at-employment.md) | Aceito |
+| 0011  | [Layered observability stack for lab-op (Munin + Wazuh + Prometheus + Monit + rsyslog/GELF)](ADR-0011-lab-op-observability-stack-layered.md) | Aceito |
+| 0012  | [OCR and image-based sensitive data detection (Tesseract primary, EasyOCR opt-in, BLOB/base64)](ADR-0012-ocr-image-sensitive-data-detection.md) | Proposto |
+| 0013  | [Browser artifact scanning — SQLite (default) + LevelDB (opt-in) strategy](ADR-0013-browser-artifact-sqlite-leveldb-scan-strategy.md) | Aceito |
+| 0014  | [Rename repository and package from python3-lgpd-crawler to data-boar](ADR-0014-rename-repo-and-package-python3-lgpd-crawler-to-data-boar.md) | Aceito |
+| 0015  | [PoC test infrastructure with synthetic corpus and API testing](ADR-0015-poc-test-infrastructure-synthetic-corpus-and-api-testing.md) | Aceito |
+| 0016  | [OpenTofu corporate IaC path alongside existing Ansible operations](ADR-0016-opentofu-corporate-iac-path-alongside-ansible.md) | Aceito |
+| 0017  | [Quasi-identification risk/confidence contract and LGPD guardrails](ADR-0017-quasi-identification-risk-confidence-contract-and-lgpd-guardrails.md) | Aceito |
+| 0018  | [PII anti-recurrence guardrails for tracked files and branch history](ADR-0018-pii-anti-recurrence-guardrails-for-tracked-files-and-branch-history.md) | Aceito |
+| 0019  | [PII verification cadence and manual review gate](ADR-0019-pii-verification-cadence-and-manual-review-gate.md) | Aceito |
+| 0020  | [CI must scan full Git history for PII anti-recurrence patterns](ADR-0020-ci-full-git-history-pii-gate.md) | Aceito |
+| 0021  | [Public web presence — DNS alias (CNAME), canonical host, TLS, hosting shape](ADR-0021-public-web-presence-dns-alias-and-hosting.md) | Aceito |
+| 0022  | [Public glossary — compliance laws, roles, and platform terms](ADR-0022-public-glossary-compliance-and-platform-terms.md) | Aceito |
+| 0023  | [Windows primary dev PC filename search — Everything (`es.exe`) first, capped PowerShell fallback](ADR-0023-windows-primary-dev-filename-search-everything-es-first-with-fallback.md) | Aceito |
+| 0024  | [Enterprise discovery — three complementary tracks (planning posture)](ADR-0024-enterprise-discovery-three-complementary-tracks.md) | Aceito |
+| 0025  | [Compliance positioning — evidence and inventory, not a legal-conclusion engine](ADR-0025-compliance-positioning-evidence-inventory-not-legal-conclusion-engine.md) | Aceito |
+| 0026  | [Optional jurisdiction hints — DPO-facing, heuristic, metadata-only](ADR-0026-optional-jurisdiction-hints-dpo-facing-heuristic-metadata-only.md) | Aceito |
+| 0027  | [Commercial tier boundaries — licensing docs and future JWT claims](ADR-0027-commercial-tier-boundaries-licensing-docs-and-future-jwt-claims.md) | Aceito |
+| 0028  | [Lab external connectivity evaluation playbook (tracked)](ADR-0028-lab-external-connectivity-eval-playbook.md) | Aceito |
+| 0029  | [Cursor Markdown preview guardrail + lab-smoke Ansible hook](ADR-0029-cursor-markdown-preview-guardrail-and-lab-smoke-ansible-hook.md) | Aceito |
+| 0030  | [Python dependency update closure (single pass)](ADR-0030-python-dependency-update-closure-single-pass.md) | Aceito |
+| 0031  | [PyPI packaging with Hatchling (flat layout)](ADR-0031-pypi-packaging-hatchling-flat-layout.md) | Aceito |
+| 0032  | [Maturity self-assessment — per-batch history on dashboard HTML](ADR-0032-maturity-assessment-batch-history-sqlite.md) | Aceito |
+| 0033  | [WebAuthn open Relying Party — JSON endpoints (Phase 1)](ADR-0033-webauthn-open-relying-party-json-endpoints.md) | Aceito |
+| 0034  | [Outbound HTTP User-Agent — `DataBoar-Prospector/<version>`](ADR-0034-outbound-http-user-agent-data-boar-prospector.md) | Aceito |
+| 0035  | [README stakeholder pitch vs optional deck vocabulary](ADR-0035-readme-stakeholder-pitch-vs-deck-vocabulary.md) | Aceito |
+| 0036  | [Exception and log PII redaction pipeline](ADR-0036-exception-and-log-pii-redaction-pipeline.md) | Aceito |
+| 0037  | [Data Boar self-audit log and governance of the auditor](ADR-0037-data-boar-self-audit-log-governance.md) | Aceito |
+| 0038  | [Jurisdictional ambiguity — alert and inventory, do not decide law](ADR-0038-jurisdictional-ambiguity-alert-dont-decide.md) | Aceito |
+| 0039  | [Retention and evidence posture in bonded / customs-adjacent contexts](ADR-0039-retention-evidence-posture-bonded-customs-adjacent-contexts.md) | Aceito |
+| 0040  | [Assistant default: private stack evidence mirrors without rhetorical asks](ADR-0040-assistant-private-stack-evidence-mirrors-default.md) | Aceito |
+| 0041  | [Lab completão optional data contract preflight before host smoke](ADR-0041-lab-completao-data-contract-preflight.md) | Aceito |
+| 0042  | [Public LAB lessons archive + hub (dated snapshots)](ADR-0042-lab-lessons-learned-archive-contract.md) | Aceito |
+| 0043  | [SQL column sampling — non-null filter and strategy hook](ADR-0043-sql-column-sampling-non-null-and-strategy-hook.md) | Aceito |
+| 0044  | [Dependabot uv ecosystem for pyproject + lock closure](ADR-0044-dependabot-uv-ecosystem-for-pyproject-lock-closure.md) | Aceito |
+| 0045  | [ADR metadata and format standardization](ADR-0045-adr-metadata-and-format-standardization.md) | Aceito |
+| 0046  | [Operator intent and blameless collaboration posture](ADR-0046-operator-intent-and-blameless-collaboration.md) | Aceito |
+| 0047  | [RCA-first defect investigation and fix discipline](ADR-0047-rca-first-defect-investigation-and-fix-discipline.md) | Aceito |
+| 0048  | [Operator-facing taxonomy and naming contract preservation](ADR-0048-operator-facing-taxonomy-and-naming-contract-preservation.md) | Aceito |
+| 0049  | [No brittle mitigations — robust input handling over symptom suppression](ADR-0049-no-brittle-mitigations-robust-input-handling.md) | Aceito |
+| 0050  | [Plan document metadata standard](ADR-0050-plan-document-metadata-standard.md) | Aceito |
+| 0051  | [Incremental filesystem scan: file-identity fingerprint contract](ADR-0051-incremental-filesystem-scan-file-identity-fingerprint.md) | Aceito |
+| 0052  | [YAML plugin system: centralized schema and unified plugin file](ADR-0052-yaml-plugin-system-centralized-schema.md) | Aceito |
+| 0053  | [`ebcdic` direct upper-bound pin and Dependabot ignore for blocked semver-major](ADR-0053-ebcdic-direct-upper-bound-and-dependabot-ignore.md) | Aceito |
+| 0054  | [Decline `chardet` semver-major bumps while `cyclonedx-bom` pins `chardet<6.0`](ADR-0054-chardet-pinned-by-cyclonedx-bom.md) | Aceito |
+| 0055  | [Orthogonal priority axes (H/U/A/P/G/S/M) anti-collision contract](ADR-0055-orthogonal-priority-axes-anti-collision-contract.md) | Aceito |
+| 0056  | [Cryptographic ADR inventory (inv-adr.ps1 + SSH ed25519 attestation)](ADR-0056-cryptographic-adr-inventory-inv-adr-ssh-attestation.md) | Aceito |
+| 0057  | [Lightweight hub index (co-located links, no file moves)](ADR-0057-lightweight-hub-index-co-located-links.md) | Aceito |
+| 0058  | [Primer hub registration ritual](ADR-0058-primer-hub-registration-ritual.md) | Aceito |
+| 0059  | *Reservado* — minimal plugin hook infrastructure (GitHub #606, 1.8.x) | Reservado |
+| 0060 | [`db/` Ruff and Bandit exclusion — risk accepted](ADR-0060-db-lint-bandit-exclusion-risk-accepted.md) | Aceito |
+| 0061 | [ADR-0061 U-axis issue sub-order and cross-milestone gate](ADR-0061-u-axis-issue-suborder-and-cross-milestone-gate.md) | Aceito |
+| 0062 | [ADR-0062 Agent containment: triple-audit offband pattern](ADR-0062-agent-containment-triple-audit-offband-pingpong.md) | Aceito |
+| 0063 | [ed25519 (EdDSA) for license JWT signing](ADR-0063-ed25519-license-jwt-signing.md) | Aceito |
+| 0064 | [License enforcement — additive open-core + JWT](ADR-0064-license-enforcement-additive-model.md) | Proposto |
+| 0065 | [NIST SP 800-228A as REST API security hardening reference](ADR-0065-nist-sp800228a-api-security-reference.md) | Deferido |
+| 0066 | [TAMPERED state behavior — fail-closed in enforced mode](ADR-0066-tampered-state-behavior.md) | Aceito |
+| 0067  | *Reservado* — number freed (was #769 plugin auth); see **0075** | Reservado |
+| 0068 | [Primary Linux dev workstation (temporary)](ADR-0068-primary-linux-dev-workstation-temporary.md) | Aceito |
+| 0069 | [Cap rpds-py below the 2026 CalVer pivot](ADR-0069-cap-rpds-py-below-the-2026-calver-pivot.md) | Aceito |
+| 0070 | [Primer taxonomy and home: technical/onboarding vs deliverable](ADR-0070-primer-taxonomy-and-home.md) | Aceito |
+| 0071 | [Self-protecting PII gate: word-boundary matcher, CODEOWNERS, tripwire, FP allowlist](ADR-0071-self-protecting-pii-gate.md) | Aceito |
+| 0072 | [Commit Gate vs Release Gate: distinct criteria](ADR-0072-commit-gate-vs-release-gate-distinct-criteria.md) | Aceito |
+| 0073 | [Version scheme: octet-maturity side-channel + release-line roadmap](ADR-0073-version-scheme-octet-maturity-and-roadmap.md) | Aceito |
+| 0074 | [Supply-chain Layer 1: digest pins and Rust SCA](ADR-0074-supply-chain-layer1-digest-pins-and-rust-sca.md) | Proposto |
+| 0075 | [Plugin authentication — file-based license vs Bearer](ADR-0075-plugin-auth-file-based-vs-bearer.md) | Proposto |
+| 0076 | [OPA/Rego as CI tier drift linter (not runtime)](ADR-0076-opa-rego-ci-tier-drift-linter-not-runtime.md) | Proposto |
+| 0077 | [Filesystem scan does not honor client `.gitignore`](ADR-0077-filesystem-scan-no-client-gitignore-by-design.md) | Aceito |
+| 0078 | [Multi-pattern regex: RegexSet before Vectorscan (benchmark gate; 2026-07-31 amend — RegexSet spike failed, cached Regex loop next)](ADR-0078-multi-pattern-regex-benchmark-gate-regexset-before-vectorscan.md) | Proposto |
+| 0079 | [Ecosystem engineering rigor canon (UMADR satellites)](ADR-0079-ecosystem-engineering-rigor-canon.md) | Proposto |
+| 0080 | [Local validation gate is inviolable: full check-all before any push or PR](ADR-0080-local-validation-gate-inviolable.md) | Proposto |
+| 0081 | [No silent ML confidence failures on single-class compliance profiles](ADR-0081-no-silent-ml-confidence-single-class-hardening.md) | Proposto |
+| 0082 | [Web exposure safe-by-default boundary controls](ADR-0082-web-exposure-safe-by-default-boundary-controls.md) | Proposto |
+| 0083 | [Rust regex stage: accept form B (findings superset)](ADR-0083-rust-regex-stage-superset-accept-form-b.md) | Aceito |
+| 0084 | [Native package: embed CPython by channel (Enterprise vs community)](ADR-0084-native-package-embedded-cpython-by-channel.md) | Proposto |
 
 ## Docs relacionados
 
-- [ADR 0034](ADR-0034-outbound-http-user-agent-data-boar-prospector.md) (EN) — User-Agent HTTP(S) de saída **`DataBoar-Prospector/<versão>`** para conectores de descoberta (REST/API, SharePoint, Power BI, Dataverse); override por `headers` no YAML do alvo.
-- [ADR 0035](ADR-0035-readme-stakeholder-pitch-vs-deck-vocabulary.md) (EN) — bloco executivo do README (pitch para gestores) separado de rótulos opcionais de deck (**Data Sniffing** / **Deep Boring**); contrato em `tests/test_readme_stakeholder_pitch_contract.py`.
-- [ADR 0036](ADR-0036-exception-and-log-pii-redaction-pipeline.md) (EN) — pipeline `sanitize_log_text` / `clean_error` e `scan_failures.details` redigido (sem vazar PII de exceções de driver/HTTP no SQLite ou em logs).
-- [ADR 0037](ADR-0037-data-boar-self-audit-log-governance.md) (EN) — **governança do auditor**: o que já existe (sessões SQLite, export audit trail, logs, WebAuthn), lacunas explícitas (sem log imutável por download de relatório / por POST de config) e direção futura.
-- [ADR 0038](ADR-0038-jurisdictional-ambiguity-alert-dont-decide.md) (EN) — **ambiguidade jurisdicional**: o produto **alerta** e ajuda a **inventariar tensão** (várias hints / sinais conflitantes em metadados); **não** escolhe lei aplicável nem base legal; guia [JURISDICTION_COLLISION_HANDLING.pt_BR.md](../JURISDICTION_COLLISION_HANDLING.pt_BR.md).
-- [ADR 0039](ADR-0039-retention-evidence-posture-bonded-customs-adjacent-contexts.md) (EN) — **retenção e postura de evidência** em contextos de **recinto / adjacência alfandegária**: operador dono de retenção de artefatos; produto **não** implementa prazos legais nem “flag” automática de exceção; filosofia pública em [THE_WHY.pt_BR.md](../philosophy/THE_WHY.pt_BR.md).
-- [ADR 0040](ADR-0040-assistant-private-stack-evidence-mirrors-default.md) (EN) — **espelhos do repo privado empilhado** (`docs/private/`): assistente **atualiza todos** os destinos alcançáveis (lab + bare no volume cifrado quando existir) quando o pedido já implica alinhar/sync/higiene; **sem** perguntas retóricas de backup.
-- [ADR 0041](ADR-0041-lab-completao-data-contract-preflight.md) (EN) — **preflight de contrato de dados** no completão (opcional): YAML + env com URL SQLAlchemy; valida colunas exigidas **antes** do smoke SSH por host; ver [LAB_COMPLETAO_RUNBOOK.pt_BR.md](../ops/LAB_COMPLETAO_RUNBOOK.pt_BR.md).
-- [ADR 0042](ADR-0042-lab-lessons-learned-archive-contract.md) (EN) — **arquivo público de lições de lab**: snapshots datados em **`docs/ops/lab_lessons_learned/`** + hub **`LAB_LESSONS_LEARNED.md`**; token de sessão **`lab-lessons`** e regra situacional **`lab-lessons-learned-archive.mdc`**; ponte para **`PLANS_TODO.md`**.
-- [ADR 0044](ADR-0044-dependabot-uv-ecosystem-for-pyproject-lock-closure.md) (EN) — Dependabot passa a usar **`package-ecosystem: "uv"`**: PRs movem `pyproject.toml` + `uv.lock` juntos (operador faz **`uv export`** para regenerar `requirements.txt` conforme [ADR 0030](ADR-0030-python-dependency-update-closure-single-pass.md)); evita o vermelho determinístico do guard `tests/test_dependency_artifacts_sync.py`.
-- [ADR 0053](ADR-0053-ebcdic-direct-upper-bound-and-dependabot-ignore.md) (EN) — pin explícito de **`ebcdic<2`** (cadeia `extract-msg`) + `ignore` no Dependabot para major impossível.
-- [ADR 0054](ADR-0054-chardet-pinned-by-cyclonedx-bom.md) (EN) — pin dev de **`chardet<6`** (cadeia `cyclonedx-bom` / SBOM) + `ignore` de major no Dependabot.
-- [ADR 0055](ADR-0055-orthogonal-priority-axes-anti-collision-contract.md) (EN) — eixos ortogonais de priorizacao (H/U/A/P/G/S/M) e contrato anti-colisao (G != P; CodeQL != issue P).
-- [ADR 0056](ADR-0056-cryptographic-adr-inventory-inv-adr-ssh-attestation.md) (EN) — inventario criptografico de ADRs (`INVENTORY.txt`, `inv-adr.ps1`, assinatura SSH ed25519 opcional).
-- [ADR 0057](ADR-0057-lightweight-hub-index-co-located-links.md) (EN) — hubs leves co-localizados (`docs/hubs/INDEX.md`, `check_hubs.py`; sem mover arquivos).
-- [ADR 0058](ADR-0058-primer-hub-registration-ritual.md) (EN) — ritual de registro de primer no hub: ao abrir issue para `*_PRIMER.md`, adicionar linha `*(planned — #NNN)*` em `PRIMERS_HUB.md` no mesmo PR; sem "vaporware" invisível no backlog.
-- **0059** — *Reservado* (#606, hook mínimo de plugin, 1.8.x).
-- [ADR 0060](ADR-0060-db-lint-bandit-exclusion-risk-accepted.md) (EN) — **Proposed** — exclusão temporária de `db/` no Ruff/Bandit; risco aceito (#381); desambiguação #382/#675.
-- [ADR 0061](ADR-0061-u-axis-issue-suborder-and-cross-milestone-gate.md) (EN) — sub-ordenacao por eixo U dentro do mesmo P+milestone (U0 bloqueia sessao; U1 antes de U2/U3; sem-U = U3); gate cross-milestone obrigatorio.
-- [ADR 0062](ADR-0062-agent-containment-triple-audit-offband-pingpong.md) (EN) — contencao do agente por triangulacao de tres pilares independentes (A.I.I.D.C.O.B.P.P.): dois Claude em OSes distintos + Google Gemini; operador como barramento fisico; extensivel a N auditores (quad-audit validado em 2026-05-23).
-- [ADR 0063](ADR-0063-ed25519-license-jwt-signing.md) (EN) — **Proposed** — ed25519/EdDSA para assinatura de JWT de licença (#708); higiene de chaves SSH relacionada.
-- [ADR 0064](ADR-0064-license-enforcement-additive-model.md) (EN) — **Proposed** — enforcement aditivo open-core + JWT Pro/Enterprise (#709); Watch do ADR-0027 cumprida.
-- **0067** — *Reservado* (número liberado; auth de plugin → **ADR-0075** / #769).
-- [ADR 0072](ADR-0072-commit-gate-vs-release-gate-distinct-criteria.md) (EN) — **Proposed** — **Commit Gate** (`check-all`/CI) vs **Release Gate** (#406 completão + decisão do operador); vocabulario normativo pós-#970; guarda de maquina (regra 5) em issue filha.
-- [ADR 0073](ADR-0073-version-scheme-octet-maturity-and-roadmap.md) (EN) — **Accepted** — octeto-maturidade em `[tool.databoar] maturity_build` (0–127 beta, 128–199 rc, 200–255 release; `.200`=GA, `.201`=fix-1); público **três segmentos**; pós-GA fix na linha `1.7.4` + octeto; próximo público **1.8.0** (sem **1.7.5**); pós-#970/#772/#977.
-- [ADR 0074](ADR-0074-supply-chain-layer1-digest-pins-and-rust-sca.md) (EN) — **Proposed** — supply-chain Layer 1: SHAs de Actions, digest no `Dockerfile`, `cargo-deny` (Rust SCA), Grype na imagem distroless; fecha referência pendente de #987.
-- [ADR 0075](ADR-0075-plugin-auth-file-based-vs-bearer.md) (EN) — **Proposed** — auth de plugins L2/L3: híbrido (licença file-based + RBAC interno); renumeração de #769.
-- [ADR 0065](ADR-0065-nist-sp800228a-api-security-reference.md) (EN) — **Deferido** — NIST SP 800-228A ("Secure Deployment of RESTful Web APIs") como referencia de hardening da API REST; aguardando publicacao final (public comment deadline 2026-07-02; previsto Q3/Q4 2026).
-- [ADR 0066](ADR-0066-tampered-state-behavior.md) (EN) — comportamento do estado `TAMPERED`: fail-closed em modo `enforced`; pass-through em modo `monitor`.
-- [ADR 0068](ADR-0068-primary-linux-dev-workstation-temporary.md) (EN) — estacao de desenvolvimento Linux primaria **temporaria** (LMDE 7) durante reparo do Windows principal (Lenovo E0482B2DMD, falha 2026-06-07); reversao quando o Windows retornar.
-- [ADR 0043](ADR-0043-sql-column-sampling-non-null-and-strategy-hook.md) (EN) — **amostragem SQL por coluna**: filtro **`IS NOT NULL`** antes do teto de linhas; hook **`sql_sampling`** para evolução (metadados / `TABLESAMPLE`); env opcional **`DATA_BOAR_SQL_SAMPLE_LIMIT`**; plano [`PLAN_SQL_SAMPLING_SRE_AND_AUDIT_EVIDENCE.md`](../plans/completed/PLAN_SQL_SAMPLING_SRE_AND_AUDIT_EVIDENCE.md).
-- [ADR 0032](ADR-0032-maturity-assessment-batch-history-sqlite.md) (EN) — histórico por **batch** do questionário de maturidade no HTML do dashboard (agregação SQLite + tabela; RBAC/tenant **não** — ver [#86](https://github.com/FabioLeitao/data-boar/issues/86)).
-- [ADR 0033](ADR-0033-webauthn-open-relying-party-json-endpoints.md) (EN) — WebAuthn **RP** aberto (biblioteca `webauthn`): endpoints JSON em `/auth/webauthn/` por trás de `api.webauthn.enabled`; sem lock-in de vendor; UI do dashboard ainda não exige login (fase **#86**).
-- [ADR 0030](ADR-0030-python-dependency-update-closure-single-pass.md) (EN) — fechamento de atualização Python num único passe (`pyproject.toml` → lock → `requirements.txt`, `uv sync`, gate completo, SBOM/ADR quando aplicável); qualquer origem (CI, bots, review) usa o mesmo fluxo.
-- [ADR 0031](ADR-0031-pypi-packaging-hatchling-flat-layout.md) (EN) — empacotamento PyPI com **Hatchling** (layout plano explícito), dispatch **`scripts/pypi-publish.*`** (OIDC / `publish-pypi.yml`), entry point **`data-boar`** → `main:main`.
-- [ADR 0029](ADR-0029-cursor-markdown-preview-guardrail-and-lab-smoke-ansible-hook.md) (EN) — guardrail Cursor (preview Markdown em aba) + playbook Ansible `lab-smoke-stack-init-perms`; ver [CURSOR_MARKDOWN_PREVIEW_SETTINGS.pt_BR.md](../ops/CURSOR_MARKDOWN_PREVIEW_SETTINGS.pt_BR.md) e [LAB_SMOKE_MULTI_HOST.pt_BR.md](../ops/LAB_SMOKE_MULTI_HOST.pt_BR.md).
-- [ADR 0028](ADR-0028-lab-external-connectivity-eval-playbook.md) (EN) — playbook rastreado para avaliação de conectividade **externa** (APIs públicas, BD somente leitura com política); sem segredos no Git; ver [LAB_EXTERNAL_CONNECTIVITY_EVAL.pt_BR.md](../ops/LAB_EXTERNAL_CONNECTIVITY_EVAL.pt_BR.md).
-- [ADR 0026](ADR-0026-optional-jurisdiction-hints-dpo-facing-heuristic-metadata-only.md) (EN) — *jurisdiction hints* opcionais (DPO, heurística, só metadados no Report info); não conclusão jurídica; ver [USAGE.md](../USAGE.md) e [COMPLIANCE_AND_LEGAL.pt_BR.md](../COMPLIANCE_AND_LEGAL.pt_BR.md).
-- [ADR 0027](ADR-0027-commercial-tier-boundaries-licensing-docs-and-future-jwt-claims.md) (EN) — limites **Pro / Enterprise** documentados em `LICENSING_OPEN_CORE_AND_COMMERCIAL`; claims JWT ilustrativos em `LICENSING_SPEC`; Watch cumprida por ADR-0064 (Proposed); exemplos com nome ficam em `docs/private/`.
-- [ADR 0025](ADR-0025-compliance-positioning-evidence-inventory-not-legal-conclusion-engine.md) (EN) — posicionamento de **compliance**: evidência e inventário, **não** motor de **conclusão jurídica**; alinhado a [COMPLIANCE_AND_LEGAL.md](../COMPLIANCE_AND_LEGAL.md).
-- [ADR 0024](ADR-0024-enterprise-discovery-three-complementary-tracks.md) (EN) — descoberta enterprise em **três trilhos complementares** (planos + narrativa; sem promessa legal); ver `docs/plans/PLAN_*` citados no ADR.
-- [ADR 0022](ADR-0022-public-glossary-compliance-and-platform-terms.md) (EN) — glossário público: leis de conformidade, papéis (ex.: DPO), termos de plataforma (SRE, TLS, OAuth2); definições curtas; detalhe nos docs canônicos.
-- [ADR 0021](ADR-0021-public-web-presence-dns-alias-and-hosting.md) (EN) — presença web pública: alias DNS (CNAME), host canônico, TLS, forma de hospedagem (marketing vs produto).
-- [ADR 0020](ADR-0020-ci-full-git-history-pii-gate.md) (EN) — a CI executa `pii_history_guard.py --full-history` com checkout completo (`fetch-depth: 0`).
-- [CONTRIBUTING.pt_BR.md](../../CONTRIBUTING.pt_BR.md) — fluxo do contribuidor; menciona MD029 e o script de correção.
-- [SECURITY.pt_BR.md](../../SECURITY.pt_BR.md) · [TECH_GUIDE.pt_BR.md](../TECH_GUIDE.pt_BR.md) — entradas para operadores ([ADR 0002](ADR-0002-operator-facing-security-and-technical-docs.md), EN).
-- [QUALITY_WORKFLOW_RECOMMENDATIONS.md](../QUALITY_WORKFLOW_RECOMMENDATIONS.md) — §6 (MD029), §7 (ADRs), SBOM. *(EN.)*
-- [WORKFLOW_DEFERRED_FOLLOWUPS.pt_BR.md](../ops/WORKFLOW_DEFERRED_FOLLOWUPS.pt_BR.md) — follow-ups de workflow ([ADR 0005](ADR-0005-ci-github-actions-supply-chain-pins.md) sobre pin de Actions/uv).
-- [.cursor/rules/markdown-lint.mdc](../../.cursor/rules/markdown-lint.mdc) — quando rodar `fix_markdown_sonar.py` e renumeração pós-script.
-- [.cursor/rules/audience-segmentation-docs.mdc](../../.cursor/rules/audience-segmentation-docs.mdc) — links externos vs internos; [ADR 0004](ADR-0004-external-docs-no-markdown-links-to-plans.md) (texto canônico em inglês).
+| Doc | Notas |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| [CONTRIBUTING.pt_BR.md](../../CONTRIBUTING.pt_BR.md) | fluxo do contribuidor; menciona MD029 e o script de correção. |
+| [SECURITY.pt_BR.md](../../SECURITY.pt_BR.md) · [docs/TECH_GUIDE.pt_BR.md](../TECH_GUIDE.pt_BR.md) | entradas para operadores ([ADR 0002](ADR-0002-operator-facing-security-and-technical-docs.md)). |
+| [QUALITY_WORKFLOW_RECOMMENDATIONS.md](../QUALITY_WORKFLOW_RECOMMENDATIONS.md) | §6 (MD029), §7 (ADRs), SBOM. *(EN.)* |
+| [docs/ops/WORKFLOW_DEFERRED_FOLLOWUPS.pt_BR.md](../ops/WORKFLOW_DEFERRED_FOLLOWUPS.pt_BR.md) | follow-ups de workflow/supply-chain ([ADR 0005](ADR-0005-ci-github-actions-supply-chain-pins.md) sobre pin de Actions/uv). |
+| [.cursor/rules/markdown-lint.mdc](../../.cursor/rules/markdown-lint.mdc) | quando rodar `fix_markdown_sonar.py` e renumeração pós-script. |
+| [.cursor/rules/audience-segmentation-docs.mdc](../../.cursor/rules/audience-segmentation-docs.mdc) | links externos vs internos; [ADR 0004](ADR-0004-external-docs-no-markdown-links-to-plans.md). |
 
 ## Índice geral da documentação
 
 Veja [docs/README.pt_BR.md](../README.pt_BR.md) para o mapa completo.
+
+## Ecossistema UMADR (repositórios satélite)
+
+O **data-boar** é a regência UMADR **canônica** ([ADR 0000](ADR-0000-project-origin-and-adr-baseline.md) + [ADR 0045](ADR-0045-adr-metadata-and-format-standardization.md)). Rigor de engenharia compartilhado com satélites: [ADR 0079](ADR-0079-ecosystem-engineering-rigor-canon.md). Outros repositórios do ecossistema DEVEM:
+
+1. Manter **ADR-0000** só como **gênese** (origem/rebrand — sem modus operandi do operador).
+2. Adicionar ADR(s) **reference-stub** apontando para o ADR-0000 e o ADR-0079 públicos do data-boar (não duplicar a house rule nem o cânone de rigor).
+3. Registrar **rebrands** em ADR dedicado (ver [ADR 0014](ADR-0014-rename-repo-and-package-python3-lgpd-crawler-to-data-boar.md)).
+4. Usar nomes com **quatro dígitos** e corpos de ADR **somente em inglês**.
+
+Acompanhamento: GitHub [#994](https://github.com/FabioLeitao/data-boar/issues/994).

--- a/tests/test_adr_readme_index_sync.py
+++ b/tests/test_adr_readme_index_sync.py
@@ -1,35 +1,39 @@
-"""Guardrail: docs/adr/README.md Index table lists every numbered ADR file (and only those)."""
+"""Guardrail: docs/adr README Index tables list every numbered ADR file (EN + pt-BR)."""
 
 from __future__ import annotations
 
 import re
+from collections import Counter
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ADR_DIR = REPO_ROOT / "docs" / "adr"
 README_EN = ADR_DIR / "README.md"
-# Canonical index for completeness lives in EN README (see docs/adr/README.pt_BR.md partial table).
-_INDEX_START = "## Index"
-_INDEX_END = "## Related docs"
+README_PT = ADR_DIR / "README.pt_BR.md"
+_INDEX_MARKERS = {
+    README_EN: ("## Index", "## Related docs"),
+    README_PT: ("## Índice", "## Docs relacionados"),
+}
 _LINK_TARGET = re.compile(
     r"\]\(((?:ADR-)?\d{4}-[a-z0-9._-]+\.md)\)",
     re.IGNORECASE,
 )
 
 
-def _index_table_block(text: str) -> str:
-    if _INDEX_START not in text:
-        msg = f"{README_EN}: missing {_INDEX_START!r}"
+def _index_table_block(readme: Path, text: str) -> str:
+    start, end = _INDEX_MARKERS[readme]
+    if start not in text:
+        msg = f"{readme}: missing {start!r}"
         raise AssertionError(msg)
-    after = text.split(_INDEX_START, 1)[1]
-    if _INDEX_END not in after:
-        msg = f"{README_EN}: missing {_INDEX_END!r} after {_INDEX_START!r}"
+    after = text.split(start, 1)[1]
+    if end not in after:
+        msg = f"{readme}: missing {end!r} after {start!r}"
         raise AssertionError(msg)
-    return after.split(_INDEX_END, 1)[0]
+    return after.split(end, 1)[0]
 
 
-def _indexed_filenames(readme_text: str) -> list[str]:
-    block = _index_table_block(readme_text)
+def _indexed_filenames(readme: Path, readme_text: str) -> list[str]:
+    block = _index_table_block(readme, readme_text)
     return _LINK_TARGET.findall(block)
 
 
@@ -40,33 +44,42 @@ def _numbered_adr_filenames() -> set[str]:
     return names
 
 
-def test_adr_readme_index_lists_every_numbered_adr_file() -> None:
-    text = README_EN.read_text(encoding="utf-8")
-    indexed = _indexed_filenames(text)
+def _assert_index_complete(readme: Path) -> None:
+    text = readme.read_text(encoding="utf-8")
+    indexed = _indexed_filenames(readme, text)
     on_disk = _numbered_adr_filenames()
 
     missing_in_index = sorted(on_disk - set(indexed))
     assert not missing_in_index, (
-        f"{README_EN}: Index table missing row(s) for: {missing_in_index}. "
-        "Add a line in the ## Index table (same PR as the new ADR file)."
+        f"{readme}: Index table missing row(s) for: {missing_in_index}. "
+        "Add a line in the Index table (same PR as the new ADR file)."
     )
-
-
-def test_adr_readme_index_has_no_extra_or_duplicate_links() -> None:
-    text = README_EN.read_text(encoding="utf-8")
-    indexed = _indexed_filenames(text)
-    on_disk = _numbered_adr_filenames()
 
     extra = sorted(set(indexed) - on_disk)
     assert not extra, (
-        f"{README_EN}: Index links to missing file(s): {extra}. "
+        f"{readme}: Index links to missing file(s): {extra}. "
         "Fix the link target or remove the row."
     )
 
     if len(indexed) != len(set(indexed)):
-        from collections import Counter
-
         dupes = sorted([k for k, v in Counter(indexed).items() if v > 1])
-        assert False, f"{README_EN}: duplicate Index link target(s): {dupes}"
+        raise AssertionError(f"{readme}: duplicate Index link target(s): {dupes}")
 
     assert set(indexed) == on_disk
+
+
+def test_adr_readme_index_lists_every_numbered_adr_file() -> None:
+    _assert_index_complete(README_EN)
+
+
+def test_adr_readme_pt_br_index_lists_every_numbered_adr_file() -> None:
+    _assert_index_complete(README_PT)
+
+
+def test_adr_readme_en_and_pt_br_index_same_link_set() -> None:
+    en = set(_indexed_filenames(README_EN, README_EN.read_text(encoding="utf-8")))
+    pt = set(_indexed_filenames(README_PT, README_PT.read_text(encoding="utf-8")))
+    assert en == pt, (
+        f"EN vs pt-BR Index link set drift: "
+        f"only_en={sorted(en - pt)} only_pt={sorted(pt - en)}"
+    )


### PR DESCRIPTION
## Summary
- Mirror the complete ADR Index in `docs/adr/README.pt_BR.md` (EN titles + Aceito/Proposto/Deferido/Reservado), replacing the partial 0000–0006 + 0083–0084 table and the stale ad-hoc related-ADR bullets.
- Align Related docs / UMADR sections with the EN README shape; remove the blank line that broke the EN table between 0082 and 0083.
- Extend `tests/test_adr_readme_index_sync.py` so EN and pt-BR Index link sets must match disk ADR files (prevents silent pt-BR drift).

## Test plan
- [x] `./scripts/check-all.sh --enforced`
- [x] `./scripts/quick-test.sh --path tests/test_adr_readme_index_sync.py`