### PR TITLE
fix(scan): save Phase 3 inferred controls after mid-loop errors

### DIFF
--- a/connectors/mongodb_connector.py
+++ b/connectors/mongodb_connector.py
@@ -113,6 +113,7 @@ class MongoDBConnector:
         except Exception as e:
             self.db_manager.save_failure(target_name, "unreachable", str(e))
             return
+        identifier_names: list[str] = []
         try:
             from utils.logger import log_connection
 
@@ -121,7 +122,6 @@ class MongoDBConnector:
             self._save_crypto_controls_audit(target_name)
             distinct_cap = resolve_sql_sample_limit(int(self.sample_limit))
             fetch_budget = resolve_fetch_row_budget(distinct_cap)
-            identifier_names: list[str] = []
             for coll_name in self._db.list_collection_names():
                 coll = self._db[coll_name]
                 sample_docs = list(coll.find().limit(fetch_budget))
@@ -185,10 +185,11 @@ class MongoDBConnector:
                     except Exception:
                         # Finding log is optional telemetry and must not fail the connector flow.
                         continue
-            self._save_inferred_controls_summary(target_name, identifier_names)
         except Exception as e:
             self.db_manager.save_failure(target_name, "error", str(e))
         finally:
+            # Best-effort even when mid-loop sampling/detection raises.
+            self._save_inferred_controls_summary(target_name, identifier_names)
             self.close()
 
     def _save_inferred_controls_summary(

--- a/connectors/redis_connector.py
+++ b/connectors/redis_connector.py
@@ -110,13 +110,13 @@ class RedisConnector:
         except Exception as e:
             self.db_manager.save_failure(target_name, "unreachable", str(e))
             return
+        keys: list[Any] = []
         try:
             from utils.logger import log_connection
 
             log_connection(audit_name, "redis", self.config.get("host", "localhost"))
             self._save_inventory_snapshot(target_name)
             self._save_crypto_controls_audit(target_name)
-            keys = []
             for k in self._client.scan_iter(count=self.sample_limit):
                 keys.append(k)
                 if len(keys) >= self.sample_limit:
@@ -218,10 +218,11 @@ class RedisConnector:
                         ensure_ascii=False,
                     ),
                 )
-            self._save_inferred_controls_summary(target_name, keys)
         except Exception as e:
             self.db_manager.save_failure(target_name, "error", str(e))
         finally:
+            # Best-effort even when mid-loop sampling/detection raises.
+            self._save_inferred_controls_summary(target_name, keys)
             self.close()
 
     def _save_inferred_controls_summary(

--- a/connectors/sql_connector.py
+++ b/connectors/sql_connector.py
@@ -690,6 +690,7 @@ class SQLConnector:
         except Exception as e:
             self.db_manager.save_failure(target_name, "unreachable", str(e))
             return
+        identifier_names: list[str] = []
         try:
             from utils.logger import log_connection
 
@@ -701,7 +702,6 @@ class SQLConnector:
             progress = self._scan_progress
             if progress is not None and getattr(progress, "enabled", False):
                 progress.set_tables_total(len(discovered), target_name=target_name)
-            identifier_names: list[str] = []
             for table_index, item in enumerate(discovered, start=1):
                 schema = item["schema"]
                 table = item["table"]
@@ -726,10 +726,11 @@ class SQLConnector:
                         col["type"],
                         audit_log_name=audit_name,
                     )
-            self._save_inferred_controls_summary(target_name, identifier_names)
         except Exception as e:
             self.db_manager.save_failure(target_name, "error", str(e))
         finally:
+            # Best-effort even when mid-loop sampling/detection raises.
+            self._save_inferred_controls_summary(target_name, identifier_names)
             self.close()
 
 

--- a/tests/test_crypto_controls_audit.py
+++ b/tests/test_crypto_controls_audit.py
@@ -239,6 +239,109 @@ def test_sql_connector_updates_inferred_controls_when_flag_on(tmp_path: Path) ->
     assert "a@example.com" not in summary
 
 
