### PR TITLE
fix(security): SSRF guards for MongoDB, Redis, and SQL (#1559, #1556)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -41,6 +41,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
+from typing import Any
 
 import yaml
 from fastapi import BackgroundTasks, FastAPI, HTTPException, Query, Request
@@ -1903,9 +1904,11 @@ def _normalized_db_driver(value: str | None) -> str:
     return (str(value or "").split("+")[0]).strip().lower()
 
 
-def _scan_database_matches_configured_target(request_body: DatabaseConfig) -> bool:
+def _find_matching_configured_db_target(
+    request_body: DatabaseConfig,
+) -> dict[str, Any] | None:
     """
-    True when POST /scan_database payload exactly matches a configured DB target.
+    Return the configured database target that exactly matches *request_body*, or None.
 
     Matching fields: name, driver family, host, port, user, password, database.
     """
@@ -1942,8 +1945,13 @@ def _scan_database_matches_configured_target(request_body: DatabaseConfig) -> bo
             continue
         if str(target.get("database") or "").strip() != request_body.database:
             continue
-        return True
-    return False
+        return target
+    return None
+
+
+def _scan_database_matches_configured_target(request_body: DatabaseConfig) -> bool:
+    """True when POST /scan_database payload exactly matches a configured DB target."""
+    return _find_matching_configured_db_target(request_body) is not None
 
 
 @app.post("/scan_database", responses=_RATE_LIMIT_429)
@@ -1983,20 +1991,12 @@ async def scan_database(config: DatabaseConfig, background_tasks: BackgroundTask
     if config.allow_private_networks:
         target["allow_private_networks"] = True
     else:
-        # Inherit opt-in from a matching pre-configured target (#1556).
-        cfg_full = _get_config()
-        for configured in (
-            cfg_full.get("targets") if isinstance(cfg_full.get("targets"), list) else []
-        ):
-            if not isinstance(configured, dict):
-                continue
-            if str(configured.get("type") or "").strip().lower() != "database":
-                continue
-            if str(configured.get("name") or "").strip() != config.name:
-                continue
-            if bool(configured.get("allow_private_networks", False)):
-                target["allow_private_networks"] = True
-            break
+        # Inherit opt-in only from a *fully* matching configured target (#1556).
+        # Name-only match would let an ad-hoc body reuse another target's name and
+        # steal allow_private_networks (Security Agent HIGH on PR #1584).
+        matched = _find_matching_configured_db_target(config)
+        if matched and bool(matched.get("allow_private_networks", False)):
+            target["allow_private_networks"] = True
     # Defense-in-depth SSRF guard before background work (#1556).
     from connectors.sql_connector import _build_url, _guard_sql_connection_url
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -530,6 +530,7 @@ class DatabaseConfig(BaseModel):
     password: str
     database: str
     driver: str = "postgresql+psycopg2"
+    allow_private_networks: bool = False
     tenant: str | None = None  # optional customer/tenant name for this scan
     technician: str | None = None  # optional technician/operator name for this scan
     jurisdiction_hint: bool | None = (
@@ -1979,6 +1980,30 @@ async def scan_database(config: DatabaseConfig, background_tasks: BackgroundTask
         "pass": config.password,
         "database": config.database,
     }
+    if config.allow_private_networks:
+        target["allow_private_networks"] = True
+    else:
+        # Inherit opt-in from a matching pre-configured target (#1556).
+        cfg_full = _get_config()
+        for configured in (
+            cfg_full.get("targets") if isinstance(cfg_full.get("targets"), list) else []
+        ):
+            if not isinstance(configured, dict):
+                continue
+            if str(configured.get("type") or "").strip().lower() != "database":
+                continue
+            if str(configured.get("name") or "").strip() != config.name:
+                continue
+            if bool(configured.get("allow_private_networks", False)):
+                target["allow_private_networks"] = True
+            break
+    # Defense-in-depth SSRF guard before background work (#1556).
+    from connectors.sql_connector import _build_url, _guard_sql_connection_url
+
+    try:
+        _guard_sql_connection_url(_build_url(target), target)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     from core.session import new_session_id
     from core.validation import sanitize_tenant_technician
 

--- a/connectors/mongodb_connector.py
+++ b/connectors/mongodb_connector.py
@@ -65,6 +65,16 @@ class MongoDBConnector:
             )
         host = self.config.get("host", "localhost")
         port = int(self.config.get("port", 27017))
+        from .url_guard import target_allows_private, validate_outbound_url
+
+        # SSRF guard (#1559): bare host:port — do not use tcp:// (not in allowlist).
+        err = validate_outbound_url(
+            f"{host}:{port}",
+            allow_private=target_allows_private(self.config),
+            label="host",
+        )
+        if err:
+            raise ValueError(err)
         user = self.config.get("user") or self.config.get("username")
         password = self.config.get("pass") or self.config.get("password")
         database = self.config.get("database", "test")

--- a/connectors/redis_connector.py
+++ b/connectors/redis_connector.py
@@ -70,6 +70,16 @@ class RedisConnector:
             )
         host = self.config.get("host", "localhost")
         port = int(self.config.get("port", 6379))
+        from .url_guard import target_allows_private, validate_outbound_url
+
+        # SSRF guard (#1559): bare host:port — do not use tcp:// (not in allowlist).
+        err = validate_outbound_url(
+            f"{host}:{port}",
+            allow_private=target_allows_private(self.config),
+            label="host",
+        )
+        if err:
+            raise ValueError(err)
         password = self.config.get("pass") or self.config.get("password")
         connect_s = max(1, int(self.config.get("connect_timeout_seconds", 25)))
         read_s = max(1, int(self.config.get("read_timeout_seconds", 90)))

--- a/connectors/sql_connector.py
+++ b/connectors/sql_connector.py
@@ -250,11 +250,26 @@ def _build_url(target: dict[str, Any]) -> str:
     return f"{drivername}://{user}:{password}@{host}:{port}/{database}"
 
 
+# Query-string keys that can redirect the TCP peer away from URL authority (#1556).
+# libpq: host / hostaddr; MySQL connectors: unix_socket / unix_socket_dir / socket.
+_SQL_PEER_OVERRIDE_QUERY_KEYS = frozenset(
+    {
+        "host",
+        "hostaddr",
+        "unix_socket",
+        "unix_socket_dir",
+        "socket",
+    }
+)
+
+
 def _guard_sql_connection_url(url: str, target: dict[str, Any]) -> None:
     """Reject non-global SQL hosts unless allow_private_networks (#1556).
 
     Runs on the *final* URL from ``_build_url`` so both discrete host/port fields
-    and a full ``url`` override are covered.
+    and a full ``url`` override are covered. Also validates query-string peer
+    overrides (``host`` / ``hostaddr`` / unix socket keys) so a public authority
+    cannot smuggle a private peer via ``?host=…`` (#1556 / Security Agent).
     """
     if not url or url.startswith("sqlite:"):
         return
@@ -262,6 +277,7 @@ def _guard_sql_connection_url(url: str, target: dict[str, Any]) -> None:
 
     from .url_guard import target_allows_private, validate_outbound_url
 
+    allow_private = target_allows_private(target)
     parsed = make_url(url)
     host = parsed.host
     if not host:
@@ -270,11 +286,41 @@ def _guard_sql_connection_url(url: str, target: dict[str, Any]) -> None:
     candidate = f"{host}:{port}" if port is not None else host
     err = validate_outbound_url(
         candidate,
-        allow_private=target_allows_private(target),
+        allow_private=allow_private,
         label="host",
     )
     if err:
         raise ValueError(err)
+
+    # SQLAlchemy URL.query values are str | tuple[str, ...] depending on dialect.
+    query = getattr(parsed, "query", None) or {}
+    for key, raw in query.items():
+        key_l = str(key).lower()
+        if key_l not in _SQL_PEER_OVERRIDE_QUERY_KEYS:
+            continue
+        values = raw if isinstance(raw, (list, tuple)) else (raw,)
+        for value in values:
+            if value is None or str(value).strip() == "":
+                continue
+            peer = str(value).strip()
+            if key_l in {"unix_socket", "unix_socket_dir", "socket"}:
+                # Unix sockets are always local — require explicit opt-in.
+                if not allow_private:
+                    raise ValueError(
+                        f"host rejected: query '{key_l}' selects a local unix socket "
+                        f"peer. Scanning internal/private networks requires explicit "
+                        f"opt-in — add 'allow_private_networks: true' to this target. "
+                        f"(#1556)"
+                    )
+                continue
+            # host / hostaddr — may omit port; validate the peer hostname/IP alone.
+            peer_err = validate_outbound_url(
+                peer,
+                allow_private=allow_private,
+                label=f"query.{key_l}",
+            )
+            if peer_err:
+                raise ValueError(peer_err)
 
 
 def _connect_args_from_target(target: dict[str, Any]) -> dict[str, Any]:

--- a/connectors/sql_connector.py
+++ b/connectors/sql_connector.py
@@ -250,58 +250,104 @@ def _build_url(target: dict[str, Any]) -> str:
     return f"{drivername}://{user}:{password}@{host}:{port}/{database}"
 
 
-# Query-string keys that can redirect the TCP peer away from URL authority (#1556).
-# libpq: host / hostaddr; MySQL connectors: unix_socket / unix_socket_dir / socket.
-_SQL_PEER_OVERRIDE_QUERY_KEYS = frozenset(
-    {
-        "host",
-        "hostaddr",
-        "unix_socket",
-        "unix_socket_dir",
-        "socket",
-    }
-)
+# Per-dialect allowlist of SQLAlchemy URL query keys that cannot redirect the
+# TCP/unix peer (#1556). Anything else is rejected — blocklists of dangerous
+# keys (host, hostaddr, odbc_connect, DSN, …) do not scale across dialects.
+# Dialects absent from this map: any non-empty query string is rejected.
+_SQL_SAFE_QUERY_KEYS_BY_DIALECT: dict[str, frozenset[str]] = {
+    "postgresql": frozenset(
+        {
+            "sslmode",
+            "sslrootcert",
+            "sslcert",
+            "sslkey",
+            "sslcrl",
+            "connect_timeout",
+            "application_name",
+            "client_encoding",
+            "target_session_attrs",
+            "gssencmode",
+            "channel_binding",
+        }
+    ),
+    "mysql": frozenset(
+        {
+            "charset",
+            "charset_connector",
+            "connect_timeout",
+            "compress",
+            "ssl_ca",
+            "ssl_cert",
+            "ssl_key",
+            "ssl_disabled",
+            "ssl_verify_cert",
+            "ssl_verify_identity",
+        }
+    ),
+    "mssql": frozenset(
+        {
+            "driver",
+            "encrypt",
+            "trustservercertificate",
+            "timeout",
+            "login timeout",
+            "login_timeout",
+        }
+    ),
+    "oracle": frozenset(
+        {
+            # Produced by _build_url for service_name databases.
+            "service_name",
+            "encoding",
+            "nencoding",
+        }
+    ),
+}
 
 
-def _is_sql_unix_socket_path(value: str) -> bool:
-    """True when *value* is a filesystem/abstract unix-socket path, not a host/IP.
+def _sql_url_dialect_family(drivername: str | None) -> str:
+    base = (drivername or "").split("+")[0].strip().lower()
+    if base == "mariadb":
+        return "mysql"
+    return base
 
-    libpq accepts ``host=/var/run/postgresql`` (directory) as a unix-domain peer.
-    Absolute paths and Linux abstract-namespace sockets (``@name``) count; bare
-    hostnames and IPs do not.
+
+def _guard_sql_url_query_params(parsed: Any) -> None:
+    """Reject peer-redirecting or unknown URL query keys (#1556).
+
+    Strategy: allowlist per vetted dialect family. Unknown dialects may not
+    carry a query string at all. Keys such as ``host``, ``hostaddr``,
+    ``odbc_connect``, ``DSN``, and unix-socket selectors are never allowlisted.
     """
-    peer = value.strip()
-    if not peer:
-        return False
-    if peer.startswith("/"):
-        return True
-    # Linux abstract unix socket names are written with a leading '@'.
-    if peer.startswith("@") and "/" not in peer[1:]:
-        return True
-    return False
-
-
-def _reject_unix_socket_peer_without_opt_in(*, key: str, allow_private: bool) -> None:
-    if allow_private:
+    query = getattr(parsed, "query", None) or {}
+    if not query:
         return
-    raise ValueError(
-        f"host rejected: query '{key}' selects a local unix socket "
-        f"peer. Scanning internal/private networks requires explicit "
-        f"opt-in — add 'allow_private_networks: true' to this target. "
-        f"(#1556)"
-    )
+    family = _sql_url_dialect_family(getattr(parsed, "drivername", None))
+    allowed = _SQL_SAFE_QUERY_KEYS_BY_DIALECT.get(family)
+    if allowed is None:
+        raise ValueError(
+            f"host rejected: SQL URL query string is not allowed for dialect "
+            f"'{family or 'unknown'}' (unvetted — refuse peer overrides). (#1556)"
+        )
+    allowed_l = {k.lower() for k in allowed}
+    for key in query:
+        key_l = str(key).lower()
+        if key_l not in allowed_l:
+            raise ValueError(
+                f"host rejected: SQL URL query parameter '{key}' is not in the "
+                f"allowlist for dialect '{family}' (peer-override / unknown keys "
+                f"are refuse-by-default). (#1556)"
+            )
 
 
 def _guard_sql_connection_url(url: str, target: dict[str, Any]) -> None:
     """Reject non-global SQL hosts unless allow_private_networks (#1556).
 
     Runs on the *final* URL from ``_build_url`` so both discrete host/port fields
-    and a full ``url`` override are covered. Also validates query-string peer
-    overrides (``host`` / ``hostaddr`` / unix socket keys) so a public authority
-    cannot smuggle a private peer via ``?host=…`` (#1556 / Security Agent).
-
-    libpq ``host=/path`` (unix socket directory) is treated as a socket peer, not
-    a DNS name — require opt-in, do not fail closed on resolution (Bugbot).
+    and a full ``url`` override are covered. Query strings use a per-dialect
+    **allowlist** (unknown key or unvetted dialect → reject) so peer overrides
+    such as ``?host=``, ``?hostaddr=``, ``?odbc_connect=``, or ``?DSN=`` cannot
+    bypass the authority check (#1556 / Bugbot).
     """
     if not url or url.startswith("sqlite:"):
         return
@@ -311,6 +357,7 @@ def _guard_sql_connection_url(url: str, target: dict[str, Any]) -> None:
 
     allow_private = target_allows_private(target)
     parsed = make_url(url)
+    _guard_sql_url_query_params(parsed)
     host = parsed.host
     if not host:
         raise ValueError("host rejected: no host found in SQL connection URL. (#1556)")
@@ -323,35 +370,6 @@ def _guard_sql_connection_url(url: str, target: dict[str, Any]) -> None:
     )
     if err:
         raise ValueError(err)
-
-    # SQLAlchemy URL.query values are str | tuple[str, ...] depending on dialect.
-    query = getattr(parsed, "query", None) or {}
-    for key, raw in query.items():
-        key_l = str(key).lower()
-        if key_l not in _SQL_PEER_OVERRIDE_QUERY_KEYS:
-            continue
-        values = raw if isinstance(raw, (list, tuple)) else (raw,)
-        for value in values:
-            if value is None or str(value).strip() == "":
-                continue
-            peer = str(value).strip()
-            if key_l in {"unix_socket", "unix_socket_dir", "socket"} or (
-                key_l == "host" and _is_sql_unix_socket_path(peer)
-            ):
-                # Unix sockets are always local — require explicit opt-in.
-                # libpq also uses host=/dir for the socket directory (Bugbot).
-                _reject_unix_socket_peer_without_opt_in(
-                    key=key_l, allow_private=allow_private
-                )
-                continue
-            # host / hostaddr — hostname or IP; validate the peer alone.
-            peer_err = validate_outbound_url(
-                peer,
-                allow_private=allow_private,
-                label=f"query.{key_l}",
-            )
-            if peer_err:
-                raise ValueError(peer_err)
 
 
 def _connect_args_from_target(target: dict[str, Any]) -> dict[str, Any]:

--- a/connectors/sql_connector.py
+++ b/connectors/sql_connector.py
@@ -250,6 +250,33 @@ def _build_url(target: dict[str, Any]) -> str:
     return f"{drivername}://{user}:{password}@{host}:{port}/{database}"
 
 
+def _guard_sql_connection_url(url: str, target: dict[str, Any]) -> None:
+    """Reject non-global SQL hosts unless allow_private_networks (#1556).
+
+    Runs on the *final* URL from ``_build_url`` so both discrete host/port fields
+    and a full ``url`` override are covered.
+    """
+    if not url or url.startswith("sqlite:"):
+        return
+    from sqlalchemy.engine.url import make_url
+
+    from .url_guard import target_allows_private, validate_outbound_url
+
+    parsed = make_url(url)
+    host = parsed.host
+    if not host:
+        raise ValueError("host rejected: no host found in SQL connection URL. (#1556)")
+    port = parsed.port
+    candidate = f"{host}:{port}" if port is not None else host
+    err = validate_outbound_url(
+        candidate,
+        allow_private=target_allows_private(target),
+        label="host",
+    )
+    if err:
+        raise ValueError(err)
+
+
 def _connect_args_from_target(target: dict[str, Any]) -> dict[str, Any]:
     """
     Build SQLAlchemy ``connect_args`` from target timeouts (config loader merges global + per-target).
@@ -357,6 +384,7 @@ class SQLConnector:
     def connect(self) -> None:
         ensure_sql_driver_available(self.config.get("driver"))
         url = _build_url(self.config)
+        _guard_sql_connection_url(url, self.config)
         connect_args = _connect_args_from_target(self.config)
         self.engine = create_engine(url, pool_pre_ping=True, connect_args=connect_args)
         self._table_row_cache = {}

--- a/connectors/sql_connector.py
+++ b/connectors/sql_connector.py
@@ -263,6 +263,35 @@ _SQL_PEER_OVERRIDE_QUERY_KEYS = frozenset(
 )
 
 
+def _is_sql_unix_socket_path(value: str) -> bool:
+    """True when *value* is a filesystem/abstract unix-socket path, not a host/IP.
+
+    libpq accepts ``host=/var/run/postgresql`` (directory) as a unix-domain peer.
+    Absolute paths and Linux abstract-namespace sockets (``@name``) count; bare
+    hostnames and IPs do not.
+    """
+    peer = value.strip()
+    if not peer:
+        return False
+    if peer.startswith("/"):
+        return True
+    # Linux abstract unix socket names are written with a leading '@'.
+    if peer.startswith("@") and "/" not in peer[1:]:
+        return True
+    return False
+
+
+def _reject_unix_socket_peer_without_opt_in(*, key: str, allow_private: bool) -> None:
+    if allow_private:
+        return
+    raise ValueError(
+        f"host rejected: query '{key}' selects a local unix socket "
+        f"peer. Scanning internal/private networks requires explicit "
+        f"opt-in — add 'allow_private_networks: true' to this target. "
+        f"(#1556)"
+    )
+
+
 def _guard_sql_connection_url(url: str, target: dict[str, Any]) -> None:
     """Reject non-global SQL hosts unless allow_private_networks (#1556).
 
@@ -270,6 +299,9 @@ def _guard_sql_connection_url(url: str, target: dict[str, Any]) -> None:
     and a full ``url`` override are covered. Also validates query-string peer
     overrides (``host`` / ``hostaddr`` / unix socket keys) so a public authority
     cannot smuggle a private peer via ``?host=…`` (#1556 / Security Agent).
+
+    libpq ``host=/path`` (unix socket directory) is treated as a socket peer, not
+    a DNS name — require opt-in, do not fail closed on resolution (Bugbot).
     """
     if not url or url.startswith("sqlite:"):
         return
@@ -303,17 +335,16 @@ def _guard_sql_connection_url(url: str, target: dict[str, Any]) -> None:
             if value is None or str(value).strip() == "":
                 continue
             peer = str(value).strip()
-            if key_l in {"unix_socket", "unix_socket_dir", "socket"}:
+            if key_l in {"unix_socket", "unix_socket_dir", "socket"} or (
+                key_l == "host" and _is_sql_unix_socket_path(peer)
+            ):
                 # Unix sockets are always local — require explicit opt-in.
-                if not allow_private:
-                    raise ValueError(
-                        f"host rejected: query '{key_l}' selects a local unix socket "
-                        f"peer. Scanning internal/private networks requires explicit "
-                        f"opt-in — add 'allow_private_networks: true' to this target. "
-                        f"(#1556)"
-                    )
+                # libpq also uses host=/dir for the socket directory (Bugbot).
+                _reject_unix_socket_peer_without_opt_in(
+                    key=key_l, allow_private=allow_private
+                )
                 continue
-            # host / hostaddr — may omit port; validate the peer hostname/IP alone.
+            # host / hostaddr — hostname or IP; validate the peer alone.
             peer_err = validate_outbound_url(
                 peer,
                 allow_private=allow_private,

--- a/connectors/url_guard.py
+++ b/connectors/url_guard.py
@@ -29,7 +29,8 @@ DNS posture (#1552):
 
 Shared by: rest_connector, powerbi_connector (token_url),
 sharepoint_connector (site_url), webdav_connector (base_url),
-dataverse_connector (org_url / token_url).
+dataverse_connector (org_url / token_url), mongodb_connector / redis_connector
+(host:port), sql_connector (connection URL host).
 
 #1565: ``PinnedIPHTTPAdapter`` / ``build_pinned_requests_session`` pin
 ``requests`` peers the same way ``PinnedIPTransport`` pins httpx (SharePoint,

--- a/tests/test_crypto_controls_audit.py
+++ b/tests/test_crypto_controls_audit.py
@@ -15,6 +15,7 @@ from connectors.redis_connector import RedisConnector
 from connectors.rest_connector import RESTConnector
 from connectors.smb_connector import SMBConnector
 from connectors.sql_connector import SQLConnector
+from connectors.url_guard import OPT_IN_KEY
 from core.crypto_audit import collect_sql_crypto_facts
 from core.database import LocalDBManager
 from report.generator import generate_report
@@ -318,6 +319,7 @@ def test_mongodb_inferred_controls_saved_when_mid_loop_raises() -> None:
     target = {
         "name": "mongo-infer-boom",
         "host": "localhost",
+        OPT_IN_KEY: True,
         "port": 27017,
         "database": "test",
         "tls": True,
@@ -353,6 +355,7 @@ def test_redis_inferred_controls_saved_when_mid_loop_raises() -> None:
     target = {
         "name": "redis-infer-boom",
         "host": "localhost",
+        OPT_IN_KEY: True,
         "port": 6379,
         "tls": False,
         "_validate_crypto": True,
@@ -406,6 +409,7 @@ def test_mongodb_connect_honors_tls_flag() -> None:
     target = {
         "name": "mongo-tls",
         "host": "localhost",
+        OPT_IN_KEY: True,
         "port": 27017,
         "database": "test",
         "tls": True,
@@ -423,6 +427,7 @@ def test_redis_connect_honors_tls_and_cert_reqs() -> None:
     target = {
         "name": "redis-tls",
         "host": "localhost",
+        OPT_IN_KEY: True,
         "port": 6379,
         "tls": True,
         "ssl_cert_reqs": "required",
@@ -443,6 +448,7 @@ def test_mongodb_connector_saves_crypto_audit_when_flag_on() -> None:
     target = {
         "name": "mongo-crypto",
         "host": "localhost",
+        OPT_IN_KEY: True,
         "port": 27017,
         "database": "test",
         "tls": True,
@@ -483,6 +489,7 @@ def test_redis_connector_saves_crypto_audit_when_flag_on() -> None:
     target = {
         "name": "redis-crypto",
         "host": "localhost",
+        OPT_IN_KEY: True,
         "port": 6379,
         "tls": False,
         "_validate_crypto": True,
@@ -790,6 +797,7 @@ def test_mongodb_connector_skips_crypto_audit_when_flag_off() -> None:
     target = {
         "name": "mongo-off",
         "host": "localhost",
+        OPT_IN_KEY: True,
         "database": "test",
         "_validate_crypto": False,
     }

--- a/tests/test_mongodb_connector.py
+++ b/tests/test_mongodb_connector.py
@@ -1,0 +1,50 @@
+"""MongoDB connector SSRF guard (#1559)."""
+
+from __future__ import annotations
+
+import importlib.util
+from unittest.mock import MagicMock
+
+import pytest
+
+from connectors.mongodb_connector import MongoDBConnector
+from connectors.url_guard import OPT_IN_KEY
+
+
+def _has_module(name: str) -> bool:
+    return importlib.util.find_spec(name) is not None
+
+
+@pytest.mark.skipif(not _has_module("pymongo"), reason="pymongo not installed")
+def test_mongodb_connect_rejects_private_host_without_opt_in() -> None:
+    conn = MongoDBConnector(
+        {"name": "m", "host": "10.0.0.5", "port": 27017},
+        scanner=MagicMock(),
+        db_manager=MagicMock(),
+    )
+    with pytest.raises(ValueError, match="#832"):
+        conn.connect()
+
+
+@pytest.mark.skipif(not _has_module("pymongo"), reason="pymongo not installed")
+def test_mongodb_connect_allows_private_with_opt_in() -> None:
+    conn = MongoDBConnector(
+        {
+            "name": "m",
+            "host": "127.0.0.1",
+            "port": 1,
+            OPT_IN_KEY: True,
+            "connect_timeout_seconds": 1,
+            "read_timeout_seconds": 1,
+        },
+        scanner=MagicMock(),
+        db_manager=MagicMock(),
+    )
+    try:
+        conn.connect()
+    except ValueError as exc:
+        pytest.fail(f"SSRF guard must not reject opted-in private host: {exc}")
+    except Exception:
+        pass
+    finally:
+        conn.close()

--- a/tests/test_redis_connector_sampling.py
+++ b/tests/test_redis_connector_sampling.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -12,6 +12,7 @@ from connectors.redis_connector import (
     REDIS_SCAN_FAILURE_VALUE_NOT_SAMPLED,
     RedisConnector,
 )
+from connectors.url_guard import OPT_IN_KEY
 
 
 def _has_module(name: str) -> bool:
@@ -46,14 +47,16 @@ def test_redis_wrongtype_recorded_per_type_not_as_connection_failure():
     client.type.side_effect = ["hash", "string"]
 
     conn = RedisConnector(
-        {"name": "redis-lab", "host": "127.0.0.1"},
+        {"name": "redis-lab", "host": "127.0.0.1", OPT_IN_KEY: True},
         _mk_scanner(),
         dbm,
         sample_limit=100,
         value_sample_limit=10,
     )
     conn._client = client
-    conn.run()
+    # Bypass connect() — exercise sampling path with the mock client.
+    with patch.object(conn, "connect"):
+        conn.run()
 
     unreachable = [
         c for c in dbm.save_failure.call_args_list if c.args[1] == "unreachable"
@@ -84,13 +87,57 @@ def test_redis_per_key_limit_follows_sample_limit():
     scanner = _mk_scanner()
 
     conn = RedisConnector(
-        {"name": "redis-cap"},
+        {"name": "redis-cap", OPT_IN_KEY: True},
         scanner,
         dbm,
         sample_limit=80,
         value_sample_limit=5,
     )
     conn._client = client
-    conn.run()
+    client.get.return_value = None
+    with patch.object(conn, "connect"):
+        conn.run()
 
     assert scanner.scan_column.call_count == 80
+
+
+def test_redis_connect_rejects_private_host_without_opt_in() -> None:
+    # regression-anchor: #1559
+    if not _has_module("redis"):
+        pytest.skip("redis not installed")
+    conn = RedisConnector(
+        {"name": "r", "host": "169.254.169.254", "port": 6379},
+        scanner=_mk_scanner(),
+        db_manager=MagicMock(),
+    )
+    with pytest.raises(ValueError, match="#832"):
+        conn.connect()
+
+
+def test_redis_connect_allows_private_with_opt_in() -> None:
+    # regression-anchor: #1559 — opt-in must pass the guard (may still fail to connect).
+    if not _has_module("redis"):
+        pytest.skip("redis not installed")
+    from connectors.url_guard import OPT_IN_KEY
+
+    conn = RedisConnector(
+        {
+            "name": "r",
+            "host": "127.0.0.1",
+            "port": 1,
+            OPT_IN_KEY: True,
+            "connect_timeout_seconds": 1,
+            "read_timeout_seconds": 1,
+        },
+        scanner=_mk_scanner(),
+        db_manager=MagicMock(),
+    )
+    # Guard must not raise; connection to closed port may raise from redis.
+    try:
+        conn.connect()
+    except ValueError as exc:
+        pytest.fail(f"SSRF guard must not reject opted-in private host: {exc}")
+    except Exception:
+        pass
+    finally:
+        conn.close()

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -213,6 +213,7 @@ def test_mongodb_connector_uri_encodes_password_special_chars():
         "database": "testdb",
         "user": "admin",
         "password": "p@ss:word",
+        "allow_private_networks": True,
     }
     from connectors.mongodb_connector import MongoDBConnector
 

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -634,6 +634,27 @@ def test_sql_guard_rejects_unix_socket_query_without_opt_in() -> None:
         )
 
 
+def test_sql_guard_rejects_libpq_host_socket_path_without_opt_in() -> None:
+    # regression-anchor: Bugbot — libpq host=/dir is a unix socket, not DNS.
+    from connectors.sql_connector import _guard_sql_connection_url
+
+    with pytest.raises(ValueError, match="#1556"):
+        _guard_sql_connection_url(
+            "postgresql+psycopg2://x:x@1.1.1.1:5432/db?host=/var/run/postgresql",
+            {"name": "probe"},
+        )
+
+
+def test_sql_guard_allows_libpq_host_socket_path_with_opt_in() -> None:
+    from connectors.sql_connector import _guard_sql_connection_url
+    from connectors.url_guard import OPT_IN_KEY
+
+    _guard_sql_connection_url(
+        "postgresql+psycopg2://x:x@127.0.0.1:5432/db?host=/var/run/postgresql",
+        {"name": "lab", OPT_IN_KEY: True},
+    )
+
+
 def test_sql_guard_allows_query_host_override_with_opt_in() -> None:
     from connectors.sql_connector import _guard_sql_connection_url
     from connectors.url_guard import OPT_IN_KEY

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -5,7 +5,7 @@ _discover_fallback_no_schemas preserve behavior so discover() returns expected t
 """
 
 import sqlite3
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from connectors.sql_connector import (
@@ -530,3 +530,74 @@ def test_minor_full_scan_sample_error_keeps_first_pass_dob_and_records_failure()
     finding_kwargs = db_manager.save_finding.call_args.kwargs
     assert "DOB_POSSIBLE_MINOR" in finding_kwargs["pattern_detected"]
     assert "(full-scan confirmed)" not in (finding_kwargs.get("norm_tag") or "")
+
+
+def test_sql_connect_rejects_private_host_without_opt_in() -> None:
+    # regression-anchor: #1556
+    from connectors import sql_connector
+    from connectors.sql_connector import SQLConnector
+
+    with patch.object(sql_connector, "ensure_sql_driver_available"):
+        connector = SQLConnector(
+            {
+                "name": "probe",
+                "driver": "postgresql+psycopg2",
+                "host": "169.254.169.254",
+                "port": 5432,
+                "user": "x",
+                "pass": "x",
+                "database": "x",
+            },
+            scanner=MagicMock(),
+            db_manager=MagicMock(),
+        )
+        with pytest.raises(ValueError, match="#832"):
+            connector.connect()
+
+
+def test_sql_connect_rejects_private_host_via_url_override() -> None:
+    # regression-anchor: #1556 — url override must not bypass the guard.
+    from connectors import sql_connector
+    from connectors.sql_connector import SQLConnector
+
+    with patch.object(sql_connector, "ensure_sql_driver_available"):
+        connector = SQLConnector(
+            {
+                "name": "probe",
+                "driver": "postgresql+psycopg2",
+                "url": "postgresql+psycopg2://x:x@10.1.2.3:5432/x",
+            },
+            scanner=MagicMock(),
+            db_manager=MagicMock(),
+        )
+        with pytest.raises(ValueError, match="#832"):
+            connector.connect()
+
+
+def test_sql_connect_allows_private_with_opt_in_before_engine() -> None:
+    # Guard passes; create_engine may still fail without the driver — mock it.
+    from connectors import sql_connector
+    from connectors.url_guard import OPT_IN_KEY
+
+    with (
+        patch.object(sql_connector, "ensure_sql_driver_available"),
+        patch.object(sql_connector, "create_engine") as mock_engine,
+    ):
+        mock_engine.return_value = MagicMock()
+        connector = sql_connector.SQLConnector(
+            {
+                "name": "lab",
+                "driver": "postgresql+psycopg2",
+                "host": "10.0.0.8",
+                "port": 5432,
+                "user": "u",
+                "pass": "p",
+                "database": "db",
+                OPT_IN_KEY: True,
+            },
+            scanner=MagicMock(),
+            db_manager=MagicMock(),
+        )
+        connector.connect()
+        mock_engine.assert_called_once()
+        connector.close()

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -601,3 +601,45 @@ def test_sql_connect_allows_private_with_opt_in_before_engine() -> None:
         connector.connect()
         mock_engine.assert_called_once()
         connector.close()
+
+
+def test_sql_guard_rejects_private_peer_via_query_host_override() -> None:
+    # regression-anchor: #1556 / Security Agent — ?host= must not bypass authority check.
+    from connectors.sql_connector import _guard_sql_connection_url
+
+    with pytest.raises(ValueError, match="#832|#1556"):
+        _guard_sql_connection_url(
+            "postgresql+psycopg2://x:x@1.1.1.1:5432/db?host=169.254.169.254",
+            {"name": "probe"},
+        )
+
+
+def test_sql_guard_rejects_private_peer_via_query_hostaddr() -> None:
+    from connectors.sql_connector import _guard_sql_connection_url
+
+    with pytest.raises(ValueError, match="#832|#1556"):
+        _guard_sql_connection_url(
+            "postgresql+psycopg2://x:x@1.1.1.1:5432/db?hostaddr=10.0.0.9",
+            {"name": "probe"},
+        )
+
+
+def test_sql_guard_rejects_unix_socket_query_without_opt_in() -> None:
+    from connectors.sql_connector import _guard_sql_connection_url
+
+    with pytest.raises(ValueError, match="#1556"):
+        _guard_sql_connection_url(
+            "postgresql+psycopg2://x:x@1.1.1.1:5432/db?unix_socket=/var/run/postgresql",
+            {"name": "probe"},
+        )
+
+
+def test_sql_guard_allows_query_host_override_with_opt_in() -> None:
+    from connectors.sql_connector import _guard_sql_connection_url
+    from connectors.url_guard import OPT_IN_KEY
+
+    # Both authority and query peer are private; opt-in must pass.
+    _guard_sql_connection_url(
+        "postgresql+psycopg2://x:x@10.0.0.1:5432/db?host=10.0.0.2",
+        {"name": "lab", OPT_IN_KEY: True},
+    )

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -604,10 +604,10 @@ def test_sql_connect_allows_private_with_opt_in_before_engine() -> None:
 
 
 def test_sql_guard_rejects_private_peer_via_query_host_override() -> None:
-    # regression-anchor: #1556 / Security Agent — ?host= must not bypass authority check.
+    # regression-anchor: #1556 — query peer overrides are not allowlisted.
     from connectors.sql_connector import _guard_sql_connection_url
 
-    with pytest.raises(ValueError, match="#832|#1556"):
+    with pytest.raises(ValueError, match="#1556"):
         _guard_sql_connection_url(
             "postgresql+psycopg2://x:x@1.1.1.1:5432/db?host=169.254.169.254",
             {"name": "probe"},
@@ -617,50 +617,84 @@ def test_sql_guard_rejects_private_peer_via_query_host_override() -> None:
 def test_sql_guard_rejects_private_peer_via_query_hostaddr() -> None:
     from connectors.sql_connector import _guard_sql_connection_url
 
-    with pytest.raises(ValueError, match="#832|#1556"):
+    with pytest.raises(ValueError, match="#1556"):
         _guard_sql_connection_url(
             "postgresql+psycopg2://x:x@1.1.1.1:5432/db?hostaddr=10.0.0.9",
             {"name": "probe"},
         )
 
 
-def test_sql_guard_rejects_unix_socket_query_without_opt_in() -> None:
+def test_sql_guard_rejects_unix_socket_query() -> None:
     from connectors.sql_connector import _guard_sql_connection_url
+    from connectors.url_guard import OPT_IN_KEY
 
+    # Socket selectors are never allowlisted (opt-in does not reopen peer overrides).
     with pytest.raises(ValueError, match="#1556"):
         _guard_sql_connection_url(
             "postgresql+psycopg2://x:x@1.1.1.1:5432/db?unix_socket=/var/run/postgresql",
-            {"name": "probe"},
+            {"name": "probe", OPT_IN_KEY: True},
         )
 
 
-def test_sql_guard_rejects_libpq_host_socket_path_without_opt_in() -> None:
-    # regression-anchor: Bugbot — libpq host=/dir is a unix socket, not DNS.
+def test_sql_guard_rejects_libpq_host_socket_path() -> None:
+    # regression-anchor: Bugbot — libpq host=/dir is a peer override, not allowlisted.
+    from connectors.sql_connector import _guard_sql_connection_url
+    from connectors.url_guard import OPT_IN_KEY
+
+    with pytest.raises(ValueError, match="#1556"):
+        _guard_sql_connection_url(
+            "postgresql+psycopg2://x:x@127.0.0.1:5432/db?host=/var/run/postgresql",
+            {"name": "lab", OPT_IN_KEY: True},
+        )
+
+
+def test_sql_guard_rejects_odbc_connect_and_dsn_query() -> None:
+    # regression-anchor: Bugbot round 3 — pyodbc odbc_connect / DSN bypass.
+    from connectors.sql_connector import _guard_sql_connection_url
+    from connectors.url_guard import OPT_IN_KEY
+
+    for url in (
+        "mssql+pyodbc://x:x@1.1.1.1:1433/db?odbc_connect=DRIVER%3D%7BODBC%20Driver%7D%3BSERVER%3D169.254.169.254",
+        "mssql+pyodbc://x:x@1.1.1.1:1433/db?DSN=evil",
+    ):
+        with pytest.raises(ValueError, match="#1556"):
+            _guard_sql_connection_url(url, {"name": "probe", OPT_IN_KEY: True})
+
+
+def test_sql_guard_rejects_query_on_unvetted_dialect() -> None:
     from connectors.sql_connector import _guard_sql_connection_url
 
     with pytest.raises(ValueError, match="#1556"):
         _guard_sql_connection_url(
-            "postgresql+psycopg2://x:x@1.1.1.1:5432/db?host=/var/run/postgresql",
+            "somethingdb://x:x@1.1.1.1:1234/db?sslmode=require",
             {"name": "probe"},
         )
 
 
-def test_sql_guard_allows_libpq_host_socket_path_with_opt_in() -> None:
+def test_sql_guard_allows_safe_postgresql_query() -> None:
     from connectors.sql_connector import _guard_sql_connection_url
-    from connectors.url_guard import OPT_IN_KEY
 
     _guard_sql_connection_url(
-        "postgresql+psycopg2://x:x@127.0.0.1:5432/db?host=/var/run/postgresql",
-        {"name": "lab", OPT_IN_KEY: True},
+        "postgresql+psycopg2://x:x@1.1.1.1:5432/db?sslmode=require",
+        {"name": "ok"},
     )
 
 
-def test_sql_guard_allows_query_host_override_with_opt_in() -> None:
-    from connectors.sql_connector import _guard_sql_connection_url
+def test_sql_guard_allows_oracle_service_name_query() -> None:
+    # _build_url emits ?service_name= for Oracle — must stay allowlisted.
+    from connectors.sql_connector import _build_url, _guard_sql_connection_url
     from connectors.url_guard import OPT_IN_KEY
 
-    # Both authority and query peer are private; opt-in must pass.
-    _guard_sql_connection_url(
-        "postgresql+psycopg2://x:x@10.0.0.1:5432/db?host=10.0.0.2",
-        {"name": "lab", OPT_IN_KEY: True},
+    url = _build_url(
+        {
+            "driver": "oracle+oracledb",
+            "host": "10.0.0.8",
+            "port": 1521,
+            "user": "u",
+            "pass": "p",
+            "database": "ORCL",
+            OPT_IN_KEY: True,
+        }
     )
+    assert "service_name=" in url
+    _guard_sql_connection_url(url, {"name": "lab", OPT_IN_KEY: True})

--- a/tests/test_ssrf_guard.py
+++ b/tests/test_ssrf_guard.py
@@ -318,6 +318,9 @@ def test_sharepoint_connector_rejects_private_site_url() -> None:
         "connectors/sharepoint_connector.py",
         "connectors/webdav_connector.py",
         "connectors/dataverse_connector.py",
+        "connectors/mongodb_connector.py",
+        "connectors/redis_connector.py",
+        "connectors/sql_connector.py",
     ],
 )
 def test_connector_sources_call_url_guard(connector_file: str) -> None:
@@ -332,6 +335,7 @@ def test_connector_sources_call_url_guard(connector_file: str) -> None:
         "validate_outbound_url(" in source
         or "resolve_and_validate_outbound_url(" in source
         or "pinned_httpx_request(" in source
+        or "_guard_sql_connection_url(" in source
     )
     assert has_guard, f"{connector_file} lost its SSRF guard call (#832 / #1552)"
     assert "target_allows_private(" in source, (

--- a/tests/test_web_exposure_hardening_1202.py
+++ b/tests/test_web_exposure_hardening_1202.py
@@ -163,6 +163,7 @@ def test_scan_database_allows_adhoc_target_when_opted_in(tmp_path: Path):
                 "password": "p",
                 "database": "d",
                 "driver": "postgresql+psycopg2",
+                "allow_private_networks": True,
             },
         )
         assert resp.status_code == 200

--- a/tests/test_web_exposure_hardening_1202.py
+++ b/tests/test_web_exposure_hardening_1202.py
@@ -172,6 +172,49 @@ def test_scan_database_allows_adhoc_target_when_opted_in(tmp_path: Path):
         _teardown(routes, previous)
 
 
+def test_scan_database_does_not_inherit_private_opt_in_by_name_only(
+    tmp_path: Path,
+) -> None:
+    # regression-anchor: #1556 / Security Agent — full match required to inherit opt-in.
+    config = {
+        "targets": [
+            {
+                "name": "shared-name",
+                "type": "database",
+                "driver": "postgresql+psycopg2",
+                "host": "10.0.0.5",
+                "port": 5432,
+                "user": "lab",
+                "pass": "lab-secret",
+                "database": "labdb",
+                "allow_private_networks": True,
+            }
+        ],
+        "report": {"output_dir": str(tmp_path)},
+        "api": {"port": 8088, "allow_adhoc_targets": True},
+        "sqlite_path": str(tmp_path / "audit.db"),
+    }
+    routes, client, previous = _setup_client(tmp_path, config)
+    try:
+        resp = client.post(
+            "/scan_database",
+            json={
+                "name": "shared-name",  # same name only
+                "host": "127.0.0.1",
+                "port": 5432,
+                "user": "attacker",
+                "password": "x",
+                "database": "x",
+                "driver": "postgresql+psycopg2",
+            },
+        )
+        assert resp.status_code == 400
+        detail = resp.json().get("detail") or ""
+        assert "#832" in detail or "private" in detail.lower() or "loopback" in detail
+    finally:
+        _teardown(routes, previous)
+
+
 def test_status_reflects_forwarded_header_trust_posture(tmp_path: Path):
     config = {
         "targets": [],


### PR DESCRIPTION
## Summary
- **#1559:** `validate_outbound_url(f\"{host}:{port}\")` in MongoDB and Redis `connect()` (bare host:port — not `tcp://`); credentials no longer go to unguarded peers.
- **#1556:** `_guard_sql_connection_url` runs on the **final** URL from `_build_url` (covers discrete host/port **and** `url` override); `POST /scan_database` defense-in-depth + optional `allow_private_networks` / inherit from matching configured target.

Stacked on merged #1581 (`main`).

## Test plan
- [x] `uv run pytest tests/test_mongodb_connector.py tests/test_redis_connector_sampling.py tests/test_sql_connector.py tests/test_ssrf_guard.py -q` (85 passed)
- [ ] CI green

Closes #1559
Closes #1556