### PR TITLE
docs(deploy): align image UID with distroless nonroot 65532

### DIFF
--- a/docs/deploy/DEPLOY.md
+++ b/docs/deploy/DEPLOY.md
@@ -140,7 +140,7 @@ The following are **optional** practices to harden deployments. They do not repl
 
 ### Docker
 
-- **Non-root:** The image already runs as user `appuser` (UID 1000). To enforce at runtime: `docker run --user 1000 ...` (or keep the Dockerfile `USER appuser`).
+- **Non-root:** The image already runs as distroless **nonroot** (**UID/GID 65532**). To enforce at runtime: `docker run --user 65532:65532 ...` (matches `USER 65532:65532` in the Dockerfile). There is no `appuser` account name in the image (`/etc/passwd` is not populated with that name).
 - **Resource limits:** Use `--cpus` and `--memory` for plain Docker (e.g. `--memory 1g`). In Compose, set `deploy.resources.limits` (e.g. `cpus: '1'`, `memory: 1G`).
 - **Healthchecks:** The image can be used with Docker `HEALTHCHECK`; for API mode, probe `GET /health`. Compose and Kubernetes examples in this repo already use `/health` for liveness/readiness. For observability, SLO/SLI/SLA, and SRE alignment (runbooks, error budgets, optional metrics), see [OBSERVABILITY_SRE.md](../OBSERVABILITY_SRE.md).
 - **DevSecOps:** Combine with API key (`api.require_api_key`), rate limiting (`rate_limit` in config), and CSP/security headers (see [SECURITY.md](../../SECURITY.md)). Run behind a reverse proxy with TLS and, when exposed externally, consider a WAF. **For production, set `api.require_api_key: true` and use a strong key from an environment variable** (e.g. `api.api_key_from_env: "AUDIT_API_KEY"`) so credentials are not stored in the config file.
@@ -154,7 +154,8 @@ You can tighten the Deployment with a **securityContext** and add a **NetworkPol
 ```yaml
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+        runAsUser: 65532
+        runAsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -172,7 +173,7 @@ You can tighten the Deployment with a **securityContext** and add a **NetworkPol
           # ... rest of container spec; ensure /data is a writable volumeMount so the app can write SQLite and reports
 ```
 
-The image runs as UID 1000 (`appuser`). Use a writable volume for `/data` (e.g. PVC or emptyDir) so SQLite and report output work with `readOnlyRootFilesystem: true`.
+The image runs as **UID/GID 65532** (Google distroless `:nonroot`). Use a writable volume for `/data` (e.g. PVC or emptyDir) so SQLite and report output work with `readOnlyRootFilesystem: true`.
 
 - **NetworkPolicy:** To restrict ingress to the API (e.g. only from an ingress controller or a specific namespace), use an example like `deploy/kubernetes/network-policy.example.yaml`. Apply it only if your cluster supports NetworkPolicy.
 
@@ -190,6 +191,9 @@ docker build -t data_boar:latest .
 mkdir -p data
 cp deploy/config.example.yaml data/config.yaml
 # Edit data/config.yaml as needed
+# Bind-mount ownership must match the image user (distroless nonroot):
+#   sudo chown -R 65532:65532 data
+# Named volumes (see Compose below) are usually initialized with the correct UID.
 
 docker run -d --name data-boar-audit \
   -p 8088:8088 \
@@ -198,7 +202,7 @@ docker run -d --name data-boar-audit \
   data_boar:latest
 ```
 
-Access: <http://localhost:8088/> (dashboard), <http://localhost:8088/docs> (API). In Docker and Kubernetes examples, the service is exposed via container/Service port bindings, so it is safe to keep the internal API binding on `0.0.0.0` inside the container while still using `127.0.0.1` as the default when running the CLI directly on a workstation. To stop: `docker stop data-boar-audit && docker rm data-boar-audit`.
+Access: <http://localhost:8088/> (dashboard), <http://localhost:8088/docs> (API). In Docker and Kubernetes examples, the process runs as **UID 65532**; if a bind-mounted `/data` is owned by UID 1000 (or root-only), you may see misleading failures such as “config not found” or “unable to open database file” that are really permission errors. Prefer a **named volume** (Compose default) or `chown 65532:65532` on the host path. The service is exposed via container/Service port bindings, so it is safe to keep the internal API binding on `0.0.0.0` inside the container while still using `127.0.0.1` as the default when running the CLI directly on a workstation. To stop: `docker stop data-boar-audit && docker rm data-boar-audit`.
 
 ## 4. Run with Docker Compose
 
@@ -416,7 +420,7 @@ Typical deployments keep all durable state under **`/data`** (volume or bind mou
 
 1. Stop the container, Compose stack, Swarm service, or scale the Kubernetes Deployment to zero.
 1. Restore files onto a new volume or directory at the same mount path (`/data` inside the container).
-1. Ensure **file ownership** is compatible with the image user (**UID 1000** / `appuser`) when using bind mounts on Linux hosts.
+1. Ensure **file ownership** is compatible with the image user (**UID/GID 65532**, distroless nonroot) when using bind mounts on Linux hosts.
 1. Start the workload again; verify **`GET /health`**, then run a short scan or open the dashboard to confirm SQLite and reports are visible.
 
 #### Operational notes

--- a/docs/deploy/DEPLOY.pt_BR.md
+++ b/docs/deploy/DEPLOY.pt_BR.md
@@ -88,7 +88,7 @@ Copie `deploy/config.example.yaml`, edite e use volume ou bind mount para `/data
 
 ### Segurança e endurecimento (opcional)
 