+def test_sql_inferred_controls_saved_when_mid_loop_raises(tmp_path: Path) -> None:
+    """Bugbot: mid-loop exceptions must not skip Phase 3 inferred summary."""
+    db_path = tmp_path / "scan_infer_boom.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE t1 (email TEXT, customer_cpf_hash TEXT, email_masked TEXT)"
+    )
+    conn.execute("INSERT INTO t1 VALUES ('a@x.com', 'h', 'm')")
+    conn.commit()
+    conn.close()
+
+    target = {
+        "type": "database",
+        "driver": "sqlite",
+        "database": str(db_path),
+        "name": "SQLiteInferBoom",
+        "_validate_crypto": True,
+    }
+    scanner = MagicMock()
+    db_manager = MagicMock()
+    connector = SQLConnector(target, scanner, db_manager)
+
+    def _boom(*_a, **_k):
+        _boom.n = getattr(_boom, "n", 0) + 1
+        if _boom.n >= 2:
+            raise RuntimeError("mid-loop boom")
+
+    with patch.object(SQLConnector, "_process_one_finding", side_effect=_boom):
+        connector.run()
+
+    assert db_manager.save_crypto_controls_audit.called
+    assert db_manager.save_failure.called
+    assert db_manager.update_crypto_controls_inferred_summary.called
+    summary = db_manager.update_crypto_controls_inferred_summary.call_args.args[1]
+    assert "hashing" in summary
+    assert "customer_cpf_hash" not in summary
+
+
+def test_mongodb_inferred_controls_saved_when_mid_loop_raises() -> None:
+    target = {
+        "name": "mongo-infer-boom",
+        "host": "localhost",
+        "port": 27017,
+        "database": "test",
+        "tls": True,
+        "_validate_crypto": True,
+    }
+    scanner = MagicMock()
+    scanner.scan_column.side_effect = RuntimeError("mid-loop boom")
+    db_manager = MagicMock()
+    coll = MagicMock()
+    coll.find.return_value.limit.return_value = [
+        {"email": "a@x.com", "customer_cpf_hash": "h", "email_masked": "m"}
+    ]
+    db = MagicMock()
+    db.list_collection_names.return_value = ["people"]
+    db.__getitem__.return_value = coll
+    db.command.return_value = {"version": "7.0.0"}
+    client = MagicMock()
+    client.__getitem__.return_value = db
+    connector = MongoDBConnector(target, scanner, db_manager)
+    with patch("connectors.mongodb_connector.MongoClient", return_value=client):
+        with patch("connectors.mongodb_connector._MONGO_AVAILABLE", True):
+            connector.run()
+
+    assert db_manager.save_crypto_controls_audit.called
+    assert db_manager.save_failure.called
+    assert db_manager.update_crypto_controls_inferred_summary.called
+    summary = db_manager.update_crypto_controls_inferred_summary.call_args.args[1]
+    assert "hashing" in summary
+    assert "customer_cpf_hash" not in summary
+
+
+def test_redis_inferred_controls_saved_when_mid_loop_raises() -> None:
+    target = {
+        "name": "redis-infer-boom",
+        "host": "localhost",
+        "port": 6379,
+        "tls": False,
+        "_validate_crypto": True,
+    }
+    scanner = MagicMock()
+    scanner.scan_column.side_effect = RuntimeError("mid-loop boom")
+    db_manager = MagicMock()
+    client = MagicMock()
+    client.info.return_value = {"redis_version": "7.2.0"}
+    client.scan_iter.return_value = iter(["user_hash", "session_token", "plain"])
+    fake_redis = MagicMock()
+    fake_redis.Redis.return_value = client
+    connector = RedisConnector(target, scanner, db_manager)
+    with patch("connectors.redis_connector._REDIS_AVAILABLE", True):
+        with patch("connectors.redis_connector.redis", fake_redis):
+            connector.run()
+
+    assert db_manager.save_crypto_controls_audit.called
+    assert db_manager.save_failure.called
+    assert db_manager.update_crypto_controls_inferred_summary.called
+    summary = db_manager.update_crypto_controls_inferred_summary.call_args.args[1]
+    assert "hashing" in summary
+    assert "tokenization" in summary
+    assert "user_hash" not in summary
+
+
 def test_update_crypto_controls_inferred_summary_persists(tmp_path: Path) -> None:
     db_path = str(tmp_path / "crypto_infer.db")
     mgr = LocalDBManager(db_path)


### PR DESCRIPTION
## Summary
- Bugbot follow-up to #1512: SQL / MongoDB / Redis now persist `inferred_controls_summary` in `finally`, so mid-loop exceptions no longer skip Phase 3 inference.
- Regression tests cover mid-loop raise on all three connectors.

## Test plan
- [x] `./scripts/check-all.sh` (local, exit 0)
- [x] `tests/test_crypto_controls_audit.py` (mid-loop cases)
- [ ] CI green on this PR head SHA (`statusCheckRollup`)