### PR TITLE
docs(plans): catalogue Data Soup connector gaps (#1537)

### DIFF
--- a/docs/plans/PLANS_TODO.md
+++ b/docs/plans/PLANS_TODO.md
@@ -600,6 +600,8 @@ Tighten runtime defaults for the API host. Implemented: default `127.0.0.1`, opt
 
 **Cloud object storage (S3-class):** [PLAN_OBJECT_STORAGE_CLOUD_CONNECTORS.md](PLAN_OBJECT_STORAGE_CLOUD_CONNECTORS.md) – **⬜ Plan only** (implementation backlog). **Corporate-Entity-C / reviewers:** expect **no** in-app S3/Azure/GCS connector until Phase 1 of that plan ships; compressed-file and share connectors remain the current path for file-like data.
 
+**Data Soup connector gaps (CouchDB / RabbitMQ + orphaned SAP-doc candidates):** [#1537](https://github.com/DataBoar/data-boar/issues/1537) – **⬜ Research / roadmap honesty only** (no formal `PLAN_*.md` yet; not an implementation greenlight). **New gaps never previously mentioned in-repo:** CouchDB (operator Obsidian vault sync via self-hosted LiveSync — real trigger), RabbitMQ (message-broker family; PII may live in payloads). **Still orphaned** in [PLAN_SAP_CONNECTOR.md](PLAN_SAP_CONNECTOR.md) (“Other data sources to consider” — doc already said to promote into `PLANS_TODO` when ready; that never happened): ServiceNow, Salesforce, Workday, BigQuery, Elasticsearch/OpenSearch, Kafka, Confluence/Jira, Splunk. Promote **one** named candidate (or a CouchDB / brokers slice) to its own plan/row when the operator chooses — keep this catalogue line as the non-orphan pointer only.
+
 **Static analysis (Semgrep):** [PLAN_SEMGREP_CI.md](completed/PLAN_SEMGREP_CI.md) – **✅ Complete** (CI workflow + Slack `workflow_run` for failures + optional smoke steps in plan).
 
 **Bandit (Python security linter):** [PLAN_BANDIT_SECURITY_LINTER.md](completed/PLAN_BANDIT_SECURITY_LINTER.md) – **Dev + CI strict** (`ci.yml`); **Phase 3** low triage ✅ documented; plan archived under **`completed/`**.


### PR DESCRIPTION
## Summary
- Add an **H3 catalogue** entry in `docs/plans/PLANS_TODO.md` pointing at [#1537](https://github.com/DataBoar/data-boar/issues/1537).
- Captures **CouchDB** + **RabbitMQ** as never-mentioned connector gaps, and notes the eight still-orphaned candidates from `PLAN_SAP_CONNECTOR.md` (“Other data sources to consider”).
- Research / roadmap honesty only — **no** new `PLAN_*.md`, **no** implementation greenlight.

Does **not** close #1537 (remaining checkboxes: confirm gap-check, decide CouchDB plan shape, etc.).

## Test plan
- [x] `python scripts/plans-stats.py --write` (no dashboard drift)
- [x] `./scripts/check-all.sh` (exit 0)
- [x] CI green on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only backlog catalogue update with no code, config, or runtime behavior changes.
> 
> **Overview**
> Adds a **catalogue-only** H3 backlog row in `PLANS_TODO.md` pointing at [#1537](https://github.com/DataBoar/data-boar/issues/1537).
> 
> Records **CouchDB** and **RabbitMQ** as previously unmentioned connector gaps, and lifts the eight still-orphaned candidates from `PLAN_SAP_CONNECTOR.md` (ServiceNow, Salesforce, Workday, BigQuery, Elasticsearch/OpenSearch, Kafka, Confluence/Jira, Splunk) into the central backlog. Explicitly **research / roadmap honesty only** — no new `PLAN_*.md` and no implementation greenlight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 209e796098e7fec2bf4d2f50313f9570024a4e44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->