### PR TITLE
chore(github): require Closes #NNN in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,12 +8,28 @@ Brief description of the change and why it is needed.
 - [ ] Refactor / maintenance
 - [ ] Other (describe):
 
+## Issue linking (required)
+
+GitHub **only** auto-closes issues that appear with a closing keyword in the **merge commit / PR body**.
+A bare `#NNN`, “refs”, or “related” does **not** close. Putting `(#NNN)` at the **end of the PR title** is usually the **PR number** after squash-merge — not an issue.
+
+Use **one issue per line** (comma-separated lists are unreliable — e.g. `Closes #1133, #1134` may only close the first):
+
+```text
+Closes #NNNN
+```
+
+If this PR must **not** close any issue (docs index, partial slice, epic child, tracking-only):
+
+```text
+No issue closed: <one-line reason>
+```
+
+- [ ] This PR links the issue with `Closes #NNNN` **or** documents `No issue closed:` above
+
 ## 🧱 Checklist de Integridade
 - [ ] **Python:** `uv run pytest` e `uv run ruff check .` sem erros.
 - [ ] **Rust Core:** `cargo clippy --locked` passou no motor nativo.
 - [ ] **Performance:** Validei que o benchmark não caiu abaixo de **0.574x**.
 - [ ] **Drift Doc:** O `README.pt_BR.md` reflete as mudanças atuais (LCM nível 1).
 - [ ] **Léxico:** Verifiquei se não há "anglicismos sintáticos" ou traduções artificiais.
-
-## Related issues
-Fixes (issue number) (if applicable).


### PR DESCRIPTION
## Summary
- Make issue linking mandatory in `.github/PULL_REQUEST_TEMPLATE.md`
- Prefer one `Closes #NNNN` per line; document `No issue closed:` opt-out
- Note: trailing `(#N)` on titles is usually the PR number after squash

No issue closed: hygiene / process enforcement only (no tracking issue).

## Test plan
- [x] `./scripts/check-all.sh --enforced` green