### PR TITLE
fix(labop): sudoers.d load-order WARN in gate-readiness (maestro#6)

### DIFF
--- a/scripts/labop-gate-readiness.sh
+++ b/scripts/labop-gate-readiness.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # scripts/labop-gate-readiness.sh
 # Per-node Maestro pre-flight readiness (#960): ALARM (--check) / REMEDIATE (--apply).
-# Parses: lines "GR check=<name> status=<OK|ALARM|REMEDIATE> ..."
+# Parses: lines "GR check=<name> status=<OK|ALARM|REMEDIATE|WARN> ..."
 #
 # Usage:
 #   bash labop-gate-readiness.sh --check --personas baremetal,target_nfs,web
@@ -71,13 +71,20 @@ _ensure_login_path() {
 
 _ensure_login_path
 
-# Narrow sudoers/doas grants match a literal bash path (#1021 ROUND 5/6).
-# Prefer /usr/bin/bash and /bin/bash (grant-canonical) before command -v bash,
-# which may resolve to /usr/sbin/bash via secure_path and miss the grant (#1021 R6 RCA).
+# Narrow sudoers/doas grants match a literal bash path (#1021 ROUND 5/6, maestro#6).
+# Prefer canonical /usr/bin/bash|/bin/bash via readlink -f (usrmerge: same inode,
+# different path-string misses grant-match). Cover BOTH paths in sudoers templates.
 _resolve_bash_bin() {
   local candidate resolved
   for candidate in /usr/bin/bash /bin/bash; do
     if [[ -x "$candidate" ]]; then
+      resolved="$(readlink -f "$candidate" 2>/dev/null || printf '%s' "$candidate")"
+      case "$resolved" in
+        /usr/bin/bash|/bin/bash)
+          printf '%s' "$resolved"
+          return 0
+          ;;
+      esac
       printf '%s' "$candidate"
       return 0
     fi
@@ -116,6 +123,8 @@ fi
 
 # shellcheck source=labop-rfc1918-cidr-lib.sh
 . "$SCRIPT_DIR/labop-rfc1918-cidr-lib.sh"
+# shellcheck source=labop-sudoers-load-order-lib.sh
+. "$SCRIPT_DIR/labop-sudoers-load-order-lib.sh"
 
 _is_rfc1918_lab_subnet() {
   labop_is_rfc1918_cidr "$1"
@@ -303,7 +312,22 @@ if [[ -n "$LABOP_BASH_BIN" ]]; then
     FAIL=1
   else
     _gr privilege OK "$PRIV" "${_PRIV_DETAIL:-}"
+    # maestro#6: sudo -l can list NOPASSWD while a later %wheel forces a password on RUN.
+    if [[ "${_PRIV_DETAIL:-}" == "sudo_l" ]]; then
+      echo "[GateReadiness] WARN: privilege detail=sudo_l — sudo -l is not proof; test RUN (sudo -n) and sudoers.d load-order" >&2
+    fi
   fi
+fi
+
+# --- sudoers.d load-order (maestro#6): WARN only — last rule wins vs %wheel ---
+if command -v sudo >/dev/null 2>&1; then
+  while IFS= read -r _sudoers_gr_line; do
+    [[ -n "$_sudoers_gr_line" ]] || continue
+    printf '%s\n' "$_sudoers_gr_line"
+    if [[ "$_sudoers_gr_line" == *'status=WARN'* ]]; then
+      echo "[GateReadiness] WARN: sudoers.d load-order — narrow Maestro grant loads BEFORE generic %wheel/%sudo; rename grant to z-* so it wins (last-match). Lesson: test RUN, not sudo -l." >&2
+    fi
+  done < <(labop_sudoers_emit_gate_lines "$HOST" /etc/sudoers.d)
 fi
 
 # --- Per-persona binaries ---

--- a/scripts/labop-gate-readiness.sh
+++ b/scripts/labop-gate-readiness.sh
@@ -314,18 +314,18 @@ if [[ -n "$LABOP_BASH_BIN" ]]; then
     _gr privilege OK "$PRIV" "${_PRIV_DETAIL:-}"
     # maestro#6: sudo -l can list NOPASSWD while a later %wheel forces a password on RUN.
     if [[ "${_PRIV_DETAIL:-}" == "sudo_l" ]]; then
-      echo "[GateReadiness] WARN: privilege detail=sudo_l — sudo -l is not proof; test RUN (sudo -n) and sudoers.d load-order" >&2
+      echo "[GateReadiness] WARN: privilege detail=sudo_l - sudo -l is not proof; test RUN (sudo -n) and sudoers.d load-order" >&2
     fi
   fi
 fi
 
-# --- sudoers.d load-order (maestro#6): WARN only — last rule wins vs %wheel ---
+# --- sudoers.d load-order (maestro#6): WARN only - last rule wins vs %wheel ---
 if command -v sudo >/dev/null 2>&1; then
   while IFS= read -r _sudoers_gr_line; do
     [[ -n "$_sudoers_gr_line" ]] || continue
     printf '%s\n' "$_sudoers_gr_line"
     if [[ "$_sudoers_gr_line" == *'status=WARN'* ]]; then
-      echo "[GateReadiness] WARN: sudoers.d load-order — narrow Maestro grant loads BEFORE generic %wheel/%sudo; rename grant to z-* so it wins (last-match). Lesson: test RUN, not sudo -l." >&2
+      echo "[GateReadiness] WARN: sudoers.d load-order - narrow Maestro grant loads BEFORE generic %wheel/%sudo; rename grant to z-* so it wins (last-match). Lesson: test RUN, not sudo -l." >&2
     fi
   done < <(labop_sudoers_emit_gate_lines "$HOST" /etc/sudoers.d)
 fi

--- a/scripts/labop-sudoers-load-order-lib.sh
+++ b/scripts/labop-sudoers-load-order-lib.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# scripts/labop-sudoers-load-order-lib.sh
+# Pure helpers for Maestro sudoers.d load-order doctrine (maestro#6 / data-boar#1021).
+#
+# Doctrine:
+#   - Files in /etc/sudoers.d/ are read in lexical order; the LAST matching rule wins.
+#   - A generic %wheel/%sudo ALL=ALL (password) that loads AFTER a narrow labop grant
+#     silently overrides NOPASSWD — sudo -l still lists NOPASSWD (masks the failure).
+#   - Maestro narrow drop-ins MUST sort AFTER generic wheel (convention: z-labop-*).
+#   - Test the RUN (sudo -n …), not only sudo -l.
+#
+# Sourced by labop-gate-readiness.sh; also unit-tested via fixture directories.
+
+# shellcheck shell=bash
+
+labop_sudoers_is_skippable_dropin_name() {
+  local base="$1"
+  case "$base" in
+    ''|README|README.*|*.md|*~|*.bak|*.dpkg-*|*.rpmnew|*.rpmsave|*.orig)
+      return 0
+      ;;
+  esac
+  # visudo editor leftovers
+  case "$base" in
+    .*|*.tmp)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+# stdout: generic_wheel | maestro_narrow | other
+labop_sudoers_classify_dropin() {
+  local path="$1"
+  local base content
+  base="$(basename -- "$path")"
+  if labop_sudoers_is_skippable_dropin_name "$base"; then
+    printf '%s\n' other
+    return 0
+  fi
+  if [[ ! -f "$path" ]] || [[ ! -r "$path" ]]; then
+    printf '%s\n' other
+    return 0
+  fi
+  content="$(tr -d '\r' <"$path" 2>/dev/null || true)"
+
+  # Generic password (or blanket) group grant — last-match overrides prior NOPASSWD.
+  if grep -Eq '^[[:space:]]*%(wheel|sudo)[[:space:]]+ALL[[:space:]]*=\(?ALL' <<<"$content"; then
+    printf '%s\n' generic_wheel
+    return 0
+  fi
+
+  local looks_maestro=0
+  case "$base" in
+    *labop*|*LABOP*) looks_maestro=1 ;;
+  esac
+  if grep -Eq 'LABOP_[A-Z0-9_]+|labop-[a-z0-9_-]+-ensure\.sh|labop-dep-doctor\.sh|labop-gate-readiness\.sh' <<<"$content"; then
+    looks_maestro=1
+  fi
+  if [[ $looks_maestro -eq 1 ]] && grep -Eq 'NOPASSWD' <<<"$content"; then
+    printf '%s\n' maestro_narrow
+    return 0
+  fi
+
+  printf '%s\n' other
+}
+
+# List readable drop-ins in lexical order (one basename per line).
+labop_sudoers_list_dropin_basenames() {
+  local dir="${1:-/etc/sudoers.d}"
+  local f base
+  [[ -d "$dir" ]] || return 0
+  # LC_ALL=C for stable byte-wise lexical order matching sudoers.
+  LC_ALL=C find "$dir" -maxdepth 1 -type f -print 2>/dev/null | LC_ALL=C sort | while IFS= read -r f; do
+    base="$(basename -- "$f")"
+    if labop_sudoers_is_skippable_dropin_name "$base"; then
+      continue
+    fi
+    if [[ -r "$f" ]]; then
+      printf '%s\n' "$base"
+    fi
+  done
+}
+
+# Print violations: one line each
+#   before=<maestro_file> after=<generic_file> tip=rename_to_z-<maestro_file>
+# Exit 0 if any violation, 1 if clean / unreadable / empty.
+labop_sudoers_find_load_order_violations() {
+  local dir="${1:-/etc/sudoers.d}"
+  local -a names=()
+  local -a kinds=()
+  local base path kind i j
+  local found=0
+
+  if [[ ! -d "$dir" ]]; then
+    return 1
+  fi
+
+  while IFS= read -r base; do
+    [[ -n "$base" ]] || continue
+    path="$dir/$base"
+    kind="$(labop_sudoers_classify_dropin "$path")"
+    names+=("$base")
+    kinds+=("$kind")
+  done < <(labop_sudoers_list_dropin_basenames "$dir")
+
+  local n=${#names[@]}
+  [[ $n -gt 0 ]] || return 1
+
+  for ((i = 0; i < n; i++)); do
+    [[ "${kinds[$i]}" == maestro_narrow ]] || continue
+    for ((j = i + 1; j < n; j++)); do
+      if [[ "${kinds[$j]}" == generic_wheel ]]; then
+        found=1
+        tip="rename_to_z-${names[$i]}"
+        # Prefer tip that matches worked-example when base lacks z- already.
+        case "${names[$i]}" in
+          z-*|zz-*) tip="ensure_${names[$i]}_sorts_after_${names[$j]}" ;;
+        esac
+        printf 'before=%s after=%s tip=%s\n' "${names[$i]}" "${names[$j]}" "$tip"
+      fi
+    done
+  done
+
+  [[ $found -eq 1 ]]
+}
+
+# Emit gate-readiness style lines on stdout; never fails hard (WARN only).
+# Usage: labop_sudoers_emit_gate_lines <host> [dir]
+labop_sudoers_emit_gate_lines() {
+  local host="$1"
+  local dir="${2:-/etc/sudoers.d}"
+  local line
+
+  if [[ ! -d "$dir" ]]; then
+    printf 'GR host=%s check=sudoers_load_order status=OK detail=no_sudoers_d\n' "$host"
+    return 0
+  fi
+  if [[ ! -r "$dir" ]]; then
+    printf 'GR host=%s check=sudoers_load_order status=OK detail=sudoers_d_unreadable\n' "$host"
+    return 0
+  fi
+
+  local violations
+  violations="$(labop_sudoers_find_load_order_violations "$dir" || true)"
+  if [[ -z "$violations" ]]; then
+    printf 'GR host=%s check=sudoers_load_order status=OK detail=maestro_after_wheel_or_no_conflict\n' "$host"
+    return 0
+  fi
+
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    printf 'GR host=%s check=sudoers_load_order status=WARN detail=%s lesson=test_RUN_not_sudo_l\n' "$host" "$line"
+  done <<<"$violations"
+}

--- a/scripts/labop-sudoers-load-order-lib.sh
+++ b/scripts/labop-sudoers-load-order-lib.sh
@@ -5,9 +5,9 @@
 # Doctrine:
 #   - Files in /etc/sudoers.d/ are read in lexical order; the LAST matching rule wins.
 #   - A generic %wheel/%sudo ALL=ALL (password) that loads AFTER a narrow labop grant
-#     silently overrides NOPASSWD — sudo -l still lists NOPASSWD (masks the failure).
+#     silently overrides NOPASSWD - sudo -l still lists NOPASSWD (masks the failure).
 #   - Maestro narrow drop-ins MUST sort AFTER generic wheel (convention: z-labop-*).
-#   - Test the RUN (sudo -n …), not only sudo -l.
+#   - Test the RUN (sudo -n ...), not only sudo -l.
 #
 # Sourced by labop-gate-readiness.sh; also unit-tested via fixture directories.
 
@@ -44,7 +44,7 @@ labop_sudoers_classify_dropin() {
   fi
   content="$(tr -d '\r' <"$path" 2>/dev/null || true)"
 
-  # Generic password (or blanket) group grant — last-match overrides prior NOPASSWD.
+  # Generic password (or blanket) group grant - last-match overrides prior NOPASSWD.
   if grep -Eq '^[[:space:]]*%(wheel|sudo)[[:space:]]+ALL[[:space:]]*=\(?ALL' <<<"$content"; then
     printf '%s\n' generic_wheel
     return 0

--- a/tests/pester/Maestro-GateReadiness.Tests.ps1
+++ b/tests/pester/Maestro-GateReadiness.Tests.ps1
@@ -30,6 +30,13 @@ Describe 'labop-gate-readiness privilege probe (#1022)' {
         $raw | Should -Match 'no_narrow_grant'
         $raw | Should -Match '_FW_GUARD_PROBE_DONE'
     }
+
+    It 'wires sudoers.d load-order WARN preflight (maestro#6)' {
+        $raw = Get-ScriptRaw 'scripts/labop-gate-readiness.sh'
+        $raw | Should -Match 'labop-sudoers-load-order-lib\.sh'
+        $raw | Should -Match 'labop_sudoers_emit_gate_lines'
+        $raw | Should -Match 'readlink -f'
+    }
 }
 
 Describe 'Maestro login-env parity (#1003)' {

--- a/tests/pester/SudoersLoadOrder.Tests.ps1
+++ b/tests/pester/SudoersLoadOrder.Tests.ps1
@@ -1,0 +1,131 @@
+#requires -Module Pester
+# maestro#6 / #1021 — sudoers.d load-order parse + WARN detection (fixture dirs).
+
+Describe 'labop-sudoers-load-order-lib (maestro#6)' {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot '_RepoRoot.ps1')
+        $script:Lib = Get-RepoScript 'scripts/labop-sudoers-load-order-lib.sh'
+
+        function script:Invoke-SudoersLib {
+            param(
+                [Parameter(Mandatory = $true)][string]$BashSnippet
+            )
+            $libUnix = ($script:Lib -replace '\\', '/')
+            $scriptBody = @(
+                'set -euo pipefail'
+                ". '$libUnix'"
+                $BashSnippet
+            ) -join "`n"
+            $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("sudoers-lib-" + [guid]::NewGuid().ToString('n') + '.sh')
+            [System.IO.File]::WriteAllText($tmp, $scriptBody)
+            try {
+                $out = & bash "$tmp" 2>&1
+                return [pscustomobject]@{
+                    ExitCode = $LASTEXITCODE
+                    Output   = @($out | ForEach-Object { "$_" })
+                }
+            } finally {
+                Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        function script:New-SudoersFixtureDir {
+            $root = Join-Path ([System.IO.Path]::GetTempPath()) ("sudoers-lo-" + [guid]::NewGuid().ToString('n'))
+            New-Item -ItemType Directory -Path $root | Out-Null
+            return $root
+        }
+
+        function script:Write-FixtureFile {
+            param([string]$Path, [string]$Content)
+            [System.IO.File]::WriteAllText($Path, ($Content -replace "`r", ''))
+        }
+    }
+
+    It 'classifies generic %wheel and maestro NOPASSWD drop-ins' {
+        $dir = New-SudoersFixtureDir
+        try {
+            Write-FixtureFile (Join-Path $dir 'wheel') '%wheel ALL=(ALL:ALL) ALL'
+            Write-FixtureFile (Join-Path $dir 'labop-maestro') @"
+Cmnd_Alias LABOP_FW_GUARD = /usr/bin/bash /opt/data-boar/scripts/labop-fw-guard-ensure.sh --check
+operator ALL=(root) NOPASSWD: LABOP_FW_GUARD
+"@
+            $r = Invoke-SudoersLib @"
+labop_sudoers_classify_dropin '$dir/wheel'
+labop_sudoers_classify_dropin '$dir/labop-maestro'
+"@
+            $r.ExitCode | Should -Be 0
+            $r.Output -join "`n" | Should -Match 'generic_wheel'
+            $r.Output -join "`n" | Should -Match 'maestro_narrow'
+        } finally {
+            Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'detects worked-example: labop-maestro before wheel (WARN tip z-)' {
+        $dir = New-SudoersFixtureDir
+        try {
+            Write-FixtureFile (Join-Path $dir 'labop-maestro') @"
+Cmnd_Alias LABOP_FW_GUARD = /bin/bash /repo/scripts/labop-fw-guard-ensure.sh --check
+op ALL=(root) NOPASSWD: LABOP_FW_GUARD
+"@
+            Write-FixtureFile (Join-Path $dir 'wheel') '%wheel ALL=(ALL:ALL) ALL'
+            Write-FixtureFile (Join-Path $dir 'z-labop-host-report') @"
+Cmnd_Alias LABOP_DEP_DOCTOR = /usr/bin/bash /repo/scripts/labop-dep-doctor.sh --check
+op ALL=(root) NOPASSWD: LABOP_DEP_DOCTOR
+"@
+
+            $r = Invoke-SudoersLib "labop_sudoers_find_load_order_violations '$dir' || true"
+            ($r.Output -join "`n") | Should -Match 'before=labop-maestro'
+            ($r.Output -join "`n") | Should -Match 'after=wheel'
+            ($r.Output -join "`n") | Should -Match 'tip=rename_to_z-labop-maestro'
+            ($r.Output -join "`n") | Should -Not -Match 'before=z-labop-host-report'
+        } finally {
+            Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'accepts z-labop-maestro after wheel (clean)' {
+        $dir = New-SudoersFixtureDir
+        try {
+            Write-FixtureFile (Join-Path $dir 'wheel') '%wheel ALL=(ALL:ALL) ALL'
+            Write-FixtureFile (Join-Path $dir 'z-labop-maestro') @"
+Cmnd_Alias LABOP_FW_GUARD = /usr/bin/bash /repo/scripts/labop-fw-guard-ensure.sh --check
+op ALL=(root) NOPASSWD: LABOP_FW_GUARD
+"@
+
+            $r = Invoke-SudoersLib @"
+if labop_sudoers_find_load_order_violations '$dir'; then echo HAS_VIOLATION; else echo CLEAN; fi
+"@
+            $r.Output -join "`n" | Should -Match 'CLEAN'
+            $r.Output -join "`n" | Should -Not -Match 'HAS_VIOLATION'
+        } finally {
+            Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'emit_gate_lines prints WARN with lesson tag' {
+        $dir = New-SudoersFixtureDir
+        try {
+            Write-FixtureFile (Join-Path $dir 'labop-maestro') "LABOP_X`nNOPASSWD: ALL"
+            Write-FixtureFile (Join-Path $dir 'wheel') '%sudo ALL=(ALL) ALL'
+            $r = Invoke-SudoersLib "labop_sudoers_emit_gate_lines 'lab-pb-01' '$dir'"
+            $joined = $r.Output -join "`n"
+            $joined | Should -Match 'check=sudoers_load_order status=WARN'
+            $joined | Should -Match 'lesson=test_RUN_not_sudo_l'
+            $joined | Should -Match 'tip=rename_to_z-labop-maestro'
+        } finally {
+            Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'gate-readiness sources load-order lib and documents bash readlink doctrine' {
+        $raw = Get-ScriptRaw 'scripts/labop-gate-readiness.sh'
+        $raw | Should -Match 'labop-sudoers-load-order-lib\.sh'
+        $raw | Should -Match 'labop_sudoers_emit_gate_lines'
+        $raw | Should -Match 'readlink -f'
+        $raw | Should -Match 'maestro#6'
+        $lib = Get-ScriptRaw 'scripts/labop-sudoers-load-order-lib.sh'
+        $lib | Should -Match 'sudoers_load_order'
+        $lib | Should -Match 'test_RUN_not_sudo_l'
+    }
+}


### PR DESCRIPTION
## Summary
- Add `scripts/labop-sudoers-load-order-lib.sh` — lexical parse of sudoers.d drop-ins; detect Maestro narrow grant loading **before** generic `%wheel`/`%sudo ALL=ALL`.
- Wire into `labop-gate-readiness.sh` as `GR check=sudoers_load_order status=WARN` (non-failing) with tip `rename_to_z-…` and lesson `test_RUN_not_sudo_l`.
- Canonicalize bash via `readlink -f` (usrmerge / grant-match).
- Pester fixtures cover the worked-example (`labop-maestro` < `wheel` < `z-labop-host-report`).

Tracks [DataBoar/maestro#6](https://github.com/DataBoar/maestro/issues/6).

## Test plan
- [x] `Invoke-Pester -Path tests/pester/SudoersLoadOrder.Tests.ps1`
- [ ] CI green