### PR TITLE
fix(security): pin MongoDB TCP peers via HostResolutionPin (#1586 slice B)

### DIFF
--- a/connectors/mongodb_connector.py
+++ b/connectors/mongodb_connector.py
@@ -52,6 +52,7 @@ class MongoDBConnector:
         self.detection_config = detection_config or {}
         self._client = None
         self._tls_enabled = False
+        self._dns_pin = None
 
     def connect(self) -> None:
         if not _MONGO_AVAILABLE:
@@ -65,10 +66,13 @@ class MongoDBConnector:
             )
         host = self.config.get("host", "localhost")
         port = int(self.config.get("port", 27017))
-        from .url_guard import target_allows_private, validate_outbound_url
+        from .tcp_pin import HostResolutionPin
+        from .url_guard import resolve_and_validate_outbound_url, target_allows_private
 
         # SSRF guard (#1559): bare host:port — do not use tcp:// (not in allowlist).
-        err = validate_outbound_url(
+        # Capture validated IPs for TCP pin (#1586) so pymongo cannot re-resolve
+        # to a different peer after the guard.
+        err, pin_ips = resolve_and_validate_outbound_url(
             f"{host}:{port}",
             allow_private=target_allows_private(self.config),
             label="host",
@@ -101,8 +105,17 @@ class MongoDBConnector:
             # require / prefer → encrypted without full CA/hostname verify.
             if sslmode_posture in ("require", "prefer", "allow"):
                 client_kwargs["tlsAllowInvalidCertificates"] = True
-        self._client = MongoClient(uri, **client_kwargs)
-        self._db = self._client[database]
+        # Pin before MongoClient so pool connect/reconnect uses guard IPs;
+        # URI keeps hostname for TLS server_hostname (#1586).
+        pin = HostResolutionPin(str(host), [str(ip) for ip in pin_ips]).install()
+        self._dns_pin = pin
+        try:
+            self._client = MongoClient(uri, **client_kwargs)
+            self._db = self._client[database]
+        except Exception:
+            pin.release()
+            self._dns_pin = None
+            raise
 
     def close(self) -> None:
         if self._client:
@@ -110,8 +123,12 @@ class MongoDBConnector:
                 self._client.close()
             except Exception:
                 # Best-effort close: ignore client shutdown errors.
-                return
+                pass
             self._client = None
+        pin = getattr(self, "_dns_pin", None)
+        if pin is not None:
+            pin.release()
+            self._dns_pin = None
 
     def run(self) -> None:
         from utils.audit_log_display import audit_log_target_label

--- a/connectors/tcp_pin.py
+++ b/connectors/tcp_pin.py
@@ -4,14 +4,26 @@ Closes the validate→connect DNS rebinding window by reusing IPs already
 approved by :func:`connectors.url_guard.resolve_and_validate_outbound_url`.
 
 This is **not** an HTTP adapter — each connector applies pins with its own
-driver mechanism (libpq ``hostaddr``, redis ``connection_class``, etc.).
+driver mechanism (libpq ``hostaddr``, redis ``connection_class``,
+pymongo via :class:`HostResolutionPin`, etc.).
 """
 
 from __future__ import annotations
 
 import ipaddress
+import socket
+import threading
+from typing import Any
 
 from .url_guard import IpAddr
+
+# pymongo sync pool calls ``socket.getaddrinfo`` on every connect/reconnect
+# (#1586). While pins are registered, matching hostnames resolve only to
+# guard-validated addresses (hostname string stays in the URI for TLS SNI).
+_PIN_LOCK = threading.RLock()
+_HOST_PINS: dict[str, tuple[str, ...]] = {}
+_ORIG_GETADDRINFO = socket.getaddrinfo
+_GETADDRINFO_PATCHED = False
 
 
 def primary_pin_str(ips: list[IpAddr] | list[str]) -> str:
@@ -31,3 +43,128 @@ def primary_pin_str(ips: list[IpAddr] | list[str]) -> str:
 def format_libpq_hostaddr(ip: IpAddr | str) -> str:
     """Format an address for libpq ``hostaddr`` (no brackets on IPv6)."""
     return str(ipaddress.ip_address(str(ip)))
+
+
+def normalize_pin_hostname(host: str) -> str:
+    """Canonical key for pin maps (lowercase, strip trailing dot)."""
+    return (host or "").strip().rstrip(".").lower()
+
+
+def _is_ip_literal(host: str) -> bool:
+    try:
+        ipaddress.ip_address(host)
+        return True
+    except ValueError:
+        return False
+
+
+def _synthetic_addrinfo(
+    pins: tuple[str, ...],
+    port: Any,
+    family: int,
+    type_: int,
+    proto: int,
+) -> list[tuple[Any, ...]]:
+    """Build ``getaddrinfo``-shaped results for *pins* only."""
+    port_i = 0 if port is None else int(port)
+    socktype = type_ if type_ else socket.SOCK_STREAM
+    out: list[tuple[Any, ...]] = []
+    for pin in pins:
+        ip = ipaddress.ip_address(pin)
+        if family not in (0, socket.AF_UNSPEC):
+            if family == socket.AF_INET and ip.version != 4:
+                continue
+            if family == socket.AF_INET6 and ip.version != 6:
+                continue
+        if ip.version == 4:
+            af = socket.AF_INET
+            sockaddr: tuple[Any, ...] = (str(ip), port_i)
+        else:
+            af = socket.AF_INET6
+            sockaddr = (str(ip), port_i, 0, 0)
+        out.append((af, socktype, proto or 0, "", sockaddr))
+    if not out:
+        raise socket.gaierror(socket.EAI_NONAME, "Name or service not known")
+    return out
+
+
+def _pinned_getaddrinfo(
+    host: Any,
+    port: Any,
+    family: int = 0,
+    type: int = 0,
+    proto: int = 0,
+    flags: int = 0,
+) -> list[tuple[Any, ...]]:
+    host_s = host.decode("idna") if isinstance(host, bytes) else str(host)
+    key = normalize_pin_hostname(host_s)
+    with _PIN_LOCK:
+        pins = _HOST_PINS.get(key)
+    if pins:
+        return _synthetic_addrinfo(pins, port, family, type, proto)
+    return _ORIG_GETADDRINFO(host, port, family, type, proto, flags)
+
+
+def _ensure_getaddrinfo_patched() -> None:
+    global _GETADDRINFO_PATCHED
+    with _PIN_LOCK:
+        if not _GETADDRINFO_PATCHED:
+            socket.getaddrinfo = _pinned_getaddrinfo  # type: ignore[assignment]
+            _GETADDRINFO_PATCHED = True
+
+
+def _maybe_unpatch_getaddrinfo() -> None:
+    global _GETADDRINFO_PATCHED
+    with _PIN_LOCK:
+        if _GETADDRINFO_PATCHED and not _HOST_PINS:
+            socket.getaddrinfo = _ORIG_GETADDRINFO  # type: ignore[assignment]
+            _GETADDRINFO_PATCHED = False
+
+
+class HostResolutionPin:
+    """Pin DNS for one hostname to guard-validated IPs for a client lifetime.
+
+    Used by MongoDB (#1586): pymongo keeps the hostname for TLS
+    ``server_hostname`` but resolves TCP peers via ``socket.getaddrinfo``.
+    Register before ``MongoClient(...)`` and :meth:`release` on close.
+    """
+
+    def __init__(self, hostname: str, pin_ips: list[IpAddr] | list[str]) -> None:
+        if not hostname:
+            raise ValueError("hostname required for TCP peer pinning (#1586)")
+        if _is_ip_literal(hostname.strip().rstrip(".")):
+            # Literal peer — no DNS rebinding window; no patch needed.
+            self._key: str | None = None
+            self._active = False
+            return
+        if not pin_ips:
+            raise ValueError("no pin IPs available for TCP peer pinning (#1586)")
+        normalized = tuple(str(ipaddress.ip_address(str(ip))) for ip in pin_ips)
+        self._key = normalize_pin_hostname(hostname)
+        self._pins = normalized
+        self._active = False
+
+    def install(self) -> HostResolutionPin:
+        if self._key is None:
+            return self
+        with _PIN_LOCK:
+            _HOST_PINS[self._key] = self._pins
+            self._active = True
+        _ensure_getaddrinfo_patched()
+        return self
+
+    def release(self) -> None:
+        if not self._active or self._key is None:
+            return
+        with _PIN_LOCK:
+            current = _HOST_PINS.get(self._key)
+            if current == self._pins:
+                _HOST_PINS.pop(self._key, None)
+            self._active = False
+        _maybe_unpatch_getaddrinfo()
+
+    def __enter__(self) -> HostResolutionPin:
+        return self.install()
+
+    def __exit__(self, *exc: object) -> None:
+        self.release()

--- a/connectors/url_guard.py
+++ b/connectors/url_guard.py
@@ -39,6 +39,10 @@ WebDAV).
 #1586 (SQL slice A): ``sql_connector`` pins PostgreSQL TCP peers via libpq
 ``hostaddr`` in ``connect_args`` (see ``connectors.tcp_pin``) using the same
 resolved IPs from :func:`resolve_and_validate_outbound_url`.
+
+#1586 (Mongo slice): ``mongodb_connector`` keeps the hostname in the URI for
+TLS ``server_hostname`` and pins DNS via :class:`connectors.tcp_pin.HostResolutionPin`
+(pymongo sync resolves with ``socket.getaddrinfo`` on each pool connect).
 """
 
 from __future__ import annotations

--- a/tests/test_mongodb_connector.py
+++ b/tests/test_mongodb_connector.py
@@ -78,14 +78,17 @@ def test_mongodb_connect_pins_dns_keeps_hostname_in_uri(
 ) -> None:
     """#1586 — URI keeps hostname (TLS identity); getaddrinfo only returns pin."""
     import ipaddress
+    from urllib.parse import urlsplit
 
-    def fake_resolve(host: str):
-        if host == "mongo.example.com":
+    host = "mongo.example.com"
+
+    def fake_resolve(name: str):
+        if name == host:
             return [
                 ipaddress.ip_address("1.1.1.1"),
                 ipaddress.ip_address("2606:4700:4700::1111"),
             ]
-        raise OSError(f"unexpected {host}")
+        raise OSError(f"unexpected {name}")
 
     monkeypatch.setattr(
         "connectors.url_guard._resolve_host_ips",
@@ -99,9 +102,7 @@ def test_mongodb_connect_pins_dns_keeps_hostname_in_uri(
             captured["uri"] = uri
             captured["kwargs"] = kwargs
             # While client is "open", pool would call getaddrinfo(hostname).
-            infos = socket.getaddrinfo(
-                "mongo.example.com", 27017, type=socket.SOCK_STREAM
-            )
+            infos = socket.getaddrinfo(host, 27017, type=socket.SOCK_STREAM)
             captured["peer_ips"] = {info[4][0] for info in infos}
 
         def __getitem__(self, name: str) -> MagicMock:
@@ -118,7 +119,7 @@ def test_mongodb_connect_pins_dns_keeps_hostname_in_uri(
     conn = MongoDBConnector(
         {
             "name": "m",
-            "host": "mongo.example.com",
+            "host": host,
             "port": 27017,
             "database": "app",
             "user": "u",
@@ -130,8 +131,8 @@ def test_mongodb_connect_pins_dns_keeps_hostname_in_uri(
     try:
         conn.connect()
         uri = str(captured["uri"])
-        assert "mongo.example.com" in uri
-        assert "1.1.1.1" not in uri
+        # Authority hostname (not substring) — CodeQL-safe and precise vs pin IP.
+        assert urlsplit(uri).hostname == host
         assert captured["peer_ips"] == {"1.1.1.1", "2606:4700:4700::1111"}
     finally:
         conn.close()

--- a/tests/test_mongodb_connector.py
+++ b/tests/test_mongodb_connector.py
@@ -1,13 +1,15 @@
-"""MongoDB connector SSRF guard (#1559)."""
+"""MongoDB connector SSRF guard (#1559) and TCP peer pin (#1586)."""
 
 from __future__ import annotations
 
 import importlib.util
+import socket
 from unittest.mock import MagicMock
 
 import pytest
 
 from connectors.mongodb_connector import MongoDBConnector
+from connectors.tcp_pin import HostResolutionPin
 from connectors.url_guard import OPT_IN_KEY
 
 
@@ -48,3 +50,90 @@ def test_mongodb_connect_allows_private_with_opt_in() -> None:
         pass
     finally:
         conn.close()
+
+
+def test_host_resolution_pin_returns_only_guard_ips() -> None:
+    """#1586 — pinned hostname cannot rebind to an unvalidated A record."""
+    with HostResolutionPin("db.example.com", ["1.1.1.1"]):
+        infos = socket.getaddrinfo("db.example.com", 27017, type=socket.SOCK_STREAM)
+        addrs = {info[4][0] for info in infos}
+        assert addrs == {"1.1.1.1"}
+        # Unrelated hosts still use the real resolver path (literal IP).
+        socket.getaddrinfo("1.0.0.1", 80, type=socket.SOCK_STREAM)
+
+
+def test_host_resolution_pin_noop_for_ip_literal() -> None:
+    pin = HostResolutionPin("1.1.1.1", ["1.1.1.1"])
+    pin.install()
+    try:
+        assert pin._key is None
+        assert pin._active is False
+    finally:
+        pin.release()
+
+
+@pytest.mark.skipif(not _has_module("pymongo"), reason="pymongo not installed")
+def test_mongodb_connect_pins_dns_keeps_hostname_in_uri(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1586 — URI keeps hostname (TLS identity); getaddrinfo only returns pin."""
+    import ipaddress
+
+    def fake_resolve(host: str):
+        if host == "mongo.example.com":
+            return [
+                ipaddress.ip_address("1.1.1.1"),
+                ipaddress.ip_address("2606:4700:4700::1111"),
+            ]
+        raise OSError(f"unexpected {host}")
+
+    monkeypatch.setattr(
+        "connectors.url_guard._resolve_host_ips",
+        fake_resolve,
+    )
+
+    captured: dict[str, object] = {}
+
+    class FakeMongoClient:
+        def __init__(self, uri: str, **kwargs: object) -> None:
+            captured["uri"] = uri
+            captured["kwargs"] = kwargs
+            # While client is "open", pool would call getaddrinfo(hostname).
+            infos = socket.getaddrinfo(
+                "mongo.example.com", 27017, type=socket.SOCK_STREAM
+            )
+            captured["peer_ips"] = {info[4][0] for info in infos}
+
+        def __getitem__(self, name: str) -> MagicMock:
+            return MagicMock()
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "connectors.mongodb_connector.MongoClient",
+        FakeMongoClient,
+    )
+
+    conn = MongoDBConnector(
+        {
+            "name": "m",
+            "host": "mongo.example.com",
+            "port": 27017,
+            "database": "app",
+            "user": "u",
+            "pass": "p",
+        },
+        scanner=MagicMock(),
+        db_manager=MagicMock(),
+    )
+    try:
+        conn.connect()
+        uri = str(captured["uri"])
+        assert "mongo.example.com" in uri
+        assert "1.1.1.1" not in uri
+        assert captured["peer_ips"] == {"1.1.1.1", "2606:4700:4700::1111"}
+    finally:
+        conn.close()
+
+    assert conn._dns_pin is None


### PR DESCRIPTION
## Summary
- Close the validate→connect DNS rebinding window for **MongoDB** by pinning `socket.getaddrinfo` for the configured hostname to guard-validated IPs (`HostResolutionPin` in `connectors/tcp_pin.py`).
- Keep the original hostname in the Mongo URI so TLS `server_hostname` / cert checks stay bound to the name (pymongo has no first-class TCP pin API).
- Release the pin on `close()` so pool reconnects stay covered for the client lifetime; IP literals are a no-op.

## Out of scope
- Redis / MySQL / Oracle / mssql pinning (later #1586 slices; mssql also #1588)
- `docs/plans` / `PLANS_HUB`

## Test plan
- [x] `uv run pytest tests/test_mongodb_connector.py` (5 passed)
- [x] CI green on this PR

Tracks https://github.com/DataBoar/data-boar/issues/1586 (partial; postgres slice already on `main` via #1589)