### PR TITLE
fix(security): pin PostgreSQL TCP peer via libpq hostaddr (#1586 slice A)

### DIFF
--- a/connectors/sql_connector.py
+++ b/connectors/sql_connector.py
@@ -340,7 +340,7 @@ def _guard_sql_url_query_params(parsed: Any) -> None:
             )
 
 
-def _guard_sql_connection_url(url: str, target: dict[str, Any]) -> None:
+def _guard_sql_connection_url(url: str, target: dict[str, Any]) -> list[str]:
     """Reject non-global SQL hosts unless allow_private_networks (#1556).
 
     Runs on the *final* URL from ``_build_url`` so both discrete host/port fields
@@ -348,12 +348,15 @@ def _guard_sql_connection_url(url: str, target: dict[str, Any]) -> None:
     **allowlist** (unknown key or unvetted dialect → reject) so peer overrides
     such as ``?host=``, ``?hostaddr=``, ``?odbc_connect=``, or ``?DSN=`` cannot
     bypass the authority check (#1556 / Bugbot).
+
+    Returns the guard-validated pin IP strings (preferred order) for TCP pinning
+    (#1586). Empty list for sqlite / empty URL (no network peer).
     """
     if not url or url.startswith("sqlite:"):
-        return
+        return []
     from sqlalchemy.engine.url import make_url
 
-    from .url_guard import target_allows_private, validate_outbound_url
+    from .url_guard import resolve_and_validate_outbound_url, target_allows_private
 
     allow_private = target_allows_private(target)
     parsed = make_url(url)
@@ -363,13 +366,32 @@ def _guard_sql_connection_url(url: str, target: dict[str, Any]) -> None:
         raise ValueError("host rejected: no host found in SQL connection URL. (#1556)")
     port = parsed.port
     candidate = f"{host}:{port}" if port is not None else host
