### PR TITLE
docs: methodology cross-links + encoding anti-overclaim (#1525)

### DIFF
--- a/docs/COMPLIANCE_METHODOLOGY.md
+++ b/docs/COMPLIANCE_METHODOLOGY.md
@@ -16,6 +16,8 @@ Data Boar is built to answer **technical** questions with **repeatable evidence*
 
 That is **not** the same as declaring **legal adequacy** (e.g. that a given processing is lawful) or filling every column of a **Record of processing activities** (ROPA / **RIPD**-style inventory under LGPD) without human ownership. The methodology below keeps that boundary explicit while giving you **verification modules** you can map to coursework, audits, or internal checklists—including checklists you maintain outside this repo.
 
+Regime profiles are **YAML-distance** (any configured sample / jurisdiction mix)—not a single-country audit application. Evidence remains technical; counsel and the DPO own legal conclusions.
+
 ---
 
 ## Aligning your own adequacy index (e.g. a diagnostic Word template)
@@ -39,6 +41,8 @@ These modules describe **what the software can verify or signal today** (or in c
 | **M7 — Retention in sealed / customs-adjacent contexts** | Is **retention** of artefacts understood as **operator-owned**, without automated “legal basis” tags? | [ADR 0039](adr/ADR-0039-retention-evidence-posture-bonded-customs-adjacent-contexts.md) |
 
 **Risk level in this methodology** means **technical and triage risk** (exposure, category strength, combination risk)—**not** a substitute for your enterprise risk register or legal conclusion.
+
+**Coverage honesty:** A session with **zero findings** is not proof that every configured target was fully observed. Operators should review **`scan_failures`** (and related session metadata) alongside findings—see [CANONICAL_PRODUCT_FACTS.md](CANONICAL_PRODUCT_FACTS.md) and the Excel “Scan failures” sheet. Product research on a stronger evidence envelope and observability completeness is tracked in issues [#1504](https://github.com/DataBoar/data-boar/issues/1504), [#1521](https://github.com/DataBoar/data-boar/issues/1521), and [#1525](https://github.com/DataBoar/data-boar/issues/1525) (research only—not shipped guarantees).
 
 ---
 
@@ -69,4 +73,6 @@ If you want the next **product** slice, the highest leverage is usually: **(1)**
 
 - [COMPLIANCE_AND_LEGAL.md](COMPLIANCE_AND_LEGAL.md) — what the product does and does not claim.
 - [philosophy/THE_WHY.md](philosophy/THE_WHY.md) — evidence-first posture.
-- [COMPLIANCE_TECHNICAL_REFERENCE.md](COMPLIANCE_TECHNICAL_REFERENCE.md) — limits, sampling, timeouts.
+- [COMPLIANCE_TECHNICAL_REFERENCE.md](COMPLIANCE_TECHNICAL_REFERENCE.md) — limits, sampling, timeouts, encodings.
+- [compliance-samples/OPERATOR_GOVERNANCE_CHECKLIST.md](compliance-samples/OPERATOR_GOVERNANCE_CHECKLIST.md) — operator cadence for enabling and revalidating samples.
+- Research (not product guarantees): [#1504](https://github.com/DataBoar/data-boar/issues/1504) evidence envelope · [#1521](https://github.com/DataBoar/data-boar/issues/1521) observability completeness · [#1525](https://github.com/DataBoar/data-boar/issues/1525) coverage / sample / encoding inventory.

--- a/docs/COMPLIANCE_METHODOLOGY.pt_BR.md
+++ b/docs/COMPLIANCE_METHODOLOGY.pt_BR.md
@@ -16,6 +16,8 @@ O Data Boar responde a perguntas **técnicas** com **evidência repetível**:
 
 Isso **não** equivale a declarar **adequação jurídica** (por exemplo, que determinado tratamento é lícito) nem a preencher sozinho todas as colunas de um **registro de atividades de tratamento** (ROPA / enfoque **RIPD** sob a LGPD). A metodologia abaixo mantém essa fronteira explícita e oferece **módulos de verificação** para mapear em aulas, auditorias ou checklists internos — inclusive índices que você mantém fora deste repositório.
 
+Perfis de regime são de **distância YAML** (*YAML-distance* — qualquer mistura configurada de amostras / jurisdições) — não uma aplicação de auditoria de um único país. A evidência permanece técnica; a assessoria jurídica e o DPO detêm as conclusões legais.
+
 ---
 
 ## Alinhar seu próprio índice de adequação (ex.: modelo Word de diagnóstico)
@@ -39,6 +41,8 @@ Estes módulos descrevem **o que o software verifica ou sinaliza hoje** (ou em t
 | **M7 — Retenção em contexto lacrado / adjacente à alfândega** | A **retenção** de artefatos é **do operador**, sem etiquetas automáticas de “base legal”? | [ADR 0039](adr/ADR-0039-retention-evidence-posture-bonded-customs-adjacent-contexts.md) |
 
 **Nível de risco** nesta metodologia significa **risco técnico e de triagem** (exposição, força da categoria, risco de combinação) — **não** substitui seu registro de risco empresarial nem conclusão jurídica.
+
+**Honestidade de cobertura:** Uma sessão com **zero achados** não prova que todo alvo configurado foi plenamente observado. Operadores devem revisar **`scan_failures`** (e metadados de sessão relacionados) junto com os achados — veja [CANONICAL_PRODUCT_FACTS.pt_BR.md](CANONICAL_PRODUCT_FACTS.pt_BR.md) e a planilha Excel “Scan failures”. Pesquisa de produto sobre um envelope de evidência mais forte e completude de observabilidade está nas issues [#1504](https://github.com/DataBoar/data-boar/issues/1504), [#1521](https://github.com/DataBoar/data-boar/issues/1521) e [#1525](https://github.com/DataBoar/data-boar/issues/1525) (apenas pesquisa — não são garantias entregues).
 
 ---
 
@@ -69,4 +73,6 @@ Para a próxima fatia de **produto**, em geral o maior retorno é: **(1)** expor
 
 - [COMPLIANCE_AND_LEGAL.pt_BR.md](COMPLIANCE_AND_LEGAL.pt_BR.md) — o que o produto faz e não reivindica.
 - [philosophy/THE_WHY.pt_BR.md](philosophy/THE_WHY.pt_BR.md) — postura evidência primeiro.
-- [COMPLIANCE_TECHNICAL_REFERENCE.pt_BR.md](COMPLIANCE_TECHNICAL_REFERENCE.pt_BR.md) — limites, amostragem, timeouts.
+- [COMPLIANCE_TECHNICAL_REFERENCE.pt_BR.md](COMPLIANCE_TECHNICAL_REFERENCE.pt_BR.md) — limites, amostragem, timeouts, encodings.
+- [compliance-samples/OPERATOR_GOVERNANCE_CHECKLIST.pt_BR.md](compliance-samples/OPERATOR_GOVERNANCE_CHECKLIST.pt_BR.md) — cadência do operador para habilitar e revalidar amostras.
+- Pesquisa (não são garantias de produto): [#1504](https://github.com/DataBoar/data-boar/issues/1504) envelope de evidência · [#1521](https://github.com/DataBoar/data-boar/issues/1521) completude de observabilidade · [#1525](https://github.com/DataBoar/data-boar/issues/1525) inventário de cobertura / amostra / encoding.

--- a/docs/COMPLIANCE_TECHNICAL_REFERENCE.md
+++ b/docs/COMPLIANCE_TECHNICAL_REFERENCE.md
@@ -26,6 +26,8 @@ Configuration and pattern files support **UTF-8** (recommended), **UTF-8 with BO
 
 **Unicode in scanned data:** Findings and Excel output treat text as **Unicode**—**Latin**, **Cyrillic**, **CJK** (e.g. Japanese), **Arabic script**, and mixed corpora are in scope at the character level. **Byte-level decoding** of sources depends on connectors and file formats; **sniffing and heuristics** can be **tuned** per deployment. **Operator dashboard UI** and **full documentation** in many additional human languages are **not** all shipped yet; direction is **roadmapped** (short- to mid-term) with **en** + **pt-BR** first—see [COMPLIANCE_FRAMEWORKS.md](COMPLIANCE_FRAMEWORKS.md#multi-language-multi-encoding-and-multi-regional-operation) and the **Roadmap — internationalization and regional depth** paragraph in the repository **[README.md](../README.md)**. **Compliance YAML samples** must be **re-reviewed periodically** as regulations and wording change—see [compliance-samples/README.md](compliance-samples/README.md#sample-maintenance).
 
+**Policy (anti-overclaim):** “Any encoding” means **operator-tunable** config and Unicode-aware detection where implemented—not a guarantee that every connector decodes every on-disk or wire representation the same way, nor that the engine performs **universal mojibake repair** or NFC/homoglyph normalisation on all paths. Treat residual decode ambiguity as a **coverage limitation** (document or surface via `scan_failures` / connector behaviour), not as “clean.”
+
 Step-by-step: [USAGE.md — File encoding, config, and pattern files](USAGE.md#file-encoding-config-and-pattern-files) ([pt-BR](USAGE.pt_BR.md)).
 
 ---
@@ -50,12 +52,13 @@ Off-band, after a scan **completes**, the app can send a **short summary** (Slac
 
 ## Related documents
 
-| Topic                                        | Document                                             |
-| -----                                        | --------                                             |
-| Legal / compliance summary (decision-makers) | [COMPLIANCE_AND_LEGAL.md](COMPLIANCE_AND_LEGAL.md)   |
-| Frameworks, samples, YAML profiles           | [COMPLIANCE_FRAMEWORKS.md](COMPLIANCE_FRAMEWORKS.md) |
-| Full config schema, credentials, CLI         | [USAGE.md](USAGE.md)                                 |
-| Connectors, architecture, deploy             | [TECH_GUIDE.md](TECH_GUIDE.md)                       |
-| Detection patterns, ML/DL                    | [SENSITIVITY_DETECTION.md](SENSITIVITY_DETECTION.md) |
+| Topic                                        | Document                                                                   |
+| -----                                        | --------                                                                   |
+| Legal / compliance summary (decision-makers) | [COMPLIANCE_AND_LEGAL.md](COMPLIANCE_AND_LEGAL.md)                         |
+| Methodology (discovery, risk, ROPA-style)    | [COMPLIANCE_METHODOLOGY.md](COMPLIANCE_METHODOLOGY.md)                     |
+| Frameworks, samples, YAML profiles           | [COMPLIANCE_FRAMEWORKS.md](COMPLIANCE_FRAMEWORKS.md)                       |
+| Full config schema, credentials, CLI         | [USAGE.md](USAGE.md)                                                       |
+| Connectors, architecture, deploy             | [TECH_GUIDE.md](TECH_GUIDE.md)                                             |
+| Detection patterns, ML/DL                    | [SENSITIVITY_DETECTION.md](SENSITIVITY_DETECTION.md)                       |
 
 Full index: [README.md](README.md) · [README.pt_BR.md](README.pt_BR.md).

--- a/docs/COMPLIANCE_TECHNICAL_REFERENCE.pt_BR.md
+++ b/docs/COMPLIANCE_TECHNICAL_REFERENCE.pt_BR.md
@@ -26,6 +26,8 @@ Arquivos de configuração e de padrões suportam **UTF-8** (recomendado), **UTF
 
 **Unicode nos dados varridos:** achados e Excel tratam texto como **Unicode** — **latim**, **cirílico**, **CJK** (ex.: japonês), **árabe** e corpus mistos entram no âmbito de caracteres. A **decodificação em bytes** das fontes depende de conectores e formatos; **sniffing e heurísticas** podem ser **afinados** por implantação. **Interface web do operador** e **documentação completa** em muitos idiomas adicionais **ainda não** estão todas entregues; a direção está no **roadmap** (curto a médio prazo), com **en** + **pt-BR** primeiro — veja [COMPLIANCE_FRAMEWORKS.pt_BR.md](COMPLIANCE_FRAMEWORKS.pt_BR.md#operação-multilíngue-multi-encoding-e-multirregional) e o parágrafo **Roadmap — internacionalização e profundidade regional** no **[README.pt_BR.md](../README.pt_BR.md)**. **Amostras YAML de compliance** precisam de **revisão periódica** conforme normas e redações mudam — [compliance-samples/README.pt_BR.md](compliance-samples/README.pt_BR.md#manutenção-das-amostras).
 
+**Política (anti-overclaim):** “Qualquer encoding” significa config **ajustável pelo operador** e detecção ciente de Unicode onde implementada — não uma garantia de que todo conector decodifica da mesma forma toda representação em disco ou no fio, nem de que o motor faz **reparo universal de mojibake** ou normalização NFC/homóglifos em todos os caminhos. Trate ambiguidade residual de decode como **limitação de cobertura** (documente ou exponha via `scan_failures` / comportamento do conector), não como “limpo”.
+
 Passo a passo: [USAGE.pt_BR.md — Encoding de arquivos, config e padrões](USAGE.pt_BR.md#file-encoding-config-and-pattern-files) ([EN](USAGE.md)).
 
 ---
@@ -50,12 +52,13 @@ Fora de banda, ao **fim da varredura**, a aplicação pode enviar um **resumo cu
 
 ## Documentos relacionados
 
-| Tema                                                | Documento                                                        |
-| ----                                                | ---------                                                        |
-| Resumo jurídico / compliance (tomadores de decisão) | [COMPLIANCE_AND_LEGAL.pt_BR.md](COMPLIANCE_AND_LEGAL.pt_BR.md)   |
-| Frameworks, amostras, perfis YAML                   | [COMPLIANCE_FRAMEWORKS.pt_BR.md](COMPLIANCE_FRAMEWORKS.pt_BR.md) |
-| Esquema completo de config, credenciais, CLI        | [USAGE.pt_BR.md](USAGE.pt_BR.md)                                 |
-| Conectores, arquitetura, deploy                     | [TECH_GUIDE.pt_BR.md](TECH_GUIDE.pt_BR.md)                       |
-| Padrões de detecção, ML/DL                          | [SENSITIVITY_DETECTION.pt_BR.md](SENSITIVITY_DETECTION.pt_BR.md) |
+| Tema                                                | Documento                                                                      |
+| ----                                                | ---------                                                                      |
+| Resumo jurídico / compliance (tomadores de decisão) | [COMPLIANCE_AND_LEGAL.pt_BR.md](COMPLIANCE_AND_LEGAL.pt_BR.md)                 |
+| Metodologia (descoberta, risco, estilo ROPA)        | [COMPLIANCE_METHODOLOGY.pt_BR.md](COMPLIANCE_METHODOLOGY.pt_BR.md)             |
+| Frameworks, amostras, perfis YAML                   | [COMPLIANCE_FRAMEWORKS.pt_BR.md](COMPLIANCE_FRAMEWORKS.pt_BR.md)               |
+| Esquema completo de config, credenciais, CLI        | [USAGE.pt_BR.md](USAGE.pt_BR.md)                                               |
+| Conectores, arquitetura, deploy                     | [TECH_GUIDE.pt_BR.md](TECH_GUIDE.pt_BR.md)                                     |
+| Padrões de detecção, ML/DL                          | [SENSITIVITY_DETECTION.pt_BR.md](SENSITIVITY_DETECTION.pt_BR.md)               |
 
 Índice completo: [README.pt_BR.md](README.pt_BR.md) · [README.md](README.md).


### PR DESCRIPTION
## Summary
- `COMPLIANCE_METHODOLOGY` (+pt_BR): YAML-distance regimes; coverage honesty + `scan_failures`; Related → checklist + research #1504 #1521 #1525
- `COMPLIANCE_TECHNICAL_REFERENCE` (+pt_BR): encoding anti-overclaim policy; link to Methodology

Closes #1525 (inventory docs slice).
Closes #1526.

No code. No PLAN. No `CLAIMS.yml`. No sample YAML edits.

## Test plan
- [x] `./scripts/check-all.sh` green (clean license env)
- [ ] CI green on PR
- [ ] Spot-check EN/pt_BR insertion anchors match HITL comment on #1525