### PR TITLE
security(connectors): SSRF DNS fail-closed + IP pin (#1552)

### DIFF
--- a/connectors/dataverse_connector.py
+++ b/connectors/dataverse_connector.py
@@ -21,7 +21,13 @@ from core.suggested_review import (
     augment_low_id_like_for_persist,
 )
 
-from .url_guard import target_allows_private, validate_outbound_url
+from .url_guard import (
+    build_pinned_httpx_client,
+    merge_host_pins,
+    pinned_httpx_request,
+    resolve_and_validate_outbound_url,
+    target_allows_private,
+)
 
 try:
     import httpx
@@ -69,15 +75,8 @@ def _dataverse_token(target: dict[str, Any]) -> str | None:
         auth.get("token_url")
         or f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
     )
-    # SSRF guard (#1232 / #832): custom token_url receives the client_secret via POST —
-    # never let it point at link-local/private hosts without explicit opt-in.
-    err = validate_outbound_url(
-        token_url,
-        allow_private=target_allows_private(target),
-        label="auth.token_url",
-    )
-    if err:
-        raise ValueError(err)
+    # SSRF guard (#1232 / #832 / #1552): custom token_url receives client_secret —
+    # validate + pin peer IPs (no DNS rebinding on the secret-bearing request).
     token_kwargs: dict[str, Any] = {
         "data": {
             "grant_type": "client_credentials",
@@ -91,9 +90,13 @@ def _dataverse_token(target: dict[str, Any]) -> str | None:
         },
         "timeout": 30.0,
     }
-    # Token exchange carries client_secret + returns bearer — never honor
-    # target verify=False here (httpx default verify=True).
-    resp = httpx.post(token_url, **token_kwargs)
+    resp = pinned_httpx_request(
+        "POST",
+        token_url,
+        allow_private=target_allows_private(target),
+        label="auth.token_url",
+        **token_kwargs,
+    )
     resp.raise_for_status()
     data = resp.json()
     return data.get("access_token")
@@ -102,7 +105,10 @@ def _dataverse_token(target: dict[str, Any]) -> str | None:
 def _api_base(org_url: str) -> str:
     """Derive Web API base from org URL (e.g. https://org.crm.dynamics.com -> https://org.api.crm.dynamics.com/api/data/v9.2)."""
     url = org_url.rstrip("/")
-    if not url.startswith(_HTTPS_PREFIX):
+    # Normalize http→https without producing https://http://… (breaks host parse).
+    if url.lower().startswith("http://"):
+        url = _HTTPS_PREFIX + url[7:]
+    elif not url.startswith(_HTTPS_PREFIX):
         url = _HTTPS_PREFIX + url
     host = url.replace(_HTTPS_PREFIX, "").split("/")[0]
     if ".api." in host:
@@ -142,13 +148,14 @@ class DataverseConnector:
         org_url = self.config.get("org_url") or self.config.get("environment_url", "")
         if not org_url:
             raise ValueError("Dataverse requires org_url (or environment_url)")
-        # SSRF guard (#1232): validate the raw org_url from config before any HTTP —
-        # including before token POST. Do not validate `_api_base()` output: it rewrites
-        # hosts (e.g. 169.254.169.254 → 169.api.crm.dynamics.com) and would miss link-local.
-        err = validate_outbound_url(
-            org_url,
-            allow_private=target_allows_private(self.config),
-            label="org_url",
+        # SSRF guard (#1232 / #1552): validate the raw org_url from config before any
+        # HTTP — including before token POST. Do not validate `_api_base()` for the
+        # private-range check alone: it rewrites hosts (e.g. 169.254.169.254 →
+        # 169.api.crm.dynamics.com) and would miss link-local. Pin the rewritten API
+        # host separately after org_url clears the guard.
+        allow_private = target_allows_private(self.config)
+        err, _org_ips = resolve_and_validate_outbound_url(
+            org_url, allow_private=allow_private, label="org_url"
         )
         if err:
             raise ValueError(err)
@@ -158,6 +165,13 @@ class DataverseConnector:
                 "Dataverse auth failed: provide tenant_id, client_id, client_secret (or auth block)"
             )
         base = _api_base(org_url)
+        err_base, base_ips = resolve_and_validate_outbound_url(
+            base, allow_private=allow_private, label="api_base"
+        )
+        if err_base:
+            raise ValueError(err_base)
+        host_pins: dict[str, list[str]] = {}
+        merge_host_pins(host_pins, base, base_ips)
         connect_s = float(self.config.get("connect_timeout_seconds", 25))
         read_s = float(self.config.get("read_timeout_seconds", 90))
         timeout = httpx.Timeout(read_s, connect=connect_s, read=read_s)
@@ -175,7 +189,7 @@ class DataverseConnector:
         verify_opt = resolve_httpx_tls_connect_options(self.config)
         if verify_opt is not None:
             client_kwargs["verify"] = verify_opt
-        self._client = httpx.Client(**client_kwargs)
+        self._client = build_pinned_httpx_client(host_to_ips=host_pins, **client_kwargs)
 
     def close(self) -> None:
         if self._client:

--- a/connectors/powerbi_connector.py
+++ b/connectors/powerbi_connector.py
@@ -21,7 +21,13 @@ from core.suggested_review import (
     augment_low_id_like_for_persist,
 )
 
-from .url_guard import target_allows_private, validate_outbound_url
+from .url_guard import (
+    build_pinned_httpx_client,
+    merge_host_pins,
+    pinned_httpx_request,
+    resolve_and_validate_outbound_url,
+    target_allows_private,
+)
 
 try:
     import httpx
@@ -55,15 +61,8 @@ def _get_access_token(target: dict[str, Any]) -> str | None:
     token_url = auth.get("token_url") or _AZURE_TOKEN_URL_TMPL.format(
         tenant_id=tenant_id
     )
-    # SSRF guard (#832): a custom token_url receives the client_secret via POST —
-    # never let it point at link-local/private hosts without explicit opt-in.
-    err = validate_outbound_url(
-        token_url,
-        allow_private=target_allows_private(target),
-        label="auth.token_url",
-    )
-    if err:
-        raise ValueError(err)
+    # SSRF guard (#832 / #1552): custom token_url receives client_secret via POST —
+    # validate + pin peer IPs (no DNS rebinding on the secret-bearing request).
     token_kwargs: dict[str, Any] = {
         "data": {
             "grant_type": "client_credentials",
@@ -77,9 +76,14 @@ def _get_access_token(target: dict[str, Any]) -> str | None:
         },
         "timeout": 30.0,
     }
