### PR TITLE
docs(connectors): HubSpot Private App setup lessons (#1229)

### DIFF
--- a/docs/ADDING_CONNECTORS.md
+++ b/docs/ADDING_CONNECTORS.md
@@ -340,10 +340,43 @@ Managed SaaS CRM (Pro tier). Discovers **all** property names (including custom 
 where CPF/CNPJ often hide), then samples objects with pagination and rate-limit backoff.
 
 - **Module:** `connectors/hubspot_connector.py`
-- **Auth:** Private App Token via env ``HUBSPOT_PRIVATE_APP_TOKEN`` (never commit tokens).
-  Read-only scopes: `crm.objects.*.read` + `crm.schemas.*.read` for contacts/companies/deals.
+- **Auth:** Private App Token via env (never commit tokens). See setup below.
 - **SSRF:** All outbound HTTP uses `connectors/url_guard.py` host pinning (#1552) — same
   posture as the REST connector.
+
+### Create the Private App token (HubSpot UI, as of 2026-08)
+
+1. In HubSpot: **Settings → Integrations → Private Apps**.
+   If the product UI has moved Private Apps under **Legacy Apps**, open that entry and
+   continue — the credential type is still a **Private** app token (not a public OAuth app).
+2. Create (or open) an app and choose **Private** (not **Public**).
+3. **Do not** use a **Service Key** for Data Boar. Service keys are broader credentials
+   without the granular CRM scopes this connector expects.
+4. Under scopes, enable **exactly** these six **read** scopes (no write, no webhooks):
+
+   | Scope | Why |
+   | ----- | --- |
+   | `crm.objects.contacts.read` | Sample contact property **values** |
+   | `crm.objects.companies.read` | Sample company property **values** |
+   | `crm.objects.deals.read` | Sample deal property **values** |
+   | `crm.schemas.contacts.read` | Discover contact property **names** (incl. custom) |
+   | `crm.schemas.companies.read` | Discover company property **names** (incl. custom) |
+   | `crm.schemas.deals.read` | Discover deal property **names** (incl. custom) |
+
+5. Create the token and store it only in an environment variable / secret manager — never
+   in committed YAML.
+
+**Least privilege:** the connector is **read-only and on-demand** (no HubSpot webhooks).
+`crm.objects.*.read` returns field values; `crm.schemas.*.read` is required for property
+**discovery**. Without the schema scopes, custom fields (where CPF/CNPJ often live) are
+never listed, so they are never sampled — a silent coverage gap.
+
+> **Env var name must match exactly.** The connector reads
+> ``HUBSPOT_PRIVATE_APP_TOKEN`` by default (or the name you set in ``token_from_env`` /
+> ``auth.token_from_env``). A *similar but wrong* name (for example ``HUBSPOT_ACCESS_TOKEN``)
+> does **not** raise a clear “wrong variable” error: ``connect()`` still runs, the API
+> returns **401**, and findings stay empty — the most common setup friction observed when
+> wiring this connector. Confirm the exported name before debugging scopes.
 
 Config example:
 

--- a/docs/ADDING_CONNECTORS.pt_BR.md
+++ b/docs/ADDING_CONNECTORS.pt_BR.md
@@ -340,10 +340,43 @@ CRM SaaS gerenciado (tier Pro). Descobre **todos** os nomes de propriedade (incl
 customizados onde CPF/CNPJ costumam aparecer) e amostra objetos com paginação e backoff em 429.
 
 - **Módulo:** `connectors/hubspot_connector.py`
-- **Auth:** Private App Token via env ``HUBSPOT_PRIVATE_APP_TOKEN`` (nunca commitar o token).
-  Escopos somente leitura: `crm.objects.*.read` + `crm.schemas.*.read` para contacts/companies/deals.
+- **Auth:** Private App Token via env (nunca commitar o token). Ver setup abaixo.
 - **SSRF:** Todo HTTP de saída usa pin de host em `connectors/url_guard.py` (#1552) — mesma
   postura do conector REST.
+
+### Criar o token de Private App (UI HubSpot, em 2026-08)
+
+1. No HubSpot: **Settings → Integrations → Private Apps**.
+   Se a UI tiver movido Private Apps para **Legacy Apps**, abra esse caminho e siga —
+   o tipo de credencial continua sendo token de app **Private** (não app OAuth público).
+2. Crie (ou abra) um app e escolha **Private** (não **Public**).
+3. **Não** use **Service Key** no Data Boar. Service key é credencial ampla demais, sem os
+   escopos CRM granulares que este conector espera.
+4. Em escopos, marque **exatamente** estes seis escopos **.read** (sem write, sem webhooks):
+
+   | Escopo | Para quê |
+   | ------ | -------- |
+   | `crm.objects.contacts.read` | Amostrar **valores** de propriedades de contato |
+   | `crm.objects.companies.read` | Amostrar **valores** de propriedades de empresa |
+   | `crm.objects.deals.read` | Amostrar **valores** de propriedades de negócio |
+   | `crm.schemas.contacts.read` | Descobrir **nomes** de propriedades de contato (incl. custom) |
+   | `crm.schemas.companies.read` | Descobrir **nomes** de propriedades de empresa (incl. custom) |
+   | `crm.schemas.deals.read` | Descobrir **nomes** de propriedades de negócio (incl. custom) |
+
+5. Gere o token e guarde só em variável de ambiente / cofre de segredos — nunca em YAML
+   commitado.
+
+**Least privilege:** o conector é **somente leitura e sob demanda** (sem webhooks HubSpot).
+`crm.objects.*.read` devolve valores de campo; `crm.schemas.*.read` é obrigatório para a
+**descoberta** de propriedades. Sem os escopos de schema, campos customizados (onde CPF/CNPJ
+costumam ficar) nem entram na lista — e portanto nunca são amostrados (lacuna silenciosa).
+
+> **O nome da env var tem que bater exatamente.** Por padrão o conector lê
+> ``HUBSPOT_PRIVATE_APP_TOKEN`` (ou o nome em ``token_from_env`` /
+> ``auth.token_from_env``). Um nome *parecido mas errado* (por exemplo ``HUBSPOT_ACCESS_TOKEN``)
+> **não** gera erro claro de “variável errada”: o ``connect()`` roda, a API responde **401**,
+> e não há findings — a maior fonte de atrito ao configurar este conector. Confirme o nome
+> exportado antes de depurar escopos.
 
 Exemplo de config:
 


### PR DESCRIPTION
## Summary
- Enrich HubSpot section in `docs/ADDING_CONNECTORS.md` + `.pt_BR.md`: Private App UI path (incl. Legacy Apps), six read scopes, no Service Key / no webhooks, least-privilege rationale for objects vs schemas.
- Call out the env-var naming pitfall: wrong sibling name (e.g. `HUBSPOT_ACCESS_TOKEN`) yields silent **401**, not a clear misconfig error.

Context: follow-up to the shipped connector in #1229 / PR #1587 (no Closes — issue already closed).

## Test plan
- [x] `uv run pytest tests/test_docs_pt_br_locale.py`
- [x] `./scripts/lint-only.sh`
- [x] CI green
- [x] Live HubSpot `.run()` validated in operator session (aggregates only; token not in docs)