-Práticas opcionais para endurecer a implantação. Veja [SECURITY.md](../../SECURITY.md). A imagem já roda como usuário não-root (`appuser`, UID 1000). Para Kubernetes, você pode adicionar securityContext, NetworkPolicy e PDB (exemplos em `deploy/kubernetes/`). **Em produção**, defina `api.require_api_key: true` e use uma chave forte via variável de ambiente (ex.: `api.api_key_from_env: "AUDIT_API_KEY"`) para não armazenar credenciais no config.
+Práticas opcionais para endurecer a implantação. Veja [SECURITY.md](../../SECURITY.md). A imagem já roda como **nonroot** distroless (**UID/GID 65532**); não existe conta `appuser` nessa imagem. Para Kubernetes, use `runAsUser`/`runAsGroup` **65532**, NetworkPolicy e PDB (exemplos em `deploy/kubernetes/`). Em bind mount de `/data` no host, alinhe dono com `chown -R 65532:65532` — volume nomeado (Compose canônico) costuma evitar essa confusão. **Em produção**, defina `api.require_api_key: true` e use uma chave forte via variável de ambiente (ex.: `api.api_key_from_env: "AUDIT_API_KEY"`) para não armazenar credenciais no config.
 
 ## 3. Executar como container único (docker run)
 
@@ -96,6 +96,9 @@ Práticas opcionais para endurecer a implantação. Veja [SECURITY.md](../../SEC
 mkdir -p data
 cp deploy/config.example.yaml data/config.yaml
 # Edite data/config.yaml
+# Bind mount: alinhe o dono ao nonroot da imagem (distroless):
+#   sudo chown -R 65532:65532 data
+# Volume nomeado (Compose canônico) costuma evitar essa etapa.
 
 docker build -t data_boar:latest .
 docker run -d --name data-boar-audit \
@@ -105,7 +108,7 @@ docker run -d --name data-boar-audit \
   data_boar:latest
 ```
 
-Acesso: <http://localhost:8088/> (dashboard), <http://localhost:8088/docs> (API). Parar: `docker stop data-boar-audit && docker rm data-boar-audit`.
+Acesso: <http://localhost:8088/> (dashboard), <http://localhost:8088/docs> (API). O processo roda como **UID 65532**; se o bind mount de `/data` for dono de UID 1000 (ou só root), erros como “config not found” / “unable to open database file” podem ser só permissão. Prefira volume nomeado ou `chown 65532:65532`. Parar: `docker stop data-boar-audit && docker rm data-boar-audit`.
 
 ## 4. Executar com Docker Compose
 
@@ -195,7 +198,7 @@ Em implantações típicas, o estado fica sob **`/data`** (volume ou bind mount)
 
 1. Parar o container, stack Compose, serviço Swarm ou escalar o Deployment para zero.
 1. Restaurar os arquivos no mesmo caminho de montagem (`/data` dentro do container).
-1. Garantir **permissões/dono** compatíveis com o usuário da imagem (**UID 1000** / `appuser`) em bind mounts em Linux.
+1. Garantir **permissões/dono** compatíveis com o usuário da imagem (**UID/GID 65532**, nonroot distroless) em bind mounts em Linux.
 1. Subir de novo; verificar **`GET /health`** e um scan curto ou o dashboard.
 
 #### Notas operacionais


### PR DESCRIPTION
## Summary
- Fix `DEPLOY.md` / `DEPLOY.pt_BR.md` doc drift: runtime is distroless **UID/GID 65532** (not legacy `appuser` / UID 1000).
- Align optional Kubernetes `securityContext` example (`runAsUser`/`runAsGroup` 65532).
- Add operator note: bind-mount ownership vs named volume — wrong UID often surfaces as “config not found” / SQLite open failures.

Closes #1517

## Test plan
- [x] `./scripts/check-all.sh` (exit 0)
- [x] Commit signed (`git commit -S`; Good signature)
- [ ] Skim PR diff: no remaining `UID 1000` / `appuser` as current-image truth in `docs/deploy/DEPLOY*.md`
- [ ] Optional: bind-mount `/data` owned by 1000 vs `chown 65532` to confirm the failure mode described in the issue