-    # Token exchange carries client_secret + returns bearer — never honor
-    # target verify=False here (httpx default verify=True).
-    resp = httpx.post(token_url, **token_kwargs)
+    # Never honor target verify=False on token exchange.
+    resp = pinned_httpx_request(
+        "POST",
+        token_url,
+        allow_private=target_allows_private(target),
+        label="auth.token_url",
+        **token_kwargs,
+    )
     resp.raise_for_status()
     data = resp.json()
     return data.get("access_token")
@@ -118,6 +122,14 @@ class PowerBIConnector:
             raise ValueError(
                 "Power BI auth failed: provide tenant_id, client_id, client_secret (or auth block)"
             )
+        allow_private = target_allows_private(self.config)
+        err, ips = resolve_and_validate_outbound_url(
+            _PBI_BASE, allow_private=allow_private, label="api_base"
+        )
+        if err:
+            raise ValueError(err)
+        host_pins: dict[str, list[str]] = {}
+        merge_host_pins(host_pins, _PBI_BASE, ips)
         connect_s = float(self.config.get("connect_timeout_seconds", 25))
         read_s = float(self.config.get("read_timeout_seconds", 90))
         timeout = httpx.Timeout(read_s, connect=connect_s, read=read_s)
@@ -133,7 +145,7 @@ class PowerBIConnector:
         verify_opt = resolve_httpx_tls_connect_options(self.config)
         if verify_opt is not None:
             client_kwargs["verify"] = verify_opt
-        self._client = httpx.Client(**client_kwargs)
+        self._client = build_pinned_httpx_client(host_to_ips=host_pins, **client_kwargs)
 
     def close(self) -> None:
         if self._client:

--- a/connectors/rest_connector.py
+++ b/connectors/rest_connector.py
@@ -21,7 +21,13 @@ from core.suggested_review import (
     augment_low_id_like_for_persist,
 )
 
-from .url_guard import target_allows_private, validate_outbound_url
+from .url_guard import (
+    build_pinned_httpx_client,
+    merge_host_pins,
+    pinned_httpx_request,
+    resolve_and_validate_outbound_url,
+    target_allows_private,
+)
 
 try:
     import httpx
@@ -70,7 +76,9 @@ def _build_auth(client: "httpx.Client", target: dict[str, Any]) -> None:
             client_secret = os.environ.get(client_secret[2:-1], "")
         scope = auth.get("scope", "")
         if token_url and client_id and client_secret:
-            # One-off request to token endpoint (no client auth)
+            # One-off request to token endpoint (no client auth).
+            # Pin peer IPs at request time (#1552) — never honor verify=False
+            # on token exchange (httpx default verify=True).
             token_kwargs: dict[str, Any] = {
                 "data": {
                     "grant_type": "client_credentials",
@@ -84,9 +92,13 @@ def _build_auth(client: "httpx.Client", target: dict[str, Any]) -> None:
                 },
                 "timeout": 30.0,
             }
-            # Token exchange carries client_secret + returns bearer — never
-            # honor target verify=False here (httpx default verify=True).
-            resp = httpx.post(token_url, **token_kwargs)
+            resp = pinned_httpx_request(
+                "POST",
+                token_url,
+                allow_private=target_allows_private(target),
+                label="auth.token_url",
+                **token_kwargs,
+            )
             resp.raise_for_status()
             data = resp.json()
             access_token = data.get("access_token")
@@ -206,19 +218,24 @@ class RESTConnector:
         base_url = (self.config.get("base_url") or self.config.get("url", "")).rstrip(
             "/"
         )
-        # SSRF guard (#832): reject link-local/private/loopback hosts unless the
-        # target config opts in with allow_private_networks: true.
+        # SSRF guard (#832 / #1552): reject link-local/private/loopback hosts
+        # unless allow_private_networks; fail-closed on DNS failure; pin peer IPs
+        # so request-time DNS rebinding cannot change the TCP peer.
         allow_private = target_allows_private(self.config)
+        host_pins: dict[str, list[str]] = {}
         for candidate, label in (
             (base_url, "base_url"),
             (self.config.get("discover_url", ""), "discover_url"),
             ((self.config.get("auth") or {}).get("token_url", ""), "auth.token_url"),
         ):
