### PR TITLE
fix(security): pin requests/WebDAV peers + fix symlink sole-path scan (#1565, #1579)

### DIFF
--- a/connectors/filesystem_connector.py
+++ b/connectors/filesystem_connector.py
@@ -112,16 +112,49 @@ def _file_inode_key(path: Path) -> tuple[int, int] | None:
     return (st.st_dev, st.st_ino)
 
 
+def _symlink_target_inode_key(entry: os.DirEntry[str]) -> tuple[int, int] | None:
+    """Return (st_dev, st_ino) of a symlink's target regular file (#1579)."""
+    try:
+        st = entry.stat(follow_symlinks=True)
+    except OSError:
+        return None
+    if not stat.S_ISREG(st.st_mode):
+        return None
+    return (st.st_dev, st.st_ino)
+
+
+def _path_contained_under_root(path: Path, root: Path) -> bool:
+    """True when *path* resolves to a location under *root* (#1579 / #1560)."""
+    try:
+        resolved = path.resolve()
+        return resolved.is_relative_to(root)
+    except (OSError, ValueError):
+        return False
+
+
 def iter_scan_files(root: Path, *, recursive: bool) -> Iterator[Path]:
     """
     Yield files under *root* for filesystem scans.
 
     - Does not follow directory symlinks (avoids circular walk loops).
     - Skips duplicate regular files reachable via multiple hard links / symlink aliases.
+    - File symlinks: yield the symlink path when the *target* inode is new and the
+      resolved target stays under *root* (#1579).
     """
     root = root.resolve()
     seen_dirs: set[tuple[int, int]] = set()
     seen_files: set[tuple[int, int]] = set()
+
+    def _maybe_yield_file_symlink(entry: os.DirEntry[str]) -> Iterator[Path]:
+        if not entry.is_file(follow_symlinks=True):
+            return
+        fpath = Path(entry.path)
+        if not _path_contained_under_root(fpath, root):
+            return
+        fkey = _symlink_target_inode_key(entry)
+        if fkey is not None and fkey not in seen_files:
+            seen_files.add(fkey)
+            yield fpath
 
     def _walk_dir(directory: Path) -> Iterator[Path]:
         dkey = _dir_inode_key(directory)
@@ -135,12 +168,7 @@ def iter_scan_files(root: Path, *, recursive: bool) -> Iterator[Path]:
                 for entry in it:
                     try:
                         if entry.is_symlink():
-                            if entry.is_file(follow_symlinks=True):
-                                fpath = Path(entry.path)
-                                fkey = _file_inode_key(fpath)
-                                if fkey is not None and fkey not in seen_files:
-                                    seen_files.add(fkey)
-                                    yield fpath
+                            yield from _maybe_yield_file_symlink(entry)
                             continue
                         if entry.is_file(follow_symlinks=False):
                             fpath = Path(entry.path)
@@ -162,6 +190,9 @@ def iter_scan_files(root: Path, *, recursive: bool) -> Iterator[Path]:
             with os.scandir(root) as it:
                 for entry in it:
                     try:
+                        if entry.is_symlink():
+                            yield from _maybe_yield_file_symlink(entry)
+                            continue
                         if entry.is_file(follow_symlinks=False):
                             fpath = Path(entry.path)
                             fkey = _file_inode_key(fpath)

--- a/connectors/sharepoint_connector.py
+++ b/connectors/sharepoint_connector.py
@@ -130,11 +130,16 @@ class SharePointConnector:
                 "Missing site_url (e.g. https://host/sites/sitename)",
             )
             return
-        # SSRF guard (#832): reject link-local/private/loopback hosts unless the
-        # target config opts in with allow_private_networks: true.
-        from .url_guard import target_allows_private, validate_outbound_url
+        # SSRF guard (#832 / #1565): reject private hosts unless opted in; pin
+        # requests peers to IPs validated here so DNS rebinding cannot steal NTLM.
+        from .url_guard import (
+            build_pinned_requests_session,
+            host_pins_from_url,
+            resolve_and_validate_outbound_url,
+            target_allows_private,
+        )
 
