### PR TITLE
fix(security): OAuth token verify + bounded httpx crypto probe

### DIFF
--- a/connectors/dataverse_connector.py
+++ b/connectors/dataverse_connector.py
@@ -91,9 +91,8 @@ def _dataverse_token(target: dict[str, Any]) -> str | None:
         },
         "timeout": 30.0,
     }
-    verify_opt = resolve_httpx_tls_connect_options(target)
-    if verify_opt is not None:
-        token_kwargs["verify"] = verify_opt
+    # Token exchange carries client_secret + returns bearer — never honor
+    # target verify=False here (httpx default verify=True).
     resp = httpx.post(token_url, **token_kwargs)
     resp.raise_for_status()
     data = resp.json()

--- a/connectors/powerbi_connector.py
+++ b/connectors/powerbi_connector.py
@@ -77,9 +77,8 @@ def _get_access_token(target: dict[str, Any]) -> str | None:
         },
         "timeout": 30.0,
     }
-    verify_opt = resolve_httpx_tls_connect_options(target)
-    if verify_opt is not None:
-        token_kwargs["verify"] = verify_opt
+    # Token exchange carries client_secret + returns bearer — never honor
+    # target verify=False here (httpx default verify=True).
     resp = httpx.post(token_url, **token_kwargs)
     resp.raise_for_status()
     data = resp.json()

--- a/connectors/rest_connector.py
+++ b/connectors/rest_connector.py
@@ -84,9 +84,8 @@ def _build_auth(client: "httpx.Client", target: dict[str, Any]) -> None:
                 },
                 "timeout": 30.0,
             }
-            verify_opt = resolve_httpx_tls_connect_options(target)
-            if verify_opt is not None:
-                token_kwargs["verify"] = verify_opt
+            # Token exchange carries client_secret + returns bearer — never
+            # honor target verify=False here (httpx default verify=True).
             resp = httpx.post(token_url, **token_kwargs)
             resp.raise_for_status()
             data = resp.json()

--- a/connectors/sql_connector.py
+++ b/connectors/sql_connector.py
@@ -657,6 +657,7 @@ class SQLConnector:
                 inferred_controls_summary=None,
             )
         except Exception:
