### PR TITLE
feat(connector): HubSpot CRM connector with url_guard pinning (#1229)

### DIFF
--- a/connectors/hubspot_connector.py
+++ b/connectors/hubspot_connector.py
@@ -1,0 +1,297 @@
+"""
+HubSpot CRM connector (#1229): discover object properties (including custom fields),
+sample CRM objects, and run sensitivity detection.
+
+Auth: Private App Token (PAT) via environment variable — never commit tokens.
+Default env name: ``HUBSPOT_PRIVATE_APP_TOKEN``. Header: ``Authorization: Bearer <token>``.
+
+Least-privilege scopes (read-only) for the Private App:
+  - crm.objects.contacts.read
+  - crm.objects.companies.read
+  - crm.objects.deals.read
+  - crm.schemas.contacts.read (properties discovery)
+  - crm.schemas.companies.read
+  - crm.schemas.deals.read
+
+Outbound HTTP uses ``connectors.url_guard`` host pinning (#1552) — same posture as
+``rest_connector`` / Power BI. Never use raw httpx/requests without the guard.
+
+Target type: ``hubspot``. Required config keys: ``name``, ``type``.
+Optional: ``objects`` (default contacts/companies/deals), ``base_url``,
+``token_from_env``, ``allow_private_networks``.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections import defaultdict
+from typing import Any
+from urllib.parse import urlencode
+
+from core.about import get_http_user_agent
+from core.connector_registry import register
+from core.suggested_review import (
+    SUGGESTED_REVIEW_PATTERN,
+    augment_low_id_like_for_persist,
+)
+
+from .url_guard import (
+    build_pinned_httpx_client,
+    merge_host_pins,
+    resolve_and_validate_outbound_url,
+    target_allows_private,
+)
+
+try:
+    import httpx
+
+    _HTTPX_AVAILABLE = True
+except ImportError:
+    _HTTPX_AVAILABLE = False
+    httpx = None
+
+_DEFAULT_API_BASE = "https://api.hubapi.com"
+_DEFAULT_OBJECTS = ("contacts", "companies", "deals")
+_DEFAULT_TOKEN_ENV = "HUBSPOT_PRIVATE_APP_TOKEN"
+_MAX_429_RETRIES = 5
+
+
+def _token_from_config(target: dict[str, Any]) -> str | None:
+    """Resolve Private App Token from env (never from committed config values)."""
+    auth = target.get("auth") or {}
+    env_name = (
+        auth.get("token_from_env") or target.get("token_from_env") or _DEFAULT_TOKEN_ENV
+    )
+    token = os.environ.get(str(env_name), "").strip()
+    return token or None
+
+
+class HubSpotConnector:
+    """
+    HubSpot CRM scanner: property schema discovery + object sampling.
+
+    Two-step flow per object type (contacts / companies / deals by default):
+      1. GET /crm/v3/properties/{objectType} — all property names (incl. custom).
+      2. GET /crm/v3/objects/{objectType}?properties=... — paginate via ``after``.
+
+    Each property is treated as a column: ``scan_column`` → filesystem-style finding
+    with ``path=object_type`` and ``file_name=prop_name``.
+    """
+
+    def __init__(
+        self,
+        target_config: dict[str, Any],
+        scanner: Any,
+        db_manager: Any,
+        sample_limit: int = 5,
+        detection_config: dict[str, Any] | None = None,
+    ):
+        self.config = target_config
+        self.scanner = scanner
+        self.db_manager = db_manager
+        self.sample_limit = min(max(int(sample_limit), 1), 100)
+        self.detection_config = detection_config or {}
+        self._client: httpx.Client | None = None
+        self._base_url = (self.config.get("base_url") or _DEFAULT_API_BASE).rstrip("/")
+
+    def connect(self) -> None:
+        if not _HTTPX_AVAILABLE:
+            raise RuntimeError(
+                "httpx is required for HubSpot connector. Install with: pip install httpx"
+            )
+        token = _token_from_config(self.config)
+        if not token:
+            raise ValueError(
+                "HubSpot auth failed: set env "
+                f"{self.config.get('token_from_env') or _DEFAULT_TOKEN_ENV} "
+                "to a Private App Token (read-only CRM scopes). "
+                "Never put the token in committed config."
+            )
+        allow_private = target_allows_private(self.config)
+        err, ips = resolve_and_validate_outbound_url(
+            self._base_url, allow_private=allow_private, label="base_url"
+        )
+        if err:
+            raise ValueError(err)
+        host_pins: dict[str, list[str]] = {}
+        merge_host_pins(host_pins, self._base_url, ips)
+        connect_s = float(self.config.get("connect_timeout_seconds", 25))
+        read_s = float(self.config.get("read_timeout_seconds", 90))
+        timeout = httpx.Timeout(read_s, connect=connect_s, read=read_s)
+        client_kwargs: dict[str, Any] = {
+            "base_url": self._base_url,
+            "headers": {
+                "User-Agent": get_http_user_agent(),
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/json",
+            },
+            "timeout": timeout,
+        }
+        self._client = build_pinned_httpx_client(host_to_ips=host_pins, **client_kwargs)
+
+    def close(self) -> None:
+        if self._client:
+            try:
+                self._client.close()
+            except Exception:
+                # Best-effort close; always drop the handle.
+                pass
+            self._client = None
+
+    def _object_types(self) -> list[str]:
+        raw = self.config.get("objects") or self.config.get("object_types")
+        if isinstance(raw, str) and raw.strip():
+            return [raw.strip()]
+        if isinstance(raw, (list, tuple)) and raw:
+            return [str(x).strip() for x in raw if str(x).strip()]
+        return list(_DEFAULT_OBJECTS)
+
+    def _get_json(
+        self, path: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """GET with 429 backoff. Client must already be pin-built in connect()."""
+        if not self._client:
+            raise RuntimeError("HubSpot client not connected")
+        query = f"?{urlencode(params, doseq=True)}" if params else ""
+        url_path = path if path.startswith("/") else f"/{path}"
+        last_exc: Exception | None = None
+        for attempt in range(_MAX_429_RETRIES + 1):
+            r = self._client.get(f"{url_path}{query}")
+            if r.status_code == 429:
+                retry_after = r.headers.get("Retry-After")
+                try:
+                    wait_s = float(retry_after) if retry_after else (2**attempt)
+                except ValueError:
+                    wait_s = float(2**attempt)
+                wait_s = min(max(wait_s, 0.5), 60.0)
+                time.sleep(wait_s)
+                last_exc = httpx.HTTPStatusError(
+                    f"HubSpot rate limit (429) after {attempt + 1} attempts",
+                    request=r.request,
+                    response=r,
+                )
+                continue
+            r.raise_for_status()
+            return r.json() if r.content else {}
+        assert last_exc is not None
+        raise last_exc
+
+    def _list_property_names(self, object_type: str) -> list[str]:
+        """Step 1: discover all property names including custom fields (#1166 gap)."""
+        data = self._get_json(f"/crm/v3/properties/{object_type}")
+        results = data.get("results") or []
+        names: list[str] = []
+        seen: set[str] = set()
+        for item in results:
+            if not isinstance(item, dict):
+                continue
+            name = item.get("name")
+            if isinstance(name, str) and name and name not in seen:
+                seen.add(name)
+                names.append(name)
+        return names
+
+    def _iter_object_properties(
+        self, object_type: str, property_names: list[str]
+    ) -> list[dict[str, Any]]:
+        """Step 2: paginate objects; return list of property dicts per object."""
+        if not property_names:
+            return []
+        # HubSpot accepts comma-separated property names; keep batches reasonable.
+        props_param = ",".join(property_names)
+        collected: list[dict[str, Any]] = []
+        after: str | None = None
+        while True:
+            params: dict[str, Any] = {
+                "limit": 100,
+                "properties": props_param,
+            }
+            if after:
+                params["after"] = after
+            data = self._get_json(f"/crm/v3/objects/{object_type}", params=params)
+            for row in data.get("results") or []:
+                if isinstance(row, dict):
+                    props = row.get("properties") or {}
+                    if isinstance(props, dict):
+                        collected.append(props)
+            paging = data.get("paging") or {}
+            next_page = paging.get("next") if isinstance(paging, dict) else None
+            after = None
+            if isinstance(next_page, dict):
+                after = next_page.get("after")
+            if not after:
+                break
+        return collected
+
+    def _scan_object_type(self, target_name: str, object_type: str) -> None:
+        prop_names = self._list_property_names(object_type)
+        if not prop_names:
+            return
+        rows = self._iter_object_properties(object_type, prop_names)
+        samples: dict[str, list[str]] = defaultdict(list)
+        for props in rows:
+            for name in prop_names:
+                if len(samples[name]) >= self.sample_limit:
+                    continue
+                raw = props.get(name)
+                if raw is None or raw == "":
+                    continue
+                samples[name].append(str(raw)[:500])
+
+        for prop_name in prop_names:
+            values = samples.get(prop_name) or []
+            # Always scan the property name itself (custom field names can hint PII).
+            name_sample = prop_name
+            value_sample = " ".join(values) if values else ""
+            sample_text = f"{name_sample} {value_sample}".strip()
+            result = self.scanner.scan_column(prop_name, sample_text)
+            result = augment_low_id_like_for_persist(
+                result, prop_name, self.detection_config
+            )
+            hi_med = result.get("sensitivity_level") in ("HIGH", "MEDIUM")
+            suggested = result.get("pattern_detected") == SUGGESTED_REVIEW_PATTERN
+            if not hi_med and not suggested:
+                continue
+            self.db_manager.save_finding(
+                "filesystem",
+                target_name=target_name,
+                path=object_type,
+                file_name=prop_name,
+                data_type="application/json",
+                sensitivity_level=result.get("sensitivity_level", "MEDIUM"),
+                pattern_detected=result.get("pattern_detected", ""),
+                norm_tag=result.get("norm_tag", ""),
+                ml_confidence=result.get("ml_confidence") or 0,
+            )
+
+    def run(self) -> None:
+        target_name = self.config.get("name", "HubSpot")
+        if not _HTTPX_AVAILABLE:
+            self.db_manager.save_failure(
+                target_name,
+                "error",
+                "httpx not installed. Install with: pip install httpx",
+            )
+            return
+        try:
+            self.connect()
+        except Exception as e:
+            self.db_manager.save_failure(target_name, "unreachable", str(e))
+            return
+        try:
+            for object_type in self._object_types():
+                try:
+                    self._scan_object_type(target_name, object_type)
+                except Exception as e:
+                    self.db_manager.save_failure(
+                        target_name,
+                        "error",
+                        f"HubSpot {object_type}: {e}",
+                    )
+        finally:
+            self.close()
+
+
+if _HTTPX_AVAILABLE:
+    register("hubspot", HubSpotConnector, ["name", "type"])

--- a/connectors/url_guard.py
+++ b/connectors/url_guard.py
@@ -29,7 +29,7 @@ DNS posture (#1552):
 
 Shared by: rest_connector, powerbi_connector (token_url),
 sharepoint_connector (site_url), webdav_connector (base_url),
-dataverse_connector (org_url / token_url).
+dataverse_connector (org_url / token_url), hubspot_connector (api.hubapi.com).
 
 #1565: ``PinnedIPHTTPAdapter`` / ``build_pinned_requests_session`` pin
 ``requests`` peers the same way ``PinnedIPTransport`` pins httpx (SharePoint,

--- a/core/connector_registry.py
+++ b/core/connector_registry.py
@@ -61,7 +61,7 @@ def _resolve_database_connector(
 # Connector tier boundary (#843, operator-ratified 2026-06-11; #854 fail-closed):
 # - Open-core (Community): filesystem, self-hosted SQL/NoSQL (sqlite/postgres/
 #   mysql/mariadb/mongo/redis), compressed files, generic REST/API.
-# - Pro: managed corporate infrastructure (PowerBI, SharePoint, Dataverse,
+# - Pro: managed corporate infrastructure (PowerBI, HubSpot, SharePoint, Dataverse,
 #   WebDAV, SMB/CIFS, NFS, MSSQL, Oracle) + cloud connectors.
 # #854 anti-leak: this map is EXHAUSTIVE for registered connector types. A
 # type (or database driver) absent from this map has NO tier decision and is
@@ -88,6 +88,7 @@ _CONNECTOR_TIER_FEATURES: dict[str, str] = {
     "gcs": "connector_gcs",
     # Managed corporate infrastructure (Pro)
     "powerbi": "connector_powerbi",
+    "hubspot": "connector_hubspot",
     "sharepoint": "connector_sharepoint",
     "dataverse": "connector_dataverse",
     "powerapps": "connector_dataverse",  # same connector family as dataverse
@@ -198,6 +199,8 @@ def connector_for_target(target: dict[str, Any]) -> tuple[Type[Any], list[str]] 
         return _try_get_connector(t)
     if t in ("powerbi", "dataverse", "powerapps"):
         return _try_get_connector(t)
+    if t == "hubspot":
+        return _try_get_connector("hubspot")
     if t == "database":
         return _resolve_database_connector(target)
     return None

--- a/core/engine.py
+++ b/core/engine.py
@@ -86,6 +86,10 @@ try:
     import connectors.dataverse_connector  # noqa: F401
 except ImportError:  # noqa: BLE001
     pass  # optional connector not installed
+try:
+    import connectors.hubspot_connector  # noqa: F401
+except ImportError:  # noqa: BLE001
+    pass  # optional connector not installed
 
 from core.connector_registry import connector_for_target
 from core.crypto_audit import (
@@ -533,7 +537,7 @@ class AuditEngine:
                     file_sample_max_chars=file_sample_max_chars,
                     file_passwords=file_passwords,
                 )
-            elif t in ("powerbi", "dataverse", "powerapps"):
+            elif t in ("powerbi", "dataverse", "powerapps", "hubspot"):
                 connector = connector_class(
                     target_with_fs,
                     self.scanner,

--- a/core/licensing/tier_features.py
+++ b/core/licensing/tier_features.py
@@ -93,6 +93,7 @@ FEATURE_TIER_MAP: dict[str, Tier] = {
     "connector_gcs": Tier.PRO,
     # Managed corporate infrastructure connectors (#843 boundary)
     "connector_powerbi": Tier.PRO,
+    "connector_hubspot": Tier.PRO,  # managed SaaS CRM (#1229)
     "connector_sharepoint": Tier.PRO,
     "connector_dataverse": Tier.PRO,
     "connector_webdav": Tier.PRO,

--- a/docs/ADDING_CONNECTORS.md
+++ b/docs/ADDING_CONNECTORS.md
@@ -334,7 +334,32 @@ targets:
 
 ---
 
-## 7. Checklist
+## 7. Example: HubSpot CRM connector (#1229)
+
+Managed SaaS CRM (Pro tier). Discovers **all** property names (including custom fields
+where CPF/CNPJ often hide), then samples objects with pagination and rate-limit backoff.
+
+- **Module:** `connectors/hubspot_connector.py`
+- **Auth:** Private App Token via env ``HUBSPOT_PRIVATE_APP_TOKEN`` (never commit tokens).
+  Read-only scopes: `crm.objects.*.read` + `crm.schemas.*.read` for contacts/companies/deals.
+- **SSRF:** All outbound HTTP uses `connectors/url_guard.py` host pinning (#1552) — same
+  posture as the REST connector.
+
+Config example:
+
+```yaml
+targets:
+  - name: crm-hubspot
+    type: hubspot
+    objects: [contacts, companies, deals]
+```
+
+Optional keys: `base_url` (default `https://api.hubapi.com`), `token_from_env`
+(override env var name), `allow_private_networks` (lab only).
+
+---
+
+## 8. Checklist
 
 - [ ] New module under `connectors/<name>_connector.py`.
 - [ ] Class with `run()`, and optionally `connect()`/`close()`.

--- a/docs/ADDING_CONNECTORS.pt_BR.md
+++ b/docs/ADDING_CONNECTORS.pt_BR.md
@@ -334,7 +334,32 @@ targets:
 
 ---
 
-## 7. Checklist
+## 7. Exemplo: conector HubSpot CRM (#1229)
+
+CRM SaaS gerenciado (tier Pro). Descobre **todos** os nomes de propriedade (incluindo campos
+customizados onde CPF/CNPJ costumam aparecer) e amostra objetos com paginação e backoff em 429.
+
+- **Módulo:** `connectors/hubspot_connector.py`
+- **Auth:** Private App Token via env ``HUBSPOT_PRIVATE_APP_TOKEN`` (nunca commitar o token).
+  Escopos somente leitura: `crm.objects.*.read` + `crm.schemas.*.read` para contacts/companies/deals.
+- **SSRF:** Todo HTTP de saída usa pin de host em `connectors/url_guard.py` (#1552) — mesma
+  postura do conector REST.
+
+Exemplo de config:
+
+```yaml
+targets:
+  - name: crm-hubspot
+    type: hubspot
+    objects: [contacts, companies, deals]
+```
+
+Chaves opcionais: `base_url` (padrão `https://api.hubapi.com`), `token_from_env`
+(nome da env var), `allow_private_networks` (somente lab).
+
+---
+
+## 8. Checklist
 
 - [ ] Novo módulo em `connectors/<nome>_connector.py`.
 - [ ] Classe com `run()`, e opcionalmente `connect()`/`close()`.

--- a/tests/fixtures/hubspot/__init__.py
+++ b/tests/fixtures/hubspot/__init__.py
@@ -1,0 +1,1 @@
+# HubSpot synthetic fixtures package

--- a/tests/fixtures/hubspot/synthetic_crm.py
+++ b/tests/fixtures/hubspot/synthetic_crm.py
@@ -1,0 +1,92 @@
+"""Synthetic HubSpot CRM payloads for connector tests (#1229).
+
+Uses checksum-valid Brazilian CPF fixtures only — zero real customer /
+prospect (e.g. Madruga) data. Safe to commit.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Same synthetic CPF used across Data Boar unit tests (valid check digits).
+SYNTHETIC_CPF_FORMATTED = "390.533.447-05"
+SYNTHETIC_EMAIL = "audit.synthetic@example.com"
+SYNTHETIC_COMPANY = "Synthetic Audit Co Ltda"
+SYNTHETIC_DEAL = "Synthetic Pipeline Deal"
+
+
+def properties_response(*names: str) -> dict[str, Any]:
+    """HubSpot GET /crm/v3/properties/{objectType} shape."""
+    return {
+        "results": [
+            {
+                "name": n,
+                "label": n.replace("_", " ").title(),
+                "type": "string",
+                "fieldType": "text",
+                "groupName": "contactinformation",
+            }
+            for n in names
+        ]
+    }
+
+
+def objects_page(
+    rows: list[dict[str, Any]],
+    *,
+    after: str | None = None,
+) -> dict[str, Any]:
+    """HubSpot GET /crm/v3/objects/{objectType} page shape."""
+    results = []
+    for i, props in enumerate(rows, start=1):
+        results.append({"id": str(i), "properties": props})
+    payload: dict[str, Any] = {"results": results}
+    if after:
+        payload["paging"] = {"next": {"after": after}}
+    return payload
+
+
+def synthetic_contact_properties() -> dict[str, Any]:
+    """Contact with CPF in a custom field (the #1166/#1229 detection gap)."""
+    return {
+        "email": SYNTHETIC_EMAIL,
+        "firstname": "Synthetic",
+        "lastname": "Contact",
+        "cpf_custom": SYNTHETIC_CPF_FORMATTED,
+    }
+
+
+def synthetic_company_properties() -> dict[str, Any]:
+    return {
+        "name": SYNTHETIC_COMPANY,
+        "domain": "example.com",
+        "cnpj_custom": "11.222.333/0001-81",  # placeholder shape; detector may ignore
+    }
+
+
+def synthetic_deal_properties() -> dict[str, Any]:
+    return {
+        "dealname": SYNTHETIC_DEAL,
+        "amount": "1000",
+        "pipeline": "default",
+    }
+
+
+def contact_schema_and_pages() -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Full contact discovery + two object pages (for pagination tests)."""
+    schema = properties_response("email", "firstname", "lastname", "cpf_custom")
+    page1 = objects_page(
+        [synthetic_contact_properties()],
+        after="cursor-page-2",
+    )
+    page2 = objects_page(
+        [
+            {
+                "email": "second.synthetic@example.com",
+                "firstname": "Second",
+                "lastname": "Synthetic",
+                "cpf_custom": "",
+            }
+        ]
+    )
+    return schema, [page1, page2]

--- a/tests/test_connector_tier_gating.py
+++ b/tests/test_connector_tier_gating.py
@@ -44,6 +44,7 @@ def _clean_guard():
         # #843 — connectors
         ("connector_rest", Tier.COMMUNITY),
         ("connector_powerbi", Tier.PRO),
+        ("connector_hubspot", Tier.PRO),
         ("connector_sharepoint", Tier.PRO),
         ("connector_dataverse", Tier.PRO),
         ("connector_webdav", Tier.PRO),
@@ -70,6 +71,7 @@ def test_feature_tier_map_entries(feature, tier):
     ("target", "expected"),
     [
         ({"type": "powerbi"}, "connector_powerbi"),
+        ({"type": "hubspot"}, "connector_hubspot"),
         ({"type": "sharepoint"}, "connector_sharepoint"),
         ({"type": "dataverse"}, "connector_dataverse"),
         ({"type": "powerapps"}, "connector_dataverse"),

--- a/tests/test_hubspot_connector.py
+++ b/tests/test_hubspot_connector.py
@@ -1,0 +1,264 @@
+"""HubSpot CRM connector tests (#1229): schema discovery, pagination, custom-field PII, url_guard."""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from connectors.hubspot_connector import (
+    _DEFAULT_TOKEN_ENV,
+    _HTTPX_AVAILABLE,
+    HubSpotConnector,
+)
+from tests.fixtures.hubspot.synthetic_crm import (
+    SYNTHETIC_CPF_FORMATTED,
+    contact_schema_and_pages,
+    objects_page,
+    properties_response,
+    synthetic_contact_properties,
+)
+
+pytestmark = pytest.mark.skipif(not _HTTPX_AVAILABLE, reason="httpx not installed")
+
+
+def _mk_scanner_passthrough():
+    """Use real DataScanner so CPF in custom field is actually detected."""
+    from core.scanner import DataScanner
+
+    return DataScanner()
+
+
+def _mk_scanner_mock(level: str = "HIGH", pattern: str = "CPF"):
+    scanner = MagicMock()
+    scanner.scan_column.return_value = {
+        "sensitivity_level": level,
+        "pattern_detected": pattern,
+        "norm_tag": "CPF",
+        "ml_confidence": 0.9,
+    }
+    return scanner
+
+
+def _cfg(**overrides):
+    cfg = {
+        "name": "crm-hubspot",
+        "type": "hubspot",
+        "objects": ["contacts"],
+        "base_url": "https://api.hubapi.com",
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+@pytest.fixture
+def hubspot_token(monkeypatch):
+    monkeypatch.setenv(_DEFAULT_TOKEN_ENV, "pat-synthetic-test-token-not-real")
+    yield
+    monkeypatch.delenv(_DEFAULT_TOKEN_ENV, raising=False)
+
+
+def _json_response(
+    payload: dict, url: str = "https://api.hubapi.com/"
+) -> httpx.Response:
+    req = httpx.Request("GET", url)
+    return httpx.Response(200, json=payload, request=req)
+
+
+@patch("connectors.hubspot_connector.time.sleep", return_value=None)
+@patch("connectors.hubspot_connector.build_pinned_httpx_client")
+@patch("connectors.hubspot_connector.resolve_and_validate_outbound_url")
+def test_property_discovery_includes_custom_fields(
+    mock_resolve, mock_client_cls, _sleep, hubspot_token
+):
+    mock_resolve.return_value = (None, [ipaddress.ip_address("104.16.0.1")])
+    client = MagicMock()
+    mock_client_cls.return_value = client
+
+    schema = properties_response("email", "cpf_custom")
+    page = objects_page([synthetic_contact_properties()])
+
+    def _get(url, *args, **kwargs):
+        path = str(url)
+        if "/crm/v3/properties/" in path:
+            return _json_response(schema, path)
+        if "/crm/v3/objects/" in path:
+            return _json_response(page, path)
+        raise AssertionError(f"unexpected GET {path}")
+
+    client.get.side_effect = _get
+
+    dbm = MagicMock()
+    HubSpotConnector(_cfg(), _mk_scanner_mock(), dbm).run()
+
+    prop_calls = [
+        c.args[0]
+        for c in client.get.call_args_list
+        if "/crm/v3/properties/contacts" in str(c.args[0])
+    ]
+    assert prop_calls, "must discover properties before objects"
+    obj_calls = [
+        c.args[0]
+        for c in client.get.call_args_list
+        if "/crm/v3/objects/contacts" in str(c.args[0])
+    ]
+    assert obj_calls, "must fetch objects after property discovery"
+    assert "cpf_custom" in str(obj_calls[0]) or "properties=" in str(obj_calls[0])
+
+
+@patch("connectors.hubspot_connector.time.sleep", return_value=None)
+@patch("connectors.hubspot_connector.build_pinned_httpx_client")
+@patch("connectors.hubspot_connector.resolve_and_validate_outbound_url")
+def test_pagination_follows_after_cursor(
+    mock_resolve, mock_client_cls, _sleep, hubspot_token
+):
+    mock_resolve.return_value = (None, [ipaddress.ip_address("104.16.0.1")])
+    client = MagicMock()
+    mock_client_cls.return_value = client
+    schema, pages = contact_schema_and_pages()
+    object_hits = {"n": 0}
+
+    def _get(url, *args, **kwargs):
+        path = str(url)
+        if "/crm/v3/properties/" in path:
+            return _json_response(schema, path)
+        if "/crm/v3/objects/" in path:
+            idx = object_hits["n"]
+            object_hits["n"] += 1
+            return _json_response(pages[idx], path)
+        raise AssertionError(f"unexpected GET {path}")
+
+    client.get.side_effect = _get
+    dbm = MagicMock()
+    HubSpotConnector(_cfg(), _mk_scanner_mock(level="LOW", pattern=""), dbm).run()
+    assert object_hits["n"] == 2
+    second = str(client.get.call_args_list[-1].args[0])
+    assert "after=cursor-page-2" in second
+
+
+@patch("connectors.hubspot_connector.time.sleep", return_value=None)
+@patch("connectors.hubspot_connector.build_pinned_httpx_client")
+@patch("connectors.hubspot_connector.resolve_and_validate_outbound_url")
+def test_detects_pii_in_custom_field(
+    mock_resolve, mock_client_cls, _sleep, hubspot_token
+):
+    mock_resolve.return_value = (None, [ipaddress.ip_address("104.16.0.1")])
+    client = MagicMock()
+    mock_client_cls.return_value = client
+    schema = properties_response("email", "cpf_custom")
+    page = objects_page([synthetic_contact_properties()])
+
+    def _get(url, *args, **kwargs):
+        path = str(url)
+        if "/crm/v3/properties/" in path:
+            return _json_response(schema, path)
+        return _json_response(page, path)
+
+    client.get.side_effect = _get
+    dbm = MagicMock()
+    HubSpotConnector(_cfg(), _mk_scanner_passthrough(), dbm).run()
+
+    assert dbm.save_finding.called
+    file_names = [c.kwargs.get("file_name") for c in dbm.save_finding.call_args_list]
+    assert "cpf_custom" in file_names, (
+        f"custom CPF field must produce a finding; got {file_names}"
+    )
+    paths = [c.kwargs.get("path") for c in dbm.save_finding.call_args_list]
+    assert "contacts" in paths
+    cpf_calls = [
+        c
+        for c in dbm.save_finding.call_args_list
+        if c.kwargs.get("file_name") == "cpf_custom"
+    ]
+    assert cpf_calls
+    assert cpf_calls[0].kwargs.get("sensitivity_level") in ("HIGH", "MEDIUM")
+    assert SYNTHETIC_CPF_FORMATTED in synthetic_contact_properties()["cpf_custom"]
+
+
+@patch("connectors.hubspot_connector.time.sleep", return_value=None)
+@patch("connectors.hubspot_connector.build_pinned_httpx_client")
+@patch("connectors.hubspot_connector.resolve_and_validate_outbound_url")
+def test_uses_url_guard_not_raw_httpx(
+    mock_resolve, mock_client_cls, _sleep, hubspot_token
+):
+    mock_resolve.return_value = (None, [ipaddress.ip_address("104.16.0.1")])
+    client = MagicMock()
+    mock_client_cls.return_value = client
+    client.get.return_value = _json_response(properties_response("email"))
+
+    # Empty objects after schema so run completes
+    calls = {"n": 0}
+
+    def _get(url, *args, **kwargs):
+        calls["n"] += 1
+        path = str(url)
+        if "/properties/" in path:
+            return _json_response(properties_response("email"), path)
+        return _json_response(objects_page([]), path)
+
+    client.get.side_effect = _get
+    HubSpotConnector(_cfg(), _mk_scanner_mock(level="LOW"), MagicMock()).run()
+
+    mock_resolve.assert_called()
+    assert mock_resolve.call_args.kwargs.get("label") == "base_url" or (
+        len(mock_resolve.call_args.args) >= 1
+    )
+    mock_client_cls.assert_called_once()
+    # Must never construct a bare httpx.Client in the connector module path
+    assert "host_to_ips" in mock_client_cls.call_args.kwargs
+
+
+def test_connect_rejects_private_base_url_without_opt_in(hubspot_token):
+    cfg = _cfg(base_url="http://10.0.0.5")
+    with pytest.raises(ValueError, match="#832|private|blocked|base_url"):
+        HubSpotConnector(cfg, _mk_scanner_mock(), MagicMock()).connect()
+
+
+def test_connect_requires_token_env():
+    os.environ.pop(_DEFAULT_TOKEN_ENV, None)
+    with pytest.raises(ValueError, match="HUBSPOT_PRIVATE_APP_TOKEN|Private App"):
+        HubSpotConnector(_cfg(), _mk_scanner_mock(), MagicMock()).connect()
+
+
+@patch("connectors.hubspot_connector.time.sleep")
+@patch("connectors.hubspot_connector.build_pinned_httpx_client")
+@patch("connectors.hubspot_connector.resolve_and_validate_outbound_url")
+def test_rate_limit_429_retries(
+    mock_resolve, mock_client_cls, mock_sleep, hubspot_token
+):
+    mock_resolve.return_value = (None, [ipaddress.ip_address("104.16.0.1")])
+    client = MagicMock()
+    mock_client_cls.return_value = client
+    req = httpx.Request("GET", "https://api.hubapi.com/crm/v3/properties/contacts")
+    limited = httpx.Response(429, headers={"Retry-After": "1"}, request=req)
+    ok = _json_response(properties_response("email"), str(req.url))
+    empty = _json_response(objects_page([]))
+    seq = {"i": 0}
+
+    def _get(url, *args, **kwargs):
+        path = str(url)
+        if "/properties/" in path:
+            if seq["i"] == 0:
+                seq["i"] += 1
+                return limited
+            return ok
+        return empty
+
+    client.get.side_effect = _get
+    HubSpotConnector(_cfg(), _mk_scanner_mock(level="LOW"), MagicMock()).run()
+    mock_sleep.assert_called()
+
+
+def test_registry_resolves_hubspot_type():
+    # Ensure module registered
+    import connectors.hubspot_connector  # noqa: F401
+    from core.connector_registry import connector_for_target
+
+    resolved = connector_for_target({"type": "hubspot", "name": "x"})
+    assert resolved is not None
+    cls, keys = resolved
+    assert cls is HubSpotConnector
+    assert "name" in keys and "type" in keys

--- a/tests/test_ssrf_guard.py
+++ b/tests/test_ssrf_guard.py
@@ -315,6 +315,7 @@ def test_sharepoint_connector_rejects_private_site_url() -> None:
     [
         "connectors/rest_connector.py",
         "connectors/powerbi_connector.py",
+        "connectors/hubspot_connector.py",
         "connectors/sharepoint_connector.py",
         "connectors/webdav_connector.py",
         "connectors/dataverse_connector.py",


### PR DESCRIPTION
## Summary
- Add `connectors/hubspot_connector.py`: property schema discovery (incl. custom fields), object sampling with `after` pagination and 429 backoff, filesystem-style findings (`path=object_type`, `file_name=prop`).
- Wire registry (`type: hubspot`), engine import, Pro tier gate (`connector_hubspot`), and docs examples in `ADDING_CONNECTORS.md` (+ pt-BR).
- Outbound HTTP uses `url_guard` host pinning (#1552) — same posture as REST/Power BI; synthetic BR fixtures only (no real CRM data / no live token).

Closes #1229

## Test plan
- [x] `uv run pytest tests/test_hubspot_connector.py` (discovery, pagination, custom-field CPF, url_guard, 429)
- [x] `tests/test_ssrf_guard.py` + `tests/test_connector_tier_gating.py` updated
- [ ] CI green on this PR
- [ ] No live HubSpot E2E until `HUBSPOT_PRIVATE_APP_TOKEN` is available

**Note:** Local `check-all` hit unrelated Maestro/Pester failures already on the tree (`SudoersLoadOrder`, `test_maestro_scripts` missing `Get-MaestroVersion.ps1` in temp fixtures). HubSpot slice itself is green.