-        err = validate_outbound_url(
+        err, ips = resolve_and_validate_outbound_url(
             site_url,
             allow_private=target_allows_private(self.config),
             label="site_url",
@@ -153,7 +158,9 @@ class SharePointConnector:
             "",
         )
         verify_ssl = self.config.get("verify_ssl", True)
-        session = requests.Session()
+        session = build_pinned_requests_session(
+            host_to_ips=host_pins_from_url(site_url, ips)
+        )
         session.headers["User-Agent"] = get_http_user_agent()
         session.verify = verify_ssl
         if use_ntlm and user and password:

--- a/connectors/url_guard.py
+++ b/connectors/url_guard.py
@@ -30,6 +30,10 @@ DNS posture (#1552):
 Shared by: rest_connector, powerbi_connector (token_url),
 sharepoint_connector (site_url), webdav_connector (base_url),
 dataverse_connector (org_url / token_url).
+
+#1565: ``PinnedIPHTTPAdapter`` / ``build_pinned_requests_session`` pin
+``requests`` peers the same way ``PinnedIPTransport`` pins httpx (SharePoint,
+WebDAV).
 """
 
 from __future__ import annotations
@@ -37,7 +41,7 @@ from __future__ import annotations
 import ipaddress
 import socket
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 _ALLOWED_SCHEMES = frozenset(("http", "https"))
 
@@ -303,3 +307,154 @@ def pinned_httpx_request(
     pins = host_pins_from_url(url, ips)
     with build_pinned_httpx_client(host_to_ips=pins) as client:
         return client.request(method, url, **request_kwargs)
+
+
+def _format_pinned_netloc(parsed: Any, pinned_ip: str) -> str:
+    """Build netloc for *pinned_ip*, preserving userinfo and port from *parsed*."""
+    try:
+        ipaddress.IPv6Address(pinned_ip)
+        host_part = f"[{pinned_ip}]"
+    except ipaddress.AddressValueError:
+        host_part = pinned_ip
+    userinfo = ""
+    if parsed.username is not None:
+        from urllib.parse import quote
+
+        user = quote(parsed.username, safe="")
+        if parsed.password is not None:
+            userinfo = f"{user}:{quote(parsed.password, safe='')}@"
+        else:
+            userinfo = f"{user}@"
+    if parsed.port is not None:
+        return f"{userinfo}{host_part}:{parsed.port}"
+    return f"{userinfo}{host_part}"
+
+
+def rewrite_url_host_to_pin(url: str, pinned_ip: str) -> str:
+    """Rewrite *url*'s host to *pinned_ip* (IPv6 bracketed); keep path/query/userinfo."""
+    parsed = urlparse(url)
+    return urlunparse(parsed._replace(netloc=_format_pinned_netloc(parsed, pinned_ip)))
+
+
+def _make_pinned_ip_http_adapter_class() -> type:
+    """Build PinnedIPHTTPAdapter subclass (requests is a hard dependency)."""
+    from requests.adapters import HTTPAdapter
+
+    class PinnedIPHTTPAdapter(HTTPAdapter):
+        """requests adapter that connects only to pre-validated peer IPs (#1565).
+
+        Rewrites the request URL host to the pinned IP while keeping the original
+        ``Host`` header and setting urllib3 ``server_hostname`` / ``assert_hostname``
+        so TLS SNI and cert checks still use the configured hostname. Unexpected
+        hosts (not in the pin map) are rejected fail-closed — no second DNS lookup
+        on the hot path.
+        """
+
+        def __init__(
+            self,
+            host_to_ips: dict[str, list[str]],
+            **adapter_kwargs: Any,
+        ) -> None:
+            self._host_to_ips = {
+                k.lower(): list(v) for k, v in host_to_ips.items() if v
+            }
+            self._pending_tls_hostname: str | None = None
+            super().__init__(**adapter_kwargs)
+
+        def send(  # type: ignore[no-untyped-def]
+            self,
+            request,
+            stream=False,
+            timeout=None,
+            verify=True,
+            cert=None,
+            proxies=None,
+        ):
+            parsed = urlparse(request.url)
+            host = parsed.hostname
+            if not host:
+                raise ValueError("SSRF pin: request has no host (#1552)")
+            key = host.lower()
+            pins = self._host_to_ips.get(key)
+            if not pins:
+                raise ValueError(
+                    f"SSRF pin: host '{host}' was not pre-validated "
+                    f"(no DNS rebinding path). (#1552)"
+                )
+            pinned_ip = pins[0]
+            try:
+                if str(ipaddress.ip_address(host)) == pinned_ip:
+                    return super().send(
+                        request,
+                        stream=stream,
+                        timeout=timeout,
+                        verify=verify,
+                        cert=cert,
+                        proxies=proxies,
+                    )
+            except ValueError:
+                pass
+
+            port = parsed.port
+            if "Host" not in request.headers and "host" not in request.headers:
+                if port and port not in (80, 443):
+                    request.headers["Host"] = f"{host}:{port}"
+                else:
+                    request.headers["Host"] = host
+
+            request.url = rewrite_url_host_to_pin(request.url, pinned_ip)
+            self._pending_tls_hostname = host
+            try:
+                return super().send(
+                    request,
+                    stream=stream,
+                    timeout=timeout,
+                    verify=verify,
+                    cert=cert,
+                    proxies=proxies,
+                )
+            finally:
+                self._pending_tls_hostname = None
+
+        def get_connection_with_tls_context(  # type: ignore[no-untyped-def]
+            self,
+            request,
+            verify,
+            proxies=None,
+            cert=None,
+        ):
+            pool = super().get_connection_with_tls_context(
+                request, verify, proxies=proxies, cert=cert
+            )
+            hostname = self._pending_tls_hostname
+            if hostname:
+                pool.assert_hostname = hostname
+                conn_kw = dict(getattr(pool, "conn_kw", None) or {})
+                conn_kw["server_hostname"] = hostname
+                pool.conn_kw = conn_kw
+            return pool
+
+    return PinnedIPHTTPAdapter
+
+
+PinnedIPHTTPAdapter = _make_pinned_ip_http_adapter_class()
+
+
+def build_pinned_requests_session(
+    *,
+    host_to_ips: dict[str, list[str]],
+    **session_kwargs: Any,
+) -> Any:
+    """Construct a ``requests.Session`` that pins TCP peers to *host_to_ips* (#1565).
+
+    Mounts :class:`PinnedIPHTTPAdapter` for ``http://`` and ``https://``.
+    """
+    import requests
+
+    session = requests.Session()
+    for key, value in session_kwargs.items():
+        setattr(session, key, value)
+    adapter = PinnedIPHTTPAdapter(host_to_ips)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session

--- a/connectors/webdav_connector.py
+++ b/connectors/webdav_connector.py
@@ -165,11 +165,16 @@ class WebDAVConnector:
                 target_name, "error", "Missing base_url or url (e.g. https://host/path)"
             )
             return
-        # SSRF guard (#832): reject link-local/private/loopback hosts unless the
-        # target config opts in with allow_private_networks: true.
-        from .url_guard import target_allows_private, validate_outbound_url
+        # SSRF guard (#832 / #1565): reject private hosts unless opted in; pin
+        # the underlying requests.Session so WebDAV cannot rebind DNS after guard.
+        from .url_guard import (
+            build_pinned_requests_session,
+            host_pins_from_url,
+            resolve_and_validate_outbound_url,
+            target_allows_private,
+        )
 
-        err = validate_outbound_url(
+        err, ips = resolve_and_validate_outbound_url(
             base_url,
             allow_private=target_allows_private(self.config),
             label="base_url",
@@ -190,6 +195,11 @@ class WebDAVConnector:
             options["webdav_verify"] = False
         try:
             client = WebDAVClient(options)
+            # webdav3 always builds its own Session in __init__; replace with a
+            # pinned session so TCP peers stay on IPs validated above (#1565).
+            client.session = build_pinned_requests_session(
+                host_to_ips=host_pins_from_url(base_url, ips)
+            )
         except Exception as e:
             self.db_manager.save_failure(target_name, "error", str(e))
             return

--- a/tests/test_filesystem_symlink_guard.py
+++ b/tests/test_filesystem_symlink_guard.py
@@ -32,7 +32,39 @@ def test_iter_scan_files_deduplicates_same_inode_via_symlink(
 
     files = list(iter_scan_files(root, recursive=True))
     assert len(files) == 1
-    assert files[0].name == "data.txt"
+    assert files[0].resolve() == real.resolve()
+
+
+def test_iter_scan_files_yields_sole_path_symlink_inside_root(
+    tmp_path: Path,
+) -> None:
+    # regression-anchor: #1579 — content reachable only via symlink must be scanned.
+    root = tmp_path / "root"
+    hidden = root / "hidden"
+    hidden.mkdir(parents=True)
+    real = hidden / "secret.txt"
+    real.write_text("sole-via-symlink", encoding="utf-8")
+    link = root / "visible.txt"
+    os.symlink(real, link)
+
+    files = list(iter_scan_files(root, recursive=False))
+    assert len(files) == 1
+    assert files[0].name == "visible.txt"
+    assert files[0].read_text(encoding="utf-8") == "sole-via-symlink"
+
+
+def test_iter_scan_files_skips_symlink_escaping_root(
+    tmp_path: Path,
+) -> None:
+    # regression-anchor: #1579 / #1560 — outside-root symlink targets are not scanned.
+    root = tmp_path / "root"
+    root.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("escaped", encoding="utf-8")
+    os.symlink(outside, root / "escape.txt")
+
+    files = list(iter_scan_files(root, recursive=True))
+    assert files == []
 
 
 def test_iter_scan_files_non_recursive_only_top_level(tmp_path: Path) -> None:

--- a/tests/test_ssrf_guard.py
+++ b/tests/test_ssrf_guard.py
@@ -18,6 +18,7 @@ import pytest
 
 from connectors.url_guard import (
     OPT_IN_KEY,
+    PinnedIPHTTPAdapter,
     PinnedIPTransport,
     resolve_and_validate_outbound_url,
     target_allows_private,
@@ -130,6 +131,44 @@ def test_pinned_transport_rewrites_url_host_to_pin() -> None:
     assert pinned_req.url.host == "203.0.113.10"
     assert pinned_req.headers.get("host") == "api.example.com"
     assert pinned_req.extensions.get("sni_hostname") == "api.example.com"
+
+
+def test_pinned_requests_adapter_rejects_host_not_in_pin_map() -> None:
+    # regression-anchor: #1565 — requests path has no second DNS for unexpected hosts.
+    import requests
+    from requests.adapters import HTTPAdapter
+
+    adapter = PinnedIPHTTPAdapter({"api.example.com": ["203.0.113.10"]})
+    req = requests.Request("GET", "https://evil.example.com/x").prepare()
+    with (
+        pytest.raises(ValueError, match="#1552"),
+        patch.object(HTTPAdapter, "send") as mock_send,
+    ):
+        adapter.send(req)
+    mock_send.assert_not_called()
+
+
+def test_pinned_requests_adapter_rewrites_url_host_to_pin() -> None:
+    # regression-anchor: #1565 — TCP peer is the pre-validated IP; Host/SNI preserved.
+    import requests
+    from requests.adapters import HTTPAdapter
+
+    adapter = PinnedIPHTTPAdapter({"api.example.com": ["203.0.113.10"]})
+    req = requests.Request("GET", "https://api.example.com/v1").prepare()
+    fake_response = MagicMock()
+    with patch.object(HTTPAdapter, "send", return_value=fake_response) as mock_send:
+        out = adapter.send(req)
+    assert out is fake_response
+    sent_req = mock_send.call_args.args[0]
+    assert "203.0.113.10" in sent_req.url
+    assert "api.example.com" not in urlparse_host(sent_req.url)
+    assert sent_req.headers.get("Host") == "api.example.com"
+
+
+def urlparse_host(url: str) -> str:
+    from urllib.parse import urlparse
+
+    return urlparse(url).hostname or ""
 
 
 def test_resolve_and_validate_returns_pins_for_literal_global_ip() -> None:


### PR DESCRIPTION
## Summary
- **#1565:** `PinnedIPHTTPAdapter` / `build_pinned_requests_session` — SharePoint and WebDAV pin TCP peers to IPs validated at guard time (Host + SNI preserved), closing DNS-rebinding gap left after httpx pinning (#1552).
- **#1579:** filesystem scan uses the **target** inode for file symlinks and requires the resolved target to stay under the scan root (sole-path symlink scanned; escape symlink skipped). Replaces non-reproducing #1560 framing with the real false-negative bug.

## Test plan
- [x] `uv run pytest tests/test_ssrf_guard.py tests/test_filesystem_symlink_guard.py -q` (42 passed)
- [ ] CI green

Closes #1565
Closes #1579