+            # Fail-soft: crypto probe/persist errors never fail the scan.
             pass
 
     def _save_inferred_controls_summary(

--- a/core/crypto_audit.py
+++ b/core/crypto_audit.py
@@ -832,6 +832,7 @@ def collect_sql_crypto_facts(
                     source="pg_stat_ssl",
                 )
         except Exception:
+            # Fail-soft: live SQL TLS probe must never fail the scan.
             pass
 
     if dialect in ("mysql", "mariadb"):
@@ -858,6 +859,7 @@ def collect_sql_crypto_facts(
                     source="mysql_ssl_status",
                 )
         except Exception:
+            # Fail-soft: live SQL TLS probe must never fail the scan.
             pass
 
     return CryptoProbeFacts(
@@ -894,6 +896,7 @@ def collect_mongodb_crypto_facts(
                 live_tls = opt_tls
                 source = "mongodb_client_options"
     except Exception:
+        # Fail-soft: client-option introspection must never fail the scan.
         pass
 
     # Best-effort: inspect one pooled socket after a cheap server ping.
@@ -924,6 +927,7 @@ def collect_mongodb_crypto_facts(
                 live_tls = True
                 source = "mongodb_ssl_socket"
     except Exception:
+        # Fail-soft: Mongo live TLS probe must never fail the scan.
         pass
 
     if live_tls is None:
@@ -987,10 +991,12 @@ def collect_redis_crypto_facts(
                     pool.release(conn)
                     conn = None
     except Exception:
+        # Fail-soft: Redis live TLS probe must never fail the scan.
         if conn is not None and pool is not None:
             try:
                 pool.release(conn)
             except Exception:
+                # Fail-soft: pool release during probe cleanup is best-effort.
                 pass
 
     if live_tls is None:
@@ -1048,6 +1054,7 @@ def collect_smb_crypto_facts(
             if supports is False:
                 encryption = "unsupported"
     except Exception:
+        # Fail-soft: SMB attribute probe must never fail the scan.
         return CryptoProbeFacts(source="unavailable")
 
     if dialect is None and signing is None and encryption is None:
@@ -1132,12 +1139,11 @@ def collect_httpx_crypto_facts(
                     tls_version, cipher = _ssl_socket_probe(sock)
                     if tls_version or cipher:
                         source = "httpx_ssl_socket"
-                # Drain lightly so the connection can close cleanly.
-                try:
-                    resp.read()
-                except Exception:
-                    pass
+                # Do not resp.read(): probe only needs TLS socket metadata;
+                # draining the body could use unbounded memory on a hostile host.
+                # Closing the stream context is enough.
     except Exception:
+        # Fail-soft: httpx TLS probe must never fail the scan.
         pass
 
     return CryptoProbeFacts(

--- a/tests/test_crypto_audit_criteria.py
+++ b/tests/test_crypto_audit_criteria.py
@@ -500,6 +500,51 @@ def test_collect_httpx_verify_false_maps_to_require() -> None:
     assert "require" in details
 
 
+def test_collect_httpx_probe_does_not_read_response_body() -> None:
+    """Hostile/large bodies must not be drained during the TLS socket probe."""
+
+    class _Sock:
+        def version(self):
+            return "TLSv1.3"
+
+        def cipher(self):
+            return ("TLS_AES_256_GCM_SHA384", "TLSv1.3", 256)
+
+    class _Net:
+        def get_extra_info(self, name):
+            return _Sock() if name == "socket" else None
+
+    class _Resp:
+        def __init__(self) -> None:
+            self.extensions = {"network_stream": _Net()}
+            self.read_calls = 0
+
+        def read(self):
+            self.read_calls += 1
+            return b"x" * (8 * 1024 * 1024)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a):
+            return False
+
+    resp = _Resp()
+
+    class _Client:
+        base_url = "https://api.example.com"
+
+        def stream(self, *_a, **_k):
+            return resp
+
+    facts = collect_httpx_crypto_facts(
+        _Client(), {"base_url": "https://api.example.com"}
+    )
+    assert facts.source == "httpx_ssl_socket"
+    assert facts.tls_version == "TLSv1.3"
+    assert resp.read_calls == 0
+
+
 def test_infer_controls_from_identifiers_counts_without_listing_names() -> None:
     sensitive_name = "customer_cpf_hash"
     summary = infer_controls_from_identifiers(

--- a/tests/test_oauth_token_verify_strict.py
+++ b/tests/test_oauth_token_verify_strict.py
@@ -1,0 +1,97 @@
+"""OAuth token exchange must never disable TLS verify (Order 5 follow-up).
+
+Target ``verify`` / ``verify_ssl: false`` may apply to the data-plane Client,
+but client_credentials POSTs carry client_secret and return bearer tokens —
+those must keep httpx's default certificate verification.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from connectors.dataverse_connector import _dataverse_token
+from connectors.powerbi_connector import _get_access_token
+from connectors.rest_connector import _build_auth
+
+
+def _token_response(access_token: str = "access-token-xyz") -> MagicMock:
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {"access_token": access_token}
+    return resp
+
+
+def test_rest_oauth_token_post_never_gets_verify_false() -> None:
+    captured: dict = {}
+
+    def fake_post(url, **kwargs):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return _token_response()
+
+    client = MagicMock()
+    client.headers = {}
+    target = {
+        "verify": False,
+        "verify_ssl": False,
+        "auth": {
+            "type": "oauth2_client",
+            "token_url": "https://login.example.com/oauth/token",
+            "client_id": "cid",
+            "client_secret": "csecret",
+        },
+    }
+    with patch("connectors.rest_connector.httpx") as hx:
+        hx.post.side_effect = fake_post
+        _build_auth(client, target)
+
+    assert "verify" not in captured["kwargs"]
+    assert captured["kwargs"].get("verify") is not False
+    assert client.headers.get("Authorization") == "Bearer access-token-xyz"
+
+
+def test_powerbi_token_post_never_gets_verify_false() -> None:
+    captured: dict = {}
+
+    def fake_post(url, **kwargs):
+        captured["kwargs"] = kwargs
+        return _token_response("pbi-token")
+
+    target = {
+        "tenant_id": "tenant",
+        "client_id": "cid",
+        "client_secret": "csecret",
+        "verify": False,
+        "verify_ssl": False,
+    }
+    with patch("connectors.powerbi_connector.httpx") as hx:
+        hx.post.side_effect = fake_post
+        token = _get_access_token(target)
+
+    assert token == "pbi-token"
+    assert "verify" not in captured["kwargs"]
+    assert captured["kwargs"].get("verify") is not False
+
+
+def test_dataverse_token_post_never_gets_verify_false() -> None:
+    captured: dict = {}
+
+    def fake_post(url, **kwargs):
+        captured["kwargs"] = kwargs
+        return _token_response("dv-token")
+
+    target = {
+        "org_url": "https://org.crm.dynamics.com",
+        "tenant_id": "tenant",
+        "client_id": "cid",
+        "client_secret": "csecret",
+        "verify": False,
+        "verify_ssl": False,
+    }
+    with patch("connectors.dataverse_connector.httpx") as hx:
+        hx.post.side_effect = fake_post
+        token = _dataverse_token(target)
+
+    assert token == "dv-token"
+    assert "verify" not in captured["kwargs"]
+    assert captured["kwargs"].get("verify") is not False


### PR DESCRIPTION
## Summary
- Stop propagating target `verify=False` into OAuth `client_credentials` token POSTs (REST / Power BI / Dataverse); data-plane `httpx.Client` TLS options unchanged.
- Remove unbounded `resp.read()` from `collect_httpx_crypto_facts` (TLS socket metadata only).
- Add fail-soft comments on Order 5 empty `except` sites for CodeQL clarity + regression tests for token verify and probe body drain.

## Test plan
- [x] `./scripts/check-all.sh` (local, exit 0)
- [x] `tests/test_oauth_token_verify_strict.py` (3 connectors)
- [x] `test_collect_httpx_probe_does_not_read_response_body`
- [ ] CI green on head SHA
- [ ] No new inline PR review / Security Agent findings (`gh api …/pulls/N/comments`)