-    err = validate_outbound_url(
+    err, ips = resolve_and_validate_outbound_url(
         candidate,
         allow_private=allow_private,
         label="host",
     )
     if err:
         raise ValueError(err)
+    return [str(ip) for ip in ips]
+
+
+def _apply_postgres_hostaddr_pin(
+    connect_args: dict[str, Any],
+    pin_ips: list[str],
+) -> dict[str, Any]:
+    """Inject libpq ``hostaddr`` from guard pins (#1586 slice A).
+
+    Keeps SQLAlchemy URL ``host`` as the original hostname for TLS/SCRAM
+    identity. Never put ``hostaddr`` in the URL query (#1556 allowlist).
+    """
+    if not pin_ips:
+        return connect_args
+    from .tcp_pin import format_libpq_hostaddr, primary_pin_str
+
+    out = dict(connect_args)
+    out["hostaddr"] = format_libpq_hostaddr(primary_pin_str(pin_ips))
+    return out
 
 
 def _connect_args_from_target(target: dict[str, Any]) -> dict[str, Any]:
@@ -385,7 +407,8 @@ def _connect_args_from_target(target: dict[str, Any]) -> dict[str, Any]:
 
     Driver → connect_args mapping::
 
-        postgresql[+…]       connect_timeout, options=-c statement_timeout=… (ms)
+        postgresql[+…]       connect_timeout, options=-c statement_timeout=… (ms);
+                             ``hostaddr`` is added separately from guard pins (#1586)
         mysql[+…] / mariadb  connect_timeout
         sqlite               timeout  (lock wait; read_timeout_seconds)
         mssql+pymssql        login_timeout, timeout  (#1297; bare ``mssql`` maps here)
@@ -479,8 +502,11 @@ class SQLConnector:
     def connect(self) -> None:
         ensure_sql_driver_available(self.config.get("driver"))
         url = _build_url(self.config)
-        _guard_sql_connection_url(url, self.config)
+        pin_ips = _guard_sql_connection_url(url, self.config)
         connect_args = _connect_args_from_target(self.config)
+        _, base = _resolve_driver(self.config.get("driver"))
+        if base == "postgresql":
+            connect_args = _apply_postgres_hostaddr_pin(connect_args, pin_ips)
         self.engine = create_engine(url, pool_pre_ping=True, connect_args=connect_args)
         self._table_row_cache = {}
 

--- a/connectors/tcp_pin.py
+++ b/connectors/tcp_pin.py
@@ -1,0 +1,33 @@
+"""TCP peer pin helpers for DB / NoSQL connectors (#1586).
+
+Closes the validate→connect DNS rebinding window by reusing IPs already
+approved by :func:`connectors.url_guard.resolve_and_validate_outbound_url`.
+
+This is **not** an HTTP adapter — each connector applies pins with its own
+driver mechanism (libpq ``hostaddr``, redis ``connection_class``, etc.).
+"""
+
+from __future__ import annotations
+
+import ipaddress
+
+from .url_guard import IpAddr
+
+
+def primary_pin_str(ips: list[IpAddr] | list[str]) -> str:
+    """Return the first preferred pin as a canonical IP string.
+
+    Callers pass the ordered list from ``resolve_and_validate_outbound_url``
+    (already ``_prefer_pin_order``'d — IPv4 before IPv6).
+    """
+    if not ips:
+        raise ValueError("no pin IPs available for TCP peer pinning (#1586)")
+    first = ips[0]
+    if isinstance(first, str):
+        return str(ipaddress.ip_address(first))
+    return str(first)
+
+
+def format_libpq_hostaddr(ip: IpAddr | str) -> str:
+    """Format an address for libpq ``hostaddr`` (no brackets on IPv6)."""
+    return str(ipaddress.ip_address(str(ip)))

--- a/connectors/url_guard.py
+++ b/connectors/url_guard.py
@@ -35,6 +35,10 @@ mongodb_connector / redis_connector (host:port), sql_connector (connection URL h
 #1565: ``PinnedIPHTTPAdapter`` / ``build_pinned_requests_session`` pin
 ``requests`` peers the same way ``PinnedIPTransport`` pins httpx (SharePoint,
 WebDAV).
+
+#1586 (SQL slice A): ``sql_connector`` pins PostgreSQL TCP peers via libpq
+``hostaddr`` in ``connect_args`` (see ``connectors.tcp_pin``) using the same
+resolved IPs from :func:`resolve_and_validate_outbound_url`.
 """
 
 from __future__ import annotations

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -600,7 +600,96 @@ def test_sql_connect_allows_private_with_opt_in_before_engine() -> None:
         )
         connector.connect()
         mock_engine.assert_called_once()
+        call_kw = mock_engine.call_args.kwargs
+        assert call_kw["connect_args"]["hostaddr"] == "10.0.0.8"
         connector.close()
+
+
+def test_sql_postgres_connect_pins_hostaddr_from_guard_dns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1586 slice A: hostname stays in URL; TCP peer is guard-validated hostaddr."""
+    import ipaddress
+    import socket
+
+    from connectors import sql_connector
+
+    def fake_getaddrinfo(host, *args, **kwargs):
+        if host == "db.example.com":
+            return [
+                (
+                    socket.AF_INET,
+                    socket.SOCK_STREAM,
+                    6,
+                    "",
+                    ("1.1.1.1", 0),
+                ),
+                (
+                    socket.AF_INET6,
+                    socket.SOCK_STREAM,
+                    6,
+                    "",
+                    ("2606:4700:4700::1111", 0, 0, 0),
+                ),
+            ]
+        raise socket.gaierror(f"unexpected host {host!r}")
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    # url_guard imports socket at module level for _resolve_host_ips
+    monkeypatch.setattr(
+        "connectors.url_guard.socket.getaddrinfo",
+        fake_getaddrinfo,
+    )
+
+    with (
+        patch.object(sql_connector, "ensure_sql_driver_available"),
+        patch.object(sql_connector, "create_engine") as mock_engine,
+    ):
+        mock_engine.return_value = MagicMock()
+        connector = sql_connector.SQLConnector(
+            {
+                "name": "pg-pin",
+                "driver": "postgresql+psycopg2",
+                "host": "db.example.com",
+                "port": 5432,
+                "user": "u",
+                "pass": "p",
+                "database": "db",
+            },
+            scanner=MagicMock(),
+            db_manager=MagicMock(),
+        )
+        connector.connect()
+        mock_engine.assert_called_once()
+        (url,) = mock_engine.call_args.args
+        call_kw = mock_engine.call_args.kwargs
+        assert "db.example.com" in url
+        assert "1.1.1.1" not in url
+        assert call_kw["connect_args"]["hostaddr"] == "1.1.1.1"
+        assert "hostaddr=" not in url
+        # Prefer IPv4 pin (same order as HTTP #1565 / _prefer_pin_order)
+        assert call_kw["connect_args"]["hostaddr"] != str(
+            ipaddress.IPv6Address("2606:4700:4700::1111")
+        )
+        connector.close()
+
+
+def test_apply_postgres_hostaddr_pin_formats_ipv6() -> None:
+    from connectors.sql_connector import _apply_postgres_hostaddr_pin
+
+    out = _apply_postgres_hostaddr_pin(
+        {"connect_timeout": 5},
+        ["2001:db8::1"],
+    )
+    assert out["hostaddr"] == "2001:db8::1"
+    assert "[" not in out["hostaddr"]
+
+
+def test_tcp_pin_primary_pin_str_empty_raises() -> None:
+    from connectors.tcp_pin import primary_pin_str
+
+    with pytest.raises(ValueError, match="#1586"):
+        primary_pin_str([])
 
 
 def test_sql_guard_rejects_private_peer_via_query_host_override() -> None:


### PR DESCRIPTION
## Summary
- Close the validate→connect DNS rebinding window for **PostgreSQL** by injecting libpq `hostaddr` from guard-validated IPs into SQLAlchemy `connect_args` (#1586 slice A).
- Add thin `connectors/tcp_pin.py` helpers; `_guard_sql_connection_url` now returns pin IPs via `resolve_and_validate_outbound_url`.
- URL hostname stays unchanged (TLS/SCRAM); `hostaddr` is never put in the URL query (#1556 allowlist).

## Out of scope (later slices / issues)
- Redis / Mongo / MySQL / Oracle pinning (slices B–D)
- mssql (#1588)
- Unrelated local workspace drafts (not in this PR)

## Test plan
- [x] `uv run pytest tests/test_sql_connector.py` (includes DNS mock pin + IPv6 hostaddr format)
- [ ] CI green on this PR
- [ ] Manual: postgres target with hostname — connect still works; peer uses pinned IP

Closes nothing yet (partial #1586); tracks https://github.com/DataBoar/data-boar/issues/1586