### PR TITLE
docs(license): proprietary boundary for pro/ (#1576)

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,26 @@
+# Licensing — Community (BSD-3) vs Pro (`pro/`)
+
+**Why this file exists.** The repository-root [LICENSE](LICENSE) is the official **BSD 3-Clause** text for the open-core (Community) tree. Separately, the commercial Pro-tier modules under [`pro/`](pro/) are **not** covered by that grant. This document states that boundary in plain language so operators, redistributors, and counsel do not treat a single root license file as applying to every path in the clone.
+
+## Community (open-core)
+
+- **License:** BSD 3-Clause — see [LICENSE](LICENSE) (English text is authoritative). Convenience translation: [LICENSE.pt_BR.md](LICENSE.pt_BR.md).
+- **Scope:** Everything in this repository **outside** the `pro/` directory, unless a path carries its own explicit notice.
+
+## Pro tier (`pro/`)
+
+- **License:** Proprietary / all rights reserved — see [`pro/LICENSE`](pro/LICENSE).
+- **Scope:** All source under `pro/` (including per-file copyright headers that point back to `pro/LICENSE`).
+- **Commercial model:** The final commercial license terms for `pro/` remain under active definition (tracked in issue [#1576](https://github.com/DataBoar/data-boar/issues/1576) and related planning docs). Until ratified, the default in `pro/LICENSE` governs.
+
+## Runtime license-key gate vs copyright boundary
+
+Data Boar may enforce Pro features at **runtime** (license key / beacon gating). That mechanism is an **enforcement layer on top of** the licensing boundary described here. It is **not** a substitute for the copyright and license notices: receiving or running a build that includes `pro/` does not expand the BSD-3 grant into `pro/`, and stripping or bypassing the runtime gate does not create a copyright license to copy, modify, or redistribute `pro/` source.
+
+## Non-retroactivity
+
+This notice and the `pro/LICENSE` file document the intended boundary going forward. They do **not** by themselves rewrite history for parties who already obtained a copy of `pro/` source under prior repository packaging while the tree was presented under a single package-wide BSD-3 classifier. Counsel should evaluate prior distributions on the facts of each receipt; this file is not legal advice.
+
+## Contact
+
+Questions about Community or Pro licensing: see contact information in [README.md](README.md) and [SECURITY.md](SECURITY.md).

--- a/LICENSING.pt_BR.md
+++ b/LICENSING.pt_BR.md
@@ -1,0 +1,34 @@
+# Licenciamento — Community (BSD-3) vs Pro (`pro/`) (tradução para conveniência)
+
+**English (texto oficial):** [LICENSING.md](LICENSING.md)
+
+O arquivo **LICENSING.md** na raiz do repositório contém o texto **oficial em inglês** sobre a fronteira de licenciamento Community vs Pro. **Para efeitos jurídicos e de licenciamento de software, somente a versão em inglês faz fé.** A tradução abaixo é apenas para facilitar a leitura em português brasileiro.
+
+---
+
+# Licenciamento — Community (BSD-3) vs Pro (`pro/`)
+
+**Por que este arquivo existe.** O [LICENSE](LICENSE) na raiz é o texto oficial da **BSD 3-Clause** para a árvore open-core (Community). Em separado, os módulos comerciais do tier Pro em [`pro/`](pro/) **não** estão cobertos por essa concessão. Este documento declara essa fronteira em linguagem clara para que operadores, redistribuidores e assessoria jurídica não tratem um único arquivo de licença na raiz como aplicável a todos os caminhos do clone.
+
+## Community (open-core)
+
+- **Licença:** BSD 3-Clause — ver [LICENSE](LICENSE) (texto em inglês é autoritativo). Tradução de conveniência: [LICENSE.pt_BR.md](LICENSE.pt_BR.md).
+- **Escopo:** Tudo neste repositório **fora** do diretório `pro/`, salvo caminho com aviso explícito próprio.
+
+## Tier Pro (`pro/`)
+
+- **Licença:** Proprietário / todos os direitos reservados — ver [`pro/LICENSE`](pro/LICENSE).
+- **Escopo:** Todo o código-fonte sob `pro/` (incluindo cabeçalhos de copyright por arquivo que apontam de volta para `pro/LICENSE`).
+- **Modelo comercial:** Os termos comerciais finais para `pro/` seguem em definição ativa (acompanhados na issue [#1576](https://github.com/DataBoar/data-boar/issues/1576) e docs de planejamento relacionados). Até a ratificação, vale o padrão em `pro/LICENSE`.
+
+## Gate de license-key em runtime vs fronteira de copyright
+
+O Data Boar pode restringir recursos Pro em **runtime** (chave de licença / beacon). Esse mecanismo é uma **camada de enforcement sobre** a fronteira de licenciamento descrita aqui. **Não** substitui os avisos de copyright e licença: receber ou executar um build que inclui `pro/` não amplia a concessão BSD-3 para dentro de `pro/`, e remover ou contornar o gate de runtime não cria licença de copyright para copiar, modificar ou redistribuir o código-fonte de `pro/`.
+
+## Não-retroatividade
+
+Este aviso e o arquivo `pro/LICENSE` documentam a fronteira pretendida daqui em diante. Eles **não** reescrevem, por si sós, o histórico de partes que já obtiveram cópia do código-fonte de `pro/` sob o empacotamento anterior do repositório, enquanto a árvore era apresentada sob um classificador BSD-3 único para o pacote inteiro. A assessoria jurídica deve avaliar distribuições anteriores com base nos fatos de cada recebimento; este arquivo não é aconselhamento jurídico.
+
+## Contato
+
+Dúvidas sobre licenciamento Community ou Pro: ver informações de contato em [README.md](README.md) e [SECURITY.md](SECURITY.md).

--- a/pro/LICENSE
+++ b/pro/LICENSE
@@ -1,0 +1,21 @@
+Data Boar — pro/ (Pro-tier modules)
+Proprietary License Notice
+
+Copyright (c) 2025-2026, FabioLeitao. All rights reserved.
+
+The source code in this directory ("pro/") is NOT covered by the
+BSD 3-Clause License granted for the rest of this repository (see the
+repository-root LICENSE file). It is proprietary and made available
+solely to enable runtime license-key verification for licensed users
+of the Pro tier.
+
+No rights are granted to copy, modify, distribute, sublicense, or
+create derivative works from any file in this directory, except as
+may be separately agreed in writing.
+
+The final commercial license model for pro/ is under active definition
+(tracked in issue #1576 and related planning docs). Until ratified,
+this default — proprietary / all rights reserved — governs.
+
+Questions about licensing pro/ content: see the repository's contact
+information (README / SECURITY.md).

--- a/pro/__init__.py
+++ b/pro/__init__.py
@@ -1,1 +1,4 @@
+# Copyright (c) 2025-2026, FabioLeitao. All rights reserved.
+# This file is part of the Pro tier and is proprietary — NOT covered by
+# the repository's root BSD-3-Clause LICENSE. See pro/LICENSE.
 """Pro+ extension namespace (optional runtime modules)."""

--- a/pro/engine.py
+++ b/pro/engine.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025-2026, FabioLeitao. All rights reserved.
+# This file is part of the Pro tier and is proprietary — NOT covered by
+# the repository's root BSD-3-Clause LICENSE. See pro/LICENSE.
 """
 Pro+ scanner wrapper with optional Rust pre-filter.
 

--- a/pro/orchestrator.py
+++ b/pro/orchestrator.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025-2026, FabioLeitao. All rights reserved.
+# This file is part of the Pro tier and is proprietary — NOT covered by
+# the repository's root BSD-3-Clause LICENSE. See pro/LICENSE.
 """
 Pro+ discovery orchestrator with multiprocessing and adaptive throttling.
 """

--- a/pro/prefilter.py
+++ b/pro/prefilter.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025-2026, FabioLeitao. All rights reserved.
+# This file is part of the Pro tier and is proprietary — NOT covered by
+# the repository's root BSD-3-Clause LICENSE. See pro/LICENSE.
 """
 Pro+ pre-filter loader with graceful fallback.
 

--- a/pro/state_tracker.py
+++ b/pro/state_tracker.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025-2026, FabioLeitao. All rights reserved.
+# This file is part of the Pro tier and is proprietary — NOT covered by
+# the repository's root BSD-3-Clause LICENSE. See pro/LICENSE.
 """
 Atomic checkpoint tracker for resumable Pro+ scans.
 """

--- a/pro/worker_logic.py
+++ b/pro/worker_logic.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025-2026, FabioLeitao. All rights reserved.
+# This file is part of the Pro tier and is proprietary — NOT covered by
+# the repository's root BSD-3-Clause LICENSE. See pro/LICENSE.
 """
 Process worker helpers for Pro+ discovery orchestration.
 


### PR DESCRIPTION
## Summary
- Add [`pro/LICENSE`](pro/LICENSE) — proprietary / all rights reserved for the Pro-tier tree (exact operator-approved text).
- Add copyright headers on the six `pro/*.py` modules pointing to `pro/LICENSE`.
- Add root [`LICENSING.md`](LICENSING.md) (EN official) + [`LICENSING.pt_BR.md`](LICENSING.pt_BR.md) (convenience) documenting Community (BSD-3, outside `pro/`) vs Pro (`pro/`), and that the runtime license-key gate is enforcement **on top of** the licensing boundary, not a substitute.
- Non-retroactivity note for prior receipts of `pro/` under previous packaging.
- **Out of scope:** `pyproject.toml` / packaging classifier (separate decision).

Closes #1576

## Test plan
- [x] `uv run pytest tests/test_docs_pt_br_locale.py`
- [ ] CI green on PR
- [ ] Operator review of LICENSING wording before merge