### PR TITLE
feat(otel): LoggerProvider so Boar logs reach Loki (#1529)

### DIFF
--- a/core/otel_setup.py
+++ b/core/otel_setup.py
@@ -1,7 +1,10 @@
-"""Optional OpenTelemetry setup for FastAPI + SQLAlchemy (issue #1500).
+"""Optional OpenTelemetry setup for FastAPI + SQLAlchemy (issue #1500 / #1529).
 
 Opt-in only. When disabled or packages missing, this module is a no-op so
 ``python main.py`` never depends on OTel.
+
+Signals when enabled: traces, metrics, and **logs** (``LoggerProvider`` +
+stdlib ``logging`` bridge → OTLP → collector → Loki on the lab LGTM stack).
 """
 
 from __future__ import annotations
@@ -17,6 +20,9 @@ _ENV_ENABLED = "DATA_BOAR_OTEL_ENABLED"
 _ENV_ENDPOINT = "OTEL_EXPORTER_OTLP_ENDPOINT"
 _DEFAULT_ENDPOINT = "http://127.0.0.1:4317"
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+# Root handler attached once per process when OTel logs are enabled (#1529).
+_otel_logging_handlers: list[logging.Handler] = []
 
 
 def otel_enabled() -> bool:
@@ -51,6 +57,26 @@ def sanitize_otlp_endpoint_for_log(endpoint: str) -> str:
     return f"{scheme}://{host}"
 
 
+def _emit_boar_fast_filter_status_log() -> None:
+    """Emit one structured status line for Loki proof of accelerator presence (#1529)."""
+    try:
+        from core.pro_scan_path import rust_accelerator_installed
+
+        installed = rust_accelerator_installed()
+    except Exception as exc:  # noqa: BLE001 — never block OTel setup
+        logger.info(
+            "boar_fast_filter status unknown (probe failed: %s)",
+            exc,
+            extra={"boar_fast_filter_installed": None},
+        )
+        return
+    logger.info(
+        "boar_fast_filter status installed=%s",
+        installed,
+        extra={"boar_fast_filter_installed": installed},
+    )
+
+
 def maybe_setup_otel(app: Any | None = None) -> bool:
     """Initialize OTel exporters + instrument FastAPI (and SQLAlchemy when available).
 
@@ -63,6 +89,10 @@ def maybe_setup_otel(app: Any | None = None) -> bool:
     endpoint = otel_endpoint()
     try:
         from opentelemetry import metrics, trace
+        from opentelemetry._logs import set_logger_provider
+        from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
+            OTLPLogExporter,
+        )
         from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
             OTLPMetricExporter,
         )
@@ -70,6 +100,9 @@ def maybe_setup_otel(app: Any | None = None) -> bool:
             OTLPSpanExporter,
         )
         from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+        from opentelemetry.instrumentation.logging.handler import LoggingHandler
+        from opentelemetry.sdk._logs import LoggerProvider
+        from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
         from opentelemetry.sdk.metrics import MeterProvider
         from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
         from opentelemetry.sdk.resources import Resource
@@ -104,6 +137,23 @@ def maybe_setup_otel(app: Any | None = None) -> bool:
             MeterProvider(resource=resource, metric_readers=[metric_reader])
         )
 
+        # Logs (#1529): same endpoint/insecure policy as traces/metrics.
+        logger_provider = LoggerProvider(resource=resource)
+        logger_provider.add_log_record_processor(
+            BatchLogRecordProcessor(
+                OTLPLogExporter(endpoint=endpoint, insecure=insecure)
+            )
+        )
+        set_logger_provider(logger_provider)
+        if not _otel_logging_handlers:
+            # Prefer instrumentation LoggingHandler (sdk._logs.LoggingHandler is deprecated).
+            handler = LoggingHandler(
+                level=logging.INFO,
+                logger_provider=logger_provider,
+            )
+            logging.getLogger().addHandler(handler)
+            _otel_logging_handlers.append(handler)
+
         if app is not None:
             FastAPIInstrumentor.instrument_app(app)
 
@@ -115,11 +165,13 @@ def maybe_setup_otel(app: Any | None = None) -> bool:
             logger.info("OTel SQLAlchemy instrumentation skipped: %s", sqlalchemy_exc)
 
         logger.info(
-            "OpenTelemetry enabled (endpoint=%s, insecure=%s). Set %s=0 to disable.",
+            "OpenTelemetry enabled (endpoint=%s, insecure=%s, signals=traces+metrics+logs). "
+            "Set %s=0 to disable.",
             sanitize_otlp_endpoint_for_log(endpoint),
             insecure,
             _ENV_ENABLED,
         )
+        _emit_boar_fast_filter_status_log()
         return True
     except Exception as exc:  # noqa: BLE001 — never block app start
         logger.warning("OpenTelemetry setup failed (continuing without OTel): %s", exc)

--- a/docs/ops/evidence/otel_1529_loggerprovider_loki_2026-08-12.json
+++ b/docs/ops/evidence/otel_1529_loggerprovider_loki_2026-08-12.json
@@ -1,0 +1,69 @@
+{
+  "issue": 1529,
+  "date": "2026-08-12",
+  "setup_ok": true,
+  "otel_endpoint": "http://127.0.0.1:4317",
+  "service_name": "data-boar",
+  "marker": "db1529-e2e2-1786537170",
+  "loki_query": "{service_name=\"data-boar\"} |= \"db1529-e2e2-1786537170\"",
+  "loki_matching_lines": 5,
+  "sample_lines": [
+    {
+      "ts": "1786537172805086464",
+      "line": "1529 burst db1529-e2e2-1786537170 i=0",
+      "stream_labels": {
+        "service_name": "data-boar",
+        "service_namespace": "databoar",
+        "scope_name": "data_boar.e2e_1529",
+        "severity_text": "WARN"
+      }
+    },
+    {
+      "ts": "1786537172805555968",
+      "line": "1529 burst db1529-e2e2-1786537170 i=1",
+      "stream_labels": {
+        "service_name": "data-boar",
+        "service_namespace": "databoar",
+        "scope_name": "data_boar.e2e_1529",
+        "severity_text": "WARN"
+      }
+    },
+    {
+      "ts": "1786537172805807104",
+      "line": "1529 burst db1529-e2e2-1786537170 i=2",
+      "stream_labels": {
+        "service_name": "data-boar",
+        "service_namespace": "databoar",
+        "scope_name": "data_boar.e2e_1529",
+        "severity_text": "WARN"
+      }
+    },
+    {
+      "ts": "1786537172805987840",
+      "line": "1529 burst db1529-e2e2-1786537170 i=3",
+      "stream_labels": {
+        "service_name": "data-boar",
+        "service_namespace": "databoar",
+        "scope_name": "data_boar.e2e_1529",
+        "severity_text": "WARN"
+      }
+    },
+    {
+      "ts": "1786537172806178048",
+      "line": "1529 burst db1529-e2e2-1786537170 i=4",
+      "stream_labels": {
+        "service_name": "data-boar",
+        "service_namespace": "databoar",
+        "scope_name": "data_boar.e2e_1529",
+        "severity_text": "WARN"
+      }
+    }
+  ],
+  "collector": {
+    "otlp_accepted_log_records": "81714",
+    "otlp_http_logs_sent": "81714",
+    "send_failed_log_records": [],
+    "note": "send_failed empty at probe time (previous filelog send_failed episode not reproducing)"
+  },
+  "grafana_api": "GET /api/datasources/proxy/uid/loki/loki/api/v1/query_range (no token stored)"
+}

--- a/docs/plans/completed/PLAN_DATABOAR_OTEL_INSTRUMENTATION.md
+++ b/docs/plans/completed/PLAN_DATABOAR_OTEL_INSTRUMENTATION.md
@@ -22,10 +22,11 @@ Emit classical **RED** signals (request rate / errors / duration) and **distribu
 
 | Package | Role |
 | ------- | ---- |
-| `opentelemetry-api` / `opentelemetry-sdk` | Tracer + meter providers |
-| `opentelemetry-exporter-otlp` | OTLP gRPC/HTTP exporters |
+| `opentelemetry-api` / `opentelemetry-sdk` | Tracer + meter + **logger** providers |
+| `opentelemetry-exporter-otlp` | OTLP gRPC/HTTP exporters (traces / metrics / **logs**) |
 | `opentelemetry-instrumentation-fastapi` | HTTP RED + spans |
 | `opentelemetry-instrumentation-sqlalchemy` | DB spans when engines exist |
+| `opentelemetry-instrumentation-logging` | Stdlib ``logging`` → OTLP bridge (`LoggingHandler`) — [#1529](https://github.com/DataBoar/data-boar/issues/1529) |
 
 Install: `uv sync --extra otel` (or `pip install '.[otel]'`).
 
@@ -45,7 +46,8 @@ When disabled or packages missing: **no-op** (log warning if enabled-but-missing
 
 - Module: `core/otel_setup.py` (`maybe_setup_otel(app)`).
 - Wired after FastAPI app creation in `api/routes.py`.
-- Tests: `tests/test_otel_setup_1500.py` (default-off + endpoint override).
+- Tests: `tests/test_otel_setup_1500.py` (default-off + endpoint override + LoggerProvider bridge).
+- **Logs (#1529):** `LoggerProvider` + `OTLPLogExporter` + root `LoggingHandler` (same opt-in / fail-soft / loopback-insecure policy as traces/metrics). Emits a `boar_fast_filter status installed=…` line after setup so Loki can prove accelerator presence when enabled.
 
 ## Roll-out
 
@@ -59,3 +61,4 @@ When disabled or packages missing: **no-op** (log warning if enabled-but-missing
 - [x] Lab observability plan status refresh + hub / PLANS_TODO entry
 - [x] Opt-in wiring + `[otel]` extra
 - [x] E2E evidence — `docs/ops/evidence/otel_1500_smoke_2026-08-09.json` (setup_ok + OTLP HTTP `200` `partialSuccess` on local collector `:4318`)
+- [x] Logs bridge (#1529) — `docs/ops/evidence/otel_1529_loggerprovider_loki_2026-08-12.json` (stdlib → OTLP → collector → Loki `service_name=data-boar`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,7 @@ otel = [
     "opentelemetry-exporter-otlp>=1.27.0",
     "opentelemetry-instrumentation-fastapi>=0.48b0",
     "opentelemetry-instrumentation-sqlalchemy>=0.48b0",
+    "opentelemetry-instrumentation-logging>=0.48b0",
 ]
 
 [tool.uv]

--- a/tests/test_otel_setup_1500.py
+++ b/tests/test_otel_setup_1500.py
@@ -75,3 +75,30 @@ def test_otel_enabled_call_does_not_raise(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.delenv("DATA_BOAR_OTEL_ENABLED", raising=False)
     assert maybe_setup_otel(app=None) is False
     assert os.environ.get("DATA_BOAR_OTEL_ENABLED") in (None, "")
+
+
+def test_otel_logger_provider_and_stdlib_bridge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1529: when otel extra is installed, enable path wires LoggerProvider + root handler."""
+    pytest.importorskip("opentelemetry.sdk._logs")
+    pytest.importorskip("opentelemetry.instrumentation.logging.handler")
+
+    import logging
+
+    from opentelemetry._logs import get_logger_provider
+    from opentelemetry.instrumentation.logging.handler import LoggingHandler
+    from opentelemetry.sdk._logs import LoggerProvider
+
+    monkeypatch.setenv("DATA_BOAR_OTEL_ENABLED", "1")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:4317")
+    monkeypatch.setenv("OTEL_SERVICE_NAME", "data-boar-test-1529")
+
+    assert maybe_setup_otel(app=None) is True
+    provider = get_logger_provider()
+    assert isinstance(provider, LoggerProvider)
+
+    handlers = logging.getLogger().handlers
+    assert any(isinstance(h, LoggingHandler) for h in handlers), (
+        "stdlib root logger must get OTel LoggingHandler when OTel is enabled"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -949,6 +949,7 @@ otel = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-instrumentation-logging" },
     { name = "opentelemetry-instrumentation-sqlalchemy" },
     { name = "opentelemetry-sdk" },
 ]
@@ -1046,6 +1047,7 @@ requires-dist = [
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.27.0" },
     { name = "opentelemetry-exporter-otlp", marker = "extra == 'otel'", specifier = ">=1.27.0" },
     { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'otel'", specifier = ">=0.48b0" },
+    { name = "opentelemetry-instrumentation-logging", marker = "extra == 'otel'", specifier = ">=0.48b0" },
     { name = "opentelemetry-instrumentation-sqlalchemy", marker = "extra == 'otel'", specifier = ">=0.48b0" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.27.0" },
     { name = "oracledb", marker = "extra == 'oracle'", specifier = ">=4.0.1" },
@@ -2802,6 +2804,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/30/23/b057f8196d06efdc1b50e3ff11fbc499a7d96b35c87f217eb7885542f4ea/opentelemetry_instrumentation_fastapi-0.65b0.tar.gz", hash = "sha256:10a3a95486036230413a58fe4fdf4a83fa6bba46918407e527476994bd92bd97", size = 26236, upload-time = "2026-07-16T15:26:05.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/b0/c9b0300d33349ecc3dfd2362516eaffc44877e90970e6a52178ff953fec3/opentelemetry_instrumentation_fastapi-0.65b0-py3-none-any.whl", hash = "sha256:cda2610a0ec1b22d19886f33e4d861e9f5dbb886aeaa3a1263b47aff82c36943", size = 13261, upload-time = "2026-07-16T15:25:12.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-logging"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/0a/b70a9cddbc7b314a783e62739dbb1184f8538c1f85e8ded6d340142b9b54/opentelemetry_instrumentation_logging-0.65b0.tar.gz", hash = "sha256:c0a50cade5d54db6c6af12e2c69227ecd26f2b3b779e99ff850561d3d8dd77e3", size = 19783, upload-time = "2026-07-16T15:26:09.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/8e/7577914681d77b180f8d6dcbac435be8e4ca6add6315da2d01ac4289eaa3/opentelemetry_instrumentation_logging-0.65b0-py3-none-any.whl", hash = "sha256:68365b31755c844f1e85f07dcd217839ff92f2d278a214bdf02d4dc806f9d915", size = 15727, upload-time = "2026-07-16T15:25:18.774Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `LoggerProvider` + `BatchLogRecordProcessor` + `OTLPLogExporter` in `core/otel_setup.py`, same endpoint/insecure policy as traces/metrics.
- Bridge Python stdlib logging via `opentelemetry.instrumentation.logging.LoggingHandler` (extra `[otel]` dep); emit `boar_fast_filter` status line after setup.
- Lab collector already accepts OTLP logs (`otlp` receiver → `otlp_http/logs`); no current `send_failed` on that path.
- E2E evidence: `docs/ops/evidence/otel_1529_loggerprovider_loki_2026-08-12.json` — Grafana Loki `query_range` returned 5 lines for marker `db1529-e2e2-1786537170` with `service_name=data-boar`.

Closes #1529

## Test plan
- [x] `uv run pytest tests/test_otel_setup_1500.py -v` (LoggerProvider + stdlib bridge unit coverage)
- [x] `./scripts/check-all.sh` green locally (pre-commit + full pytest + Bandit/Zizmor)
- [x] With `DATA_BOAR_OTEL_ENABLED=1` and `OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317`, emit unique marker logs + `force_flush`
- [x] Confirm via Grafana API: `GET /api/datasources/proxy/uid/loki/loki/api/v1/query_range` with `{service_name="data-boar"} |= "<marker>"` — matching lines in Loki (not code-only)
- [x] Collector counters: `otelcol_receiver_accepted_log_records_total{receiver="otlp"}` and `otelcol_exporter_sent_log_records_total{exporter="otlp_http/logs"}` increased; no live `send_failed` on OTLP logs path
- [ ] CI green on this PR