-            err = validate_outbound_url(
+            if not candidate:
+                continue
+            err, ips = resolve_and_validate_outbound_url(
                 candidate, allow_private=allow_private, label=label
             )
             if err:
                 raise ValueError(err)
+            merge_host_pins(host_pins, candidate, ips)
         connect_s = float(self.config.get("connect_timeout_seconds", 25))
         read_s = float(self.config.get("read_timeout_seconds", 90))
         # Default (first arg) used for write/pool; connect and read set explicitly (httpx requires default or all four).
@@ -236,7 +253,7 @@ class RESTConnector:
         verify_opt = resolve_httpx_tls_connect_options(self.config)
         if verify_opt is not None:
             client_kwargs["verify"] = verify_opt
-        self._client = httpx.Client(**client_kwargs)
+        self._client = build_pinned_httpx_client(host_to_ips=host_pins, **client_kwargs)
         _build_auth(self._client, self.config)
         # Optional extra headers (e.g. API key, negotiated token); may override User-Agent.
         for key, value in cfg_headers.items():

--- a/connectors/url_guard.py
+++ b/connectors/url_guard.py
@@ -268,12 +268,21 @@ def build_pinned_httpx_client(
     host_to_ips: dict[str, list[str]],
     **client_kwargs: Any,
 ) -> Any:
-    """Construct an ``httpx.Client`` that pins TCP peers to *host_to_ips* (#1552)."""
+    """Construct an ``httpx.Client`` that pins TCP peers to *host_to_ips* (#1552).
+
+    TLS kwargs (``verify`` / ``cert`` / ``trust_env``) must be applied on the
+    inner ``HTTPTransport`` — with a custom ``transport=``, httpx does **not**
+    forward Client-level ``verify`` into that transport (Bugbot / #1552).
+    """
     import httpx
 
     # Redirects to a new host would bypass the pin map — keep them off.
     client_kwargs.setdefault("follow_redirects", False)
-    transport = PinnedIPTransport(host_to_ips)
+    transport_kwargs: dict[str, Any] = {}
+    for key in ("verify", "cert", "trust_env"):
+        if key in client_kwargs:
+            transport_kwargs[key] = client_kwargs.pop(key)
+    transport = PinnedIPTransport(host_to_ips, **transport_kwargs)
     return httpx.Client(transport=transport, **client_kwargs)
 
 

--- a/connectors/url_guard.py
+++ b/connectors/url_guard.py
@@ -1,4 +1,4 @@
-"""SSRF guard for outbound connector URLs (#832).
+"""SSRF guard for outbound connector URLs (#832, #1552).
 
 Threat model: operator-supplied (or partner-supplied) target configs steer
 HTTP(S) requests from the scanning host. A malicious or mistyped
@@ -19,8 +19,17 @@ Data Boar use case, so each target config may opt in explicitly::
         base_url: http://10.0.0.5:8080
         allow_private_networks: true   # explicit opt-in (#832)
 
+DNS posture (#1552):
+
+- Resolution failure is **fail-closed** (reject the URL) — an empty
+  resolve result must not skip address checks.
+- httpx clients that use :class:`PinnedIPTransport` connect to the
+  IPs validated at guard time (Host / SNI keep the original hostname)
+  so a later DNS rebinding cannot steer the TCP peer to a private IP.
+
 Shared by: rest_connector, powerbi_connector (token_url),
-sharepoint_connector (site_url), webdav_connector (base_url).
+sharepoint_connector (site_url), webdav_connector (base_url),
+dataverse_connector (org_url / token_url).
 """
 
 from __future__ import annotations
@@ -35,8 +44,10 @@ _ALLOWED_SCHEMES = frozenset(("http", "https"))
 # Config key for the per-target opt-in.
 OPT_IN_KEY = "allow_private_networks"
 
+IpAddr = ipaddress.IPv4Address | ipaddress.IPv6Address
 
-def _classify(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> str | None:
+
+def _classify(ip: IpAddr) -> str | None:
     """Return a human-readable rejection category for *ip*, or None if global."""
     if ip.is_link_local:
         return "link-local (e.g. cloud metadata 169.254.0.0/16, fe80::/10)"
@@ -53,30 +64,102 @@ def _classify(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> str | None:
     return None
 
 
-def _resolve_host_ips(
-    host: str,
-) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
-    """Best-effort resolution of *host* to IP addresses.
+def _prefer_pin_order(ips: list[IpAddr]) -> list[IpAddr]:
+    """Prefer IPv4 pins first (simpler URL form / broader NAT paths)."""
+    v4 = [i for i in ips if i.version == 4]
+    v6 = [i for i in ips if i.version == 6]
+    return v4 + v6
 
-    Literal IPs are returned directly. DNS failures return an empty list —
-    the connection will fail naturally at request time, so the guard does
-    not block on resolver outages (no availability regression).
+
+def _resolve_host_ips(host: str) -> list[IpAddr]:
+    """Resolve *host* to IP addresses.
+
+    Literal IPs are returned directly. DNS / resolver failures raise
+    ``OSError`` (callers map that to a fail-closed guard error — #1552).
     """
     try:
         return [ipaddress.ip_address(host)]
     except ValueError:
         pass
-    try:
-        infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
-    except OSError:
-        return []
-    ips: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+    ips: list[IpAddr] = []
+    seen: set[str] = set()
     for info in infos:
         try:
-            ips.append(ipaddress.ip_address(info[4][0]))
+            ip = ipaddress.ip_address(info[4][0])
         except ValueError:
             continue
+        key = str(ip)
+        if key not in seen:
+            seen.add(key)
+            ips.append(ip)
     return ips
+
+
+def _parse_url_host(url: str) -> tuple[Any, str | None, str | None]:
+    """Return (parsed, host, scheme_error)."""
+    if "://" in url:
+        parsed = urlparse(url)
+        scheme = (parsed.scheme or "").lower()
+        if scheme not in _ALLOWED_SCHEMES:
+            return (
+                parsed,
+                None,
+                (f"scheme '{scheme}' not allowed (only http/https). (#832)"),
+            )
+    else:
+        # Bare "host[:port]/path" form (WebDAV configs allow it) — no scheme
+        # to enforce, but the host still gets the address checks below.
+        parsed = urlparse(f"//{url}")
+    return parsed, parsed.hostname, None
+
+
+def resolve_and_validate_outbound_url(
+    url: str,
+    *,
+    allow_private: bool = False,
+    label: str = "url",
+) -> tuple[str | None, list[IpAddr]]:
+    """Validate *url* and return ``(error, resolved_ips)``.
+
+    On success ``error`` is ``None`` and ``resolved_ips`` is non-empty
+    (except for empty *url*, which returns ``(None, [])``).
+
+    DNS failure or empty resolution → fail-closed error (#1552).
+    Non-global addresses without opt-in → rejection (#832).
+    """
+    if not url:
+        return None, []
+    parsed, host, scheme_err = _parse_url_host(url)
+    if scheme_err:
+        return f"{label} rejected: {scheme_err}", []
+    if not host:
+        return f"{label} rejected: no host found in {url!r}. (#832)", []
+    try:
+        ips = _resolve_host_ips(host)
+    except OSError as exc:
+        return (
+            f"{label} rejected: DNS resolution failed for host '{host}' "
+            f"({exc}). Fail-closed — refusing outbound connect. (#1552)",
+            [],
+        )
+    if not ips:
+        return (
+            f"{label} rejected: host '{host}' resolved to no addresses. "
+            f"Fail-closed — refusing outbound connect. (#1552)",
+            [],
+        )
+    if not allow_private:
+        for ip in ips:
+            category = _classify(ip)
+            if category:
+                return (
+                    f"{label} rejected: host '{host}' resolves to {ip} "
+                    f"[{category}]. Scanning internal/private networks requires "
+                    f"explicit opt-in — add '{OPT_IN_KEY}: true' to this target. (#832)",
+                    [],
+                )
+    return None, _prefer_pin_order(ips)
 
 
 def validate_outbound_url(
@@ -85,42 +168,129 @@ def validate_outbound_url(
     allow_private: bool = False,
     label: str = "url",
 ) -> str | None:
-    """Validate *url* against the SSRF allowlist (#832).
+    """Validate *url* against the SSRF allowlist (#832 / #1552).
 
     Returns ``None`` when the URL is acceptable, or a human-readable error
-    string describing the rejection (scheme not http/https, missing host,
-    or host resolving to a non-global address without opt-in).
+    string describing the rejection.
     """
-    if not url:
-        return None
-    if "://" in url:
-        parsed = urlparse(url)
-        scheme = (parsed.scheme or "").lower()
-        if scheme not in _ALLOWED_SCHEMES:
-            return (
-                f"{label} rejected: scheme '{scheme}' not allowed "
-                f"(only http/https). (#832)"
-            )
-    else:
-        # Bare "host[:port]/path" form (WebDAV configs allow it) — no scheme
-        # to enforce, but the host still gets the address checks below.
-        parsed = urlparse(f"//{url}")
-    host = parsed.hostname
-    if not host:
-        return f"{label} rejected: no host found in {url!r}. (#832)"
-    if allow_private:
-        return None
-    for ip in _resolve_host_ips(host):
-        category = _classify(ip)
-        if category:
-            return (
-                f"{label} rejected: host '{host}' resolves to {ip} "
-                f"[{category}]. Scanning internal/private networks requires "
-                f"explicit opt-in — add '{OPT_IN_KEY}: true' to this target. (#832)"
-            )
-    return None
+    err, _ips = resolve_and_validate_outbound_url(
+        url, allow_private=allow_private, label=label
+    )
+    return err
 
 
 def target_allows_private(target_config: dict[str, Any]) -> bool:
     """Read the per-target opt-in flag (#832)."""
     return bool(target_config.get(OPT_IN_KEY, False))
+
+
+def host_pins_from_url(url: str, ips: list[IpAddr]) -> dict[str, list[str]]:
+    """Build a hostname → pin-IP map entry for *url* (empty if no host)."""
+    if not url or not ips:
+        return {}
+    _parsed, host, _err = _parse_url_host(url)
+    if not host:
+        return {}
+    return {host.lower(): [str(ip) for ip in _prefer_pin_order(ips)]}
+
+
+def merge_host_pins(pins: dict[str, list[str]], url: str, ips: list[IpAddr]) -> None:
+    """Merge pin entries for *url* into *pins* (mutates)."""
+    pins.update(host_pins_from_url(url, ips))
+
+
+class PinnedIPTransport:
+    """httpx transport that connects only to pre-validated peer IPs (#1552).
+
+    Rewrites the request URL host to the pinned IP while keeping the original
+    ``Host`` header and setting ``sni_hostname`` so TLS cert checks still use
+    the configured hostname. Unexpected hosts (not in the pin map) are rejected
+    fail-closed — no second DNS lookup on the hot path.
+    """
+
+    def __init__(
+        self,
+        host_to_ips: dict[str, list[str]],
+        **transport_kwargs: Any,
+    ) -> None:
+        import httpx
+
+        self._host_to_ips = {k.lower(): list(v) for k, v in host_to_ips.items() if v}
+        self._inner = httpx.HTTPTransport(**transport_kwargs)
+
+    def handle_request(self, request: Any) -> Any:
+        import httpx
+
+        host = request.url.host
+        if not host:
+            raise ValueError("SSRF pin: request has no host (#1552)")
+        key = host.lower()
+        pins = self._host_to_ips.get(key)
+        if not pins:
+            raise ValueError(
+                f"SSRF pin: host '{host}' was not pre-validated "
+                f"(no DNS rebinding path). (#1552)"
+            )
+        pinned_ip = pins[0]
+        # Literal IP already equal to pin — no rewrite needed.
+        try:
+            if str(ipaddress.ip_address(host)) == pinned_ip:
+                return self._inner.handle_request(request)
+        except ValueError:
+            pass
+
+        port = request.url.port
+        if port and port not in (80, 443):
+            host_header = f"{host}:{port}"
+        else:
+            host_header = host
+
+        headers = httpx.Headers(request.headers)
+        headers["host"] = host_header
+        extensions = dict(request.extensions or {})
+        extensions["sni_hostname"] = host
+        # httpx.Request has no copy_with (unlike Response) — rebuild with pinned peer.
+        pinned_request = httpx.Request(
+            method=request.method,
+            url=request.url.copy_with(host=pinned_ip),
+            headers=headers,
+            stream=request.stream,
+            extensions=extensions,
+        )
+        return self._inner.handle_request(pinned_request)
+
+    def close(self) -> None:
+        self._inner.close()
+
+
+def build_pinned_httpx_client(
+    *,
+    host_to_ips: dict[str, list[str]],
+    **client_kwargs: Any,
+) -> Any:
+    """Construct an ``httpx.Client`` that pins TCP peers to *host_to_ips* (#1552)."""
+    import httpx
+
+    # Redirects to a new host would bypass the pin map — keep them off.
+    client_kwargs.setdefault("follow_redirects", False)
+    transport = PinnedIPTransport(host_to_ips)
+    return httpx.Client(transport=transport, **client_kwargs)
+
+
+def pinned_httpx_request(
+    method: str,
+    url: str,
+    *,
+    allow_private: bool = False,
+    label: str = "url",
+    **request_kwargs: Any,
+) -> Any:
+    """One-shot httpx request with resolve+validate+pin (#1552)."""
+    err, ips = resolve_and_validate_outbound_url(
+        url, allow_private=allow_private, label=label
+    )
+    if err:
+        raise ValueError(err)
+    pins = host_pins_from_url(url, ips)
+    with build_pinned_httpx_client(host_to_ips=pins) as client:
+        return client.request(method, url, **request_kwargs)

--- a/tests/test_connector_timeouts.py
+++ b/tests/test_connector_timeouts.py
@@ -55,7 +55,7 @@ def test_rest_connector_uses_httpx_timeout_from_config():
         "read_timeout_seconds": 60,
     }
     connector = RESTConnector(target, MagicMock(), MagicMock())
-    with patch("connectors.rest_connector.httpx.Client") as mock_client:
+    with patch("connectors.rest_connector.build_pinned_httpx_client") as mock_client:
         connector.connect()
         mock_client.assert_called_once()
         call_kw = mock_client.call_args[1]
@@ -76,7 +76,7 @@ def test_rest_connector_sets_prospector_user_agent():
     target["connect_timeout_seconds"] = 25
     target["read_timeout_seconds"] = 90
     connector = RESTConnector(target, MagicMock(), MagicMock())
-    with patch("connectors.rest_connector.httpx.Client") as mock_client:
+    with patch("connectors.rest_connector.build_pinned_httpx_client") as mock_client:
         connector.connect()
         headers = mock_client.call_args[1].get("headers") or {}
         assert "User-Agent" in headers
@@ -94,7 +94,7 @@ def test_rest_connector_timeout_defaults_when_not_in_config():
     target["connect_timeout_seconds"] = 25
     target["read_timeout_seconds"] = 90
     connector = RESTConnector(target, MagicMock(), MagicMock())
-    with patch("connectors.rest_connector.httpx.Client") as mock_client:
+    with patch("connectors.rest_connector.build_pinned_httpx_client") as mock_client:
         connector.connect()
         timeout = mock_client.call_args[1]["timeout"]
         assert timeout.connect == 25

--- a/tests/test_crypto_controls_audit.py
+++ b/tests/test_crypto_controls_audit.py
@@ -20,7 +20,7 @@ from core.database import LocalDBManager
 from report.generator import generate_report
 
 
-def _mock_httpx_tls_client(base_url: str = "https://api.example.com") -> MagicMock:
+def _mock_httpx_tls_client(base_url: str = "https://example.com") -> MagicMock:
     """httpx.Client mock with TLS socket extras for collect_httpx_crypto_facts."""
     sock = MagicMock()
     sock.version.return_value = "TLSv1.3"
@@ -604,7 +604,7 @@ def test_rest_connector_honors_verify_and_saves_crypto_audit() -> None:
     secret = "must-not-appear-in-rest-crypto-details"
     target = {
         "name": "rest-crypto",
-        "base_url": "https://api.example.com",
+        "base_url": "https://example.com",
         "paths": ["/health"],
         "verify": False,
         "auth": {"type": "bearer", "token": secret},
@@ -618,16 +618,19 @@ def test_rest_connector_honors_verify_and_saves_crypto_audit() -> None:
         "ml_confidence": 0,
     }
     db_manager = MagicMock()
-    client = _mock_httpx_tls_client("https://api.example.com")
+    client = _mock_httpx_tls_client("https://example.com")
     fake_httpx = MagicMock()
     fake_httpx.Timeout = MagicMock(return_value=MagicMock())
-    fake_httpx.Client.return_value = client
     fake_httpx.BasicAuth = MagicMock()
     connector = RESTConnector(target, scanner, db_manager)
     with patch("connectors.rest_connector._HTTPX_AVAILABLE", True):
         with patch("connectors.rest_connector.httpx", fake_httpx):
-            connector.run()
-    assert fake_httpx.Client.call_args.kwargs.get("verify") is False
+            with patch(
+                "connectors.rest_connector.build_pinned_httpx_client",
+                return_value=client,
+            ) as mock_build:
+                connector.run()
+    assert mock_build.call_args.kwargs.get("verify") is False
     assert db_manager.save_crypto_controls_audit.called
     kwargs = db_manager.save_crypto_controls_audit.call_args.kwargs
     assert kwargs["target_name"] == "rest-crypto"
@@ -642,7 +645,7 @@ def test_rest_crypto_probe_exception_does_not_abort_scan() -> None:
     """Phase 4.1: httpx crypto probe errors must not stop path sampling."""
     target = {
         "name": "rest-failsoft",
-        "base_url": "https://api.example.com",
+        "base_url": "https://example.com",
         "paths": ["/health"],
         "_validate_crypto": True,
     }
@@ -654,19 +657,22 @@ def test_rest_crypto_probe_exception_does_not_abort_scan() -> None:
         "ml_confidence": 90,
     }
     db_manager = MagicMock()
-    client = _mock_httpx_tls_client("https://api.example.com")
+    client = _mock_httpx_tls_client("https://example.com")
     client.get.return_value.json.return_value = {"email": "a@example.com"}
     fake_httpx = MagicMock()
     fake_httpx.Timeout = MagicMock(return_value=MagicMock())
-    fake_httpx.Client.return_value = client
     connector = RESTConnector(target, scanner, db_manager)
     with patch("connectors.rest_connector._HTTPX_AVAILABLE", True):
         with patch("connectors.rest_connector.httpx", fake_httpx):
             with patch(
-                "connectors.rest_connector.collect_httpx_crypto_facts",
-                side_effect=RuntimeError("probe boom"),
+                "connectors.rest_connector.build_pinned_httpx_client",
+                return_value=client,
             ):
-                connector.run()
+                with patch(
+                    "connectors.rest_connector.collect_httpx_crypto_facts",
+                    side_effect=RuntimeError("probe boom"),
+                ):
+                    connector.run()
 
     assert not db_manager.save_crypto_controls_audit.called
     assert client.get.called
@@ -681,7 +687,7 @@ def test_rest_crypto_probe_exception_does_not_abort_scan() -> None:
 def test_rest_connector_skips_crypto_audit_when_flag_off() -> None:
     target = {
         "name": "rest-off",
-        "base_url": "https://api.example.com",
+        "base_url": "https://example.com",
         "paths": ["/health"],
         "_validate_crypto": False,
     }
@@ -696,11 +702,14 @@ def test_rest_connector_skips_crypto_audit_when_flag_off() -> None:
     client = _mock_httpx_tls_client()
     fake_httpx = MagicMock()
     fake_httpx.Timeout = MagicMock(return_value=MagicMock())
-    fake_httpx.Client.return_value = client
     connector = RESTConnector(target, scanner, db_manager)
     with patch("connectors.rest_connector._HTTPX_AVAILABLE", True):
         with patch("connectors.rest_connector.httpx", fake_httpx):
-            connector.run()
+            with patch(
+                "connectors.rest_connector.build_pinned_httpx_client",
+                return_value=client,
+            ):
+                connector.run()
     assert not db_manager.save_crypto_controls_audit.called
 
 
@@ -719,7 +728,6 @@ def test_powerbi_connector_saves_crypto_audit_when_flag_on() -> None:
     client = _mock_httpx_tls_client("https://api.powerbi.com/v1.0")
     fake_httpx = MagicMock()
     fake_httpx.Timeout = MagicMock(return_value=MagicMock())
-    fake_httpx.Client.return_value = client
     connector = PowerBIConnector(target, scanner, db_manager)
     with patch("connectors.powerbi_connector._HTTPX_AVAILABLE", True):
         with patch(
@@ -727,8 +735,12 @@ def test_powerbi_connector_saves_crypto_audit_when_flag_on() -> None:
             return_value="access-token",
         ):
             with patch("connectors.powerbi_connector.httpx", fake_httpx):
-                connector.run()
-    assert fake_httpx.Client.call_args.kwargs.get("verify") is True
+                with patch(
+                    "connectors.powerbi_connector.build_pinned_httpx_client",
+                    return_value=client,
+                ) as mock_build:
+                    connector.run()
+    assert mock_build.call_args.kwargs.get("verify") is True
     assert db_manager.save_crypto_controls_audit.called
     kwargs = db_manager.save_crypto_controls_audit.call_args.kwargs
     assert kwargs["connection_type"] == "powerbi"
@@ -753,15 +765,18 @@ def test_dataverse_connector_saves_crypto_audit_when_flag_on() -> None:
     client = _mock_httpx_tls_client("https://org.api.crm.dynamics.com/api/data/v9.2")
     fake_httpx = MagicMock()
     fake_httpx.Timeout = MagicMock(return_value=MagicMock())
-    fake_httpx.Client.return_value = client
     connector = DataverseConnector(target, scanner, db_manager)
     with patch("connectors.dataverse_connector._HTTPX_AVAILABLE", True):
         with patch(
             "connectors.dataverse_connector._dataverse_token", return_value="dv-token"
         ):
             with patch("connectors.dataverse_connector.httpx", fake_httpx):
-                connector.run()
-    assert fake_httpx.Client.call_args.kwargs.get("verify") is True
+                with patch(
+                    "connectors.dataverse_connector.build_pinned_httpx_client",
+                    return_value=client,
+                ) as mock_build:
+                    connector.run()
+    assert mock_build.call_args.kwargs.get("verify") is True
     assert db_manager.save_crypto_controls_audit.called
     kwargs = db_manager.save_crypto_controls_audit.call_args.kwargs
     assert kwargs["connection_type"] == "dataverse"

--- a/tests/test_oauth_token_verify_strict.py
+++ b/tests/test_oauth_token_verify_strict.py
@@ -24,9 +24,10 @@ def _token_response(access_token: str = "access-token-xyz") -> MagicMock:
 def test_rest_oauth_token_post_never_gets_verify_false() -> None:
     captured: dict = {}
 
-    def fake_post(url, **kwargs):
+    def fake_pinned(method, url, *, allow_private=False, label="url", **kwargs):
         captured["url"] = url
         captured["kwargs"] = kwargs
+        captured["method"] = method
         return _token_response()
 
     client = MagicMock()
@@ -41,10 +42,12 @@ def test_rest_oauth_token_post_never_gets_verify_false() -> None:
             "client_secret": "csecret",
         },
     }
-    with patch("connectors.rest_connector.httpx") as hx:
-        hx.post.side_effect = fake_post
+    with patch(
+        "connectors.rest_connector.pinned_httpx_request", side_effect=fake_pinned
+    ):
         _build_auth(client, target)
 
+    assert captured["method"] == "POST"
     assert "verify" not in captured["kwargs"]
     assert captured["kwargs"].get("verify") is not False
     assert client.headers.get("Authorization") == "Bearer access-token-xyz"
@@ -53,8 +56,9 @@ def test_rest_oauth_token_post_never_gets_verify_false() -> None:
 def test_powerbi_token_post_never_gets_verify_false() -> None:
     captured: dict = {}
 
-    def fake_post(url, **kwargs):
+    def fake_pinned(method, url, *, allow_private=False, label="url", **kwargs):
         captured["kwargs"] = kwargs
+        captured["method"] = method
         return _token_response("pbi-token")
 
     target = {
@@ -64,11 +68,13 @@ def test_powerbi_token_post_never_gets_verify_false() -> None:
         "verify": False,
         "verify_ssl": False,
     }
-    with patch("connectors.powerbi_connector.httpx") as hx:
-        hx.post.side_effect = fake_post
+    with patch(
+        "connectors.powerbi_connector.pinned_httpx_request", side_effect=fake_pinned
+    ):
         token = _get_access_token(target)
 
     assert token == "pbi-token"
+    assert captured["method"] == "POST"
     assert "verify" not in captured["kwargs"]
     assert captured["kwargs"].get("verify") is not False
 
@@ -76,8 +82,9 @@ def test_powerbi_token_post_never_gets_verify_false() -> None:
 def test_dataverse_token_post_never_gets_verify_false() -> None:
     captured: dict = {}
 
-    def fake_post(url, **kwargs):
+    def fake_pinned(method, url, *, allow_private=False, label="url", **kwargs):
         captured["kwargs"] = kwargs
+        captured["method"] = method
         return _token_response("dv-token")
 
     target = {
@@ -88,10 +95,12 @@ def test_dataverse_token_post_never_gets_verify_false() -> None:
         "verify": False,
         "verify_ssl": False,
     }
-    with patch("connectors.dataverse_connector.httpx") as hx:
-        hx.post.side_effect = fake_post
+    with patch(
+        "connectors.dataverse_connector.pinned_httpx_request", side_effect=fake_pinned
+    ):
         token = _dataverse_token(target)
 
     assert token == "dv-token"
+    assert captured["method"] == "POST"
     assert "verify" not in captured["kwargs"]
     assert captured["kwargs"].get("verify") is not False

--- a/tests/test_powerbi_dataverse_http_surfaces.py
+++ b/tests/test_powerbi_dataverse_http_surfaces.py
@@ -27,12 +27,12 @@ def _oauth_token_response_ok() -> MagicMock:
     return m
 
 
-@patch("connectors.dataverse_connector.httpx.Client")
-@patch("connectors.dataverse_connector.httpx.post")
+@patch("connectors.dataverse_connector.build_pinned_httpx_client")
+@patch("connectors.dataverse_connector.pinned_httpx_request")
 def test_dataverse_run_save_failure_on_entity_definitions_http_error(
-    mock_post, mock_client_cls
+    mock_pinned_req, mock_client_cls
 ):
-    mock_post.return_value = _oauth_token_response_ok()
+    mock_pinned_req.return_value = _oauth_token_response_ok()
     req = httpx.Request(
         "GET", "https://org.api.crm.dynamics.com/api/data/v9.2/EntityDefinitions"
     )
@@ -57,10 +57,12 @@ def test_dataverse_run_save_failure_on_entity_definitions_http_error(
     assert "403" in msg or "Forbidden" in msg
 
 
-@patch("connectors.powerbi_connector.httpx.Client")
-@patch("connectors.powerbi_connector.httpx.post")
-def test_powerbi_run_save_failure_on_groups_http_error(mock_post, mock_client_cls):
-    mock_post.return_value = _oauth_token_response_ok()
+@patch("connectors.powerbi_connector.build_pinned_httpx_client")
+@patch("connectors.powerbi_connector.pinned_httpx_request")
+def test_powerbi_run_save_failure_on_groups_http_error(
+    mock_pinned_req, mock_client_cls
+):
+    mock_pinned_req.return_value = _oauth_token_response_ok()
     req = httpx.Request("GET", "https://api.powerbi.com/v1.0/myorg/groups")
     mock_client_cls.return_value.get.return_value = httpx.Response(
         401, request=req, text="Unauthorized"
@@ -94,56 +96,62 @@ def _dataverse_auth_cfg(**overrides):
     return cfg
 
 
-@patch("connectors.dataverse_connector.httpx.Client")
-@patch("connectors.dataverse_connector.httpx.post")
+@patch("connectors.dataverse_connector.build_pinned_httpx_client")
+@patch("connectors.dataverse_connector.pinned_httpx_request")
 def test_dataverse_connect_rejects_link_local_org_url_before_token_post(
-    mock_post, mock_client_cls
+    mock_pinned_req, mock_client_cls
 ):
     """#1232: raw link-local org_url must raise before any token POST."""
     cfg = _dataverse_auth_cfg(org_url="http://169.254.169.254")
     with pytest.raises(ValueError, match="#832|org_url|private|link-local|blocked"):
         DataverseConnector(cfg, _mk_scanner(), MagicMock()).connect()
-    mock_post.assert_not_called()
+    mock_pinned_req.assert_not_called()
     mock_client_cls.assert_not_called()
 
 
-@patch("connectors.dataverse_connector.httpx.Client")
-@patch("connectors.dataverse_connector.httpx.post")
+@patch("connectors.dataverse_connector.build_pinned_httpx_client")
+@patch("connectors.dataverse_connector.pinned_httpx_request")
 def test_dataverse_connect_rejects_rfc1918_org_url_before_token_post(
-    mock_post, mock_client_cls
+    mock_pinned_req, mock_client_cls
 ):
     cfg = _dataverse_auth_cfg(org_url="http://10.0.0.5")
     with pytest.raises(ValueError, match="#832|org_url|private|blocked"):
         DataverseConnector(cfg, _mk_scanner(), MagicMock()).connect()
-    mock_post.assert_not_called()
+    mock_pinned_req.assert_not_called()
     mock_client_cls.assert_not_called()
 
 
-@patch("connectors.dataverse_connector.httpx.Client")
-@patch("connectors.dataverse_connector.httpx.post")
-def test_dataverse_connect_rejects_private_token_url_before_post(
-    mock_post, mock_client_cls
-):
-    """Public org_url + private auth.token_url must fail before httpx.post."""
+@patch("connectors.dataverse_connector.build_pinned_httpx_client")
+def test_dataverse_connect_rejects_private_token_url_before_post(mock_client_cls):
+    """Public org_url + private auth.token_url must fail before token request.
+
+    Do not mock pinned_httpx_request — the guard runs inside it (#832 / #1552).
+    """
     cfg = _dataverse_auth_cfg(
         auth={"token_url": "http://169.254.169.254/token"},
     )
     with pytest.raises(ValueError, match="#832|token_url|private|link-local|blocked"):
         DataverseConnector(cfg, _mk_scanner(), MagicMock()).connect()
-    mock_post.assert_not_called()
     mock_client_cls.assert_not_called()
 
 
-@patch("connectors.dataverse_connector.httpx.Client")
-@patch("connectors.dataverse_connector.httpx.post")
-def test_dataverse_connect_allow_private_networks_opts_in(mock_post, mock_client_cls):
+@patch("connectors.dataverse_connector.build_pinned_httpx_client")
+@patch("connectors.dataverse_connector.pinned_httpx_request")
+@patch("connectors.dataverse_connector.resolve_and_validate_outbound_url")
+def test_dataverse_connect_allow_private_networks_opts_in(
+    mock_resolve, mock_pinned_req, mock_client_cls
+):
     """#832 parity: allow_private_networks: true must not reject private org_url."""
-    mock_post.return_value = _oauth_token_response_ok()
+    import ipaddress
+
+    mock_resolve.return_value = (None, [ipaddress.ip_address("10.0.0.5")])
+    mock_pinned_req.return_value = _oauth_token_response_ok()
     mock_client_cls.return_value = MagicMock()
     cfg = _dataverse_auth_cfg(
         org_url="http://10.0.0.5",
         allow_private_networks=True,
     )
     DataverseConnector(cfg, _mk_scanner(), MagicMock()).connect()
-    mock_post.assert_called_once()
+    mock_pinned_req.assert_called_once()
     mock_client_cls.assert_called_once()
+    assert mock_resolve.call_count >= 2  # org_url + api_base

--- a/tests/test_ssrf_guard.py
+++ b/tests/test_ssrf_guard.py
@@ -1,18 +1,25 @@
 """
-Anti-regression tests for the SSRF guard on outbound connector URLs (#832).
+Anti-regression tests for the SSRF guard on outbound connector URLs (#832, #1552).
 
 Default posture: reject link-local (cloud metadata), loopback, and private
 hosts in base_url / discover_url / token_url / site_url. Each target config
 may opt in with ``allow_private_networks: true`` — internal scanning is a
 legitimate Data Boar use case, but it must be explicit.
+
+#1552: DNS resolution failure is fail-closed; httpx peers are pinned to IPs
+validated at guard time (no request-time DNS rebinding).
 """
 
 from __future__ import annotations
+
+from unittest.mock import MagicMock
 
 import pytest
 
 from connectors.url_guard import (
     OPT_IN_KEY,
+    PinnedIPTransport,
+    resolve_and_validate_outbound_url,
     target_allows_private,
     validate_outbound_url,
 )
@@ -82,13 +89,56 @@ def test_guard_rejects_non_http_schemes(url: str) -> None:
     )
 
 
-def test_guard_allows_empty_and_unresolvable_urls() -> None:
+def test_guard_allows_empty_url() -> None:
     # Empty: nothing to guard (connector handles missing-url errors itself).
     assert validate_outbound_url("") is None
-    # Unresolvable DNS: no availability regression — connection fails later.
-    assert (
-        validate_outbound_url("https://nonexistent.invalid.example-tld-x/api") is None
+
+
+def test_guard_fail_closed_on_unresolvable_dns() -> None:
+    # regression-anchor: #1552 — DNS failure must not skip address checks.
+    err = validate_outbound_url(
+        "https://nonexistent.invalid.example-tld-x/api", label="base_url"
     )
+    assert err is not None
+    assert "#1552" in err
+    assert "DNS" in err or "resolv" in err.lower()
+
+
+def test_pinned_transport_rejects_host_not_in_pin_map() -> None:
+    # regression-anchor: #1552 — no second DNS path for unexpected hosts.
+    import httpx
+
+    if not hasattr(httpx, "Client"):
+        pytest.skip("httpx not installed")
+    transport = PinnedIPTransport({"api.example.com": ["203.0.113.10"]})
+    req = httpx.Request("GET", "https://evil.example.com/x")
+    with pytest.raises(ValueError, match="#1552"):
+        transport.handle_request(req)
+
+
+def test_pinned_transport_rewrites_url_host_to_pin() -> None:
+    # regression-anchor: #1552 — TCP peer is the pre-validated IP.
+    import httpx
+
+    inner = MagicMock()
+    inner.handle_request.return_value = httpx.Response(200, text="ok")
+    transport = PinnedIPTransport({"api.example.com": ["203.0.113.10"]})
+    transport._inner = inner
+    req = httpx.Request("GET", "https://api.example.com/v1")
+    transport.handle_request(req)
+    pinned_req = inner.handle_request.call_args.args[0]
+    assert pinned_req.url.host == "203.0.113.10"
+    assert pinned_req.headers.get("host") == "api.example.com"
+    assert pinned_req.extensions.get("sni_hostname") == "api.example.com"
+
+
+def test_resolve_and_validate_returns_pins_for_literal_global_ip() -> None:
+    # 1.1.1.1 is global; TEST-NET 203.0.113.0/24 is is_private in Python ipaddress.
+    err, ips = resolve_and_validate_outbound_url(
+        "https://1.1.1.1/api", allow_private=False, label="base_url"
+    )
+    assert err is None
+    assert [str(i) for i in ips] == ["1.1.1.1"]
 
 
 def test_target_allows_private_reads_config_flag() -> None:
@@ -147,12 +197,12 @@ def test_rest_connector_guards_discover_and_token_url() -> None:
     for cfg in (
         {
             "name": "d",
-            "base_url": "https://api.example.com",
+            "base_url": "https://example.com",
             "discover_url": "http://192.168.0.1/paths",
         },
         {
             "name": "t",
-            "base_url": "https://api.example.com",
+            "base_url": "https://example.com",
             "auth": {"type": "oauth2_client", "token_url": "http://10.1.1.1/token"},
         },
     ):
@@ -217,9 +267,12 @@ def test_connector_sources_call_url_guard(connector_file: str) -> None:
     source = (Path(__file__).resolve().parents[1] / connector_file).read_text(
         encoding="utf-8"
     )
-    assert "validate_outbound_url(" in source, (
-        f"{connector_file} lost its SSRF guard call (#832)"
+    has_guard = (
+        "validate_outbound_url(" in source
+        or "resolve_and_validate_outbound_url(" in source
+        or "pinned_httpx_request(" in source
     )
+    assert has_guard, f"{connector_file} lost its SSRF guard call (#832 / #1552)"
     assert "target_allows_private(" in source, (
         f"{connector_file} lost its allow_private_networks opt-in wiring (#832)"
     )

--- a/tests/test_ssrf_guard.py
+++ b/tests/test_ssrf_guard.py
@@ -12,7 +12,7 @@ validated at guard time (no request-time DNS rebinding).
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -139,6 +139,28 @@ def test_resolve_and_validate_returns_pins_for_literal_global_ip() -> None:
     )
     assert err is None
     assert [str(i) for i in ips] == ["1.1.1.1"]
+
+
+def test_build_pinned_httpx_client_forwards_verify_to_transport() -> None:
+    # regression-anchor: #1552 / Bugbot — custom transport must receive verify.
+    import httpx
+
+    from connectors.url_guard import build_pinned_httpx_client
+
+    captured: dict = {}
+
+    class _CapturingTransport(httpx.HTTPTransport):
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            super().__init__(**kwargs)
+
+    with patch("httpx.HTTPTransport", _CapturingTransport):
+        client = build_pinned_httpx_client(
+            host_to_ips={"example.com": ["93.184.216.34"]},
+            verify=False,
+        )
+        client.close()
+    assert captured.get("verify") is False
 
 
 def test_target_allows_private_reads_config_flag() -> None:


### PR DESCRIPTION
## Summary
- **#1552:** `validate_outbound_url` / `resolve_and_validate_outbound_url` are **fail-closed** on DNS failure (no more empty-resolve skip).
- **PinnedIPTransport** + `build_pinned_httpx_client` / `pinned_httpx_request` pin TCP peers to pre-validated IPs; Host + `sni_hostname` preserve TLS virtual hosting.
- Wired into REST, Power BI, and Dataverse (including OAuth token POSTs).
- Dataverse `_api_base` normalizes `http://` → `https://` without producing `https://http://…`.
- Extended `tests/test_ssrf_guard.py` + updated httpx mocks.

Closes #1552

## Test plan
- [x] pytest SSRF + oauth + timeouts + powerbi/dataverse surfaces + crypto audit
- [x] `./scripts/check-all.sh --skip-pre-commit`
- [ ] CI green
- [ ] Bugbot run (security / non-trivial logic)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes security-critical outbound HTTP and OAuth token handling; mis-pinned hosts or TLS/verify wiring could break scans or weaken SSRF protection.
> 
> **Overview**
> Hardens outbound HTTP in REST, Power BI, and Dataverse against SSRF and **DNS rebinding** (#1552), building on the existing private-host guard (#832).
> 
> **`url_guard`** now **fails closed** when DNS resolution fails or returns no addresses (previously unresolvable hosts could slip past checks). New **`resolve_and_validate_outbound_url`** returns validated peer IPs; **`PinnedIPTransport`** connects only to those IPs while preserving **Host** and **SNI** for TLS. **`build_pinned_httpx_client`** and **`pinned_httpx_request`** wire this into httpx (redirects disabled; **`verify`** forwarded to the inner transport when a custom transport is used).
> 
> Connectors validate and pin **`base_url`**, **`discover_url`**, **`token_url`**, and Dataverse **`org_url` / API base** at connect time; OAuth token POSTs use pinned one-shot requests instead of raw **`httpx.post`**. Dataverse **`_api_base`** fixes **`http://`** normalization so hosts are not mangled into invalid **`https://http://…`** URLs.
> 
> Tests and mocks were updated for the new client builders and expanded SSRF/pin regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe06b02f39b4d2f3987e4605cf1c69960863e438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->