### PR TITLE
fix(security): Redis TCP peer pin via connection_class (#1586)

### DIFF
--- a/connectors/redis_connector.py
+++ b/connectors/redis_connector.py
@@ -4,8 +4,8 @@ Register as type 'redis'. Install: pip install redis
 Config target: type: database, driver: redis, host, port, (optional password).
 """
 
-from typing import Any
 import json
+from typing import Any
 
 try:
     import redis
@@ -21,6 +21,7 @@ except ImportError:
     RedisResponseError = Exception  # type: ignore[misc, assignment]
     RedisTimeoutError = Exception  # type: ignore[misc, assignment]
 
+from connectors.inventory_details import build_redis_inventory_details
 from core.connector_registry import register
 from core.crypto_audit import (
     collect_redis_crypto_facts,
@@ -28,7 +29,6 @@ from core.crypto_audit import (
     infer_controls_from_identifiers,
     resolve_nosql_tls_connect_options,
 )
-from connectors.inventory_details import build_redis_inventory_details
 from core.suggested_review import (
     SUGGESTED_REVIEW_PATTERN,
     augment_low_id_like_for_persist,
@@ -70,10 +70,13 @@ class RedisConnector:
             )
         host = self.config.get("host", "localhost")
         port = int(self.config.get("port", 6379))
-        from .url_guard import target_allows_private, validate_outbound_url
+        from .tcp_pin import is_ip_literal, make_pinned_redis_connection_class
+        from .url_guard import resolve_and_validate_outbound_url, target_allows_private
 
         # SSRF guard (#1559): bare host:port — do not use tcp:// (not in allowlist).
-        err = validate_outbound_url(
+        # Capture validated IPs for TCP pin (#1586) so redis-py cannot re-resolve
+        # to a different peer after the guard (Connection._connect → getaddrinfo).
+        err, pin_ips = resolve_and_validate_outbound_url(
             f"{host}:{port}",
             allow_private=target_allows_private(self.config),
             label="host",
@@ -87,7 +90,17 @@ class RedisConnector:
             self.config
         )
         self._tls_enabled = bool(tls_enabled)
-        client_kwargs: dict[str, Any] = {
+        from redis.connection import Connection, ConnectionPool, SSLConnection
+
+        base_cls: type = SSLConnection if tls_enabled else Connection
+        # Hostname stays on the connection for TLS server_hostname; pin TCP peers
+        # via connection_class (#1586). IP literals have no DNS rebinding window.
+        if is_ip_literal(str(host)):
+            connection_class = base_cls
+        else:
+            connection_class = make_pinned_redis_connection_class(base_cls, pin_ips)
+        pool_kwargs: dict[str, Any] = {
+            "connection_class": connection_class,
             "host": host,
             "port": port,
             "password": password or None,
@@ -95,11 +108,9 @@ class RedisConnector:
             "socket_connect_timeout": connect_s,
             "socket_timeout": read_s,
         }
-        if tls_enabled:
-            client_kwargs["ssl"] = True
-            if cert_reqs is not None:
-                client_kwargs["ssl_cert_reqs"] = cert_reqs
-        self._client = redis.Redis(**client_kwargs)
+        if tls_enabled and cert_reqs is not None:
+            pool_kwargs["ssl_cert_reqs"] = cert_reqs
+        self._client = redis.Redis(connection_pool=ConnectionPool(**pool_kwargs))
 
     def close(self) -> None:
         if self._client:

--- a/connectors/redis_connector.py
+++ b/connectors/redis_connector.py
@@ -9,6 +9,9 @@ from typing import Any
 
 try:
     import redis
+    from redis.connection import Connection as _RedisConnection
+    from redis.connection import ConnectionPool as _RedisConnectionPool
+    from redis.connection import SSLConnection as _RedisSSLConnection
     from redis.exceptions import ConnectionError as RedisConnectionError
     from redis.exceptions import ResponseError as RedisResponseError
     from redis.exceptions import TimeoutError as RedisTimeoutError
@@ -17,6 +20,9 @@ try:
 except ImportError:
     _REDIS_AVAILABLE = False
     redis = None
+    _RedisConnection = None  # type: ignore[misc, assignment]
+    _RedisConnectionPool = None  # type: ignore[misc, assignment]
+    _RedisSSLConnection = None  # type: ignore[misc, assignment]
     RedisConnectionError = Exception  # type: ignore[misc, assignment]
     RedisResponseError = Exception  # type: ignore[misc, assignment]
     RedisTimeoutError = Exception  # type: ignore[misc, assignment]
@@ -90,9 +96,27 @@ class RedisConnector:
             self.config
         )
         self._tls_enabled = bool(tls_enabled)
-        from redis.connection import Connection, ConnectionPool, SSLConnection
+        # Connection types come from the optional redis import at module load.
+        # CI matrices without the nosql extra still run crypto tests that stub
+        # ``redis`` + ``_REDIS_AVAILABLE`` — fall back to Redis(**kwargs) then
+        # (no pin subclass without real connection classes).
+        if _RedisConnectionPool is None or _RedisConnection is None:
+            client_kwargs: dict[str, Any] = {
+                "host": host,
+                "port": port,
+                "password": password or None,
+                "decode_responses": True,
+                "socket_connect_timeout": connect_s,
+                "socket_timeout": read_s,
+            }
+            if tls_enabled:
+                client_kwargs["ssl"] = True
+                if cert_reqs is not None:
+                    client_kwargs["ssl_cert_reqs"] = cert_reqs
+            self._client = redis.Redis(**client_kwargs)
+            return
 
-        base_cls: type = SSLConnection if tls_enabled else Connection
+        base_cls: type = _RedisSSLConnection if tls_enabled else _RedisConnection
         # Hostname stays on the connection for TLS server_hostname; pin TCP peers
         # via connection_class (#1586). IP literals have no DNS rebinding window.
         if is_ip_literal(str(host)):
@@ -110,7 +134,7 @@ class RedisConnector:
         }
         if tls_enabled and cert_reqs is not None:
             pool_kwargs["ssl_cert_reqs"] = cert_reqs
-        self._client = redis.Redis(connection_pool=ConnectionPool(**pool_kwargs))
+        self._client = redis.Redis(connection_pool=_RedisConnectionPool(**pool_kwargs))
 
     def close(self) -> None:
         if self._client:

--- a/connectors/tcp_pin.py
+++ b/connectors/tcp_pin.py
@@ -66,6 +66,11 @@ def _is_ip_literal(host: str) -> bool:
         return False
 
 
+def is_ip_literal(host: str) -> bool:
+    """True when *host* is a literal IPv4/IPv6 address (no DNS rebinding window)."""
+    return _is_ip_literal((host or "").strip().rstrip("."))
+
+
 def _synthetic_addrinfo(
     pins: tuple[str, ...],
     port: Any,
@@ -205,3 +210,78 @@ class HostResolutionPin:
 
     def __exit__(self, *exc: object) -> None:
         self.release()
+
+
+def _redis_peer_connect(conn: Any, pins: tuple[str, ...]) -> socket.socket:
+    """Mimic ``redis.connection.Connection._connect`` against fixed peer IPs.
+
+    Keeps ``conn.host`` unchanged so TLS ``server_hostname`` stays the
+    configured hostname (#1586 Redis slice).
+    """
+    err: OSError | None = None
+    for res in _synthetic_addrinfo(
+        pins,
+        conn.port,
+        getattr(conn, "socket_type", 0) or 0,
+        socket.SOCK_STREAM,
+        0,
+    ):
+        family, socktype, proto, _canon, socket_address = res
+        sock: socket.socket | None = None
+        try:
+            sock = socket.socket(family, socktype, proto)
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            if getattr(conn, "socket_keepalive", False):
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+                opts = getattr(conn, "socket_keepalive_options", None) or {}
+                for k, v in opts.items():
+                    sock.setsockopt(socket.IPPROTO_TCP, k, v)
+            sock.settimeout(getattr(conn, "socket_connect_timeout", None))
+            sock.connect(socket_address)
+            sock.settimeout(getattr(conn, "socket_timeout", None))
+            return sock
+        except OSError as exc:
+            err = exc
+            if sock is not None:
+                try:
+                    sock.shutdown(socket.SHUT_RDWR)
+                except OSError:
+                    pass
+                sock.close()
+    if err is not None:
+        raise err
+    raise OSError("pinned TCP peer list empty (#1586)")
+
+
+def make_pinned_redis_connection_class(
+    base_cls: type,
+    pin_ips: list[IpAddr] | list[str],
+) -> type:
+    """Return a ``connection_class`` that dials only *pin_ips* (#1586 Redis).
+
+    ``base_cls`` is typically ``redis.connection.Connection`` or
+    ``SSLConnection``. Hostname remains on the connection for TLS SNI;
+    TCP peers are the guard-validated addresses only.
+    """
+    if not pin_ips:
+        raise ValueError("no pin IPs available for TCP peer pinning (#1586)")
+    pins = tuple(str(ipaddress.ip_address(str(ip))) for ip in pin_ips)
+
+    class PinnedRedisConnection(base_cls):  # type: ignore[misc,valid-type]
+        """Connection that never re-resolves hostname after the SSRF guard."""
+
+        def _connect(self) -> socket.socket:
+            sock = _redis_peer_connect(self, pins)
+            wrap = getattr(self, "_wrap_socket_with_ssl", None)
+            if wrap is None:
+                return sock
+            try:
+                return wrap(sock)
+            except OSError:
+                sock.close()
+                raise
+
+    base_name = getattr(base_cls, "__name__", "Connection")
+    PinnedRedisConnection.__name__ = f"Pinned{base_name}"
+    PinnedRedisConnection.__qualname__ = PinnedRedisConnection.__name__
+    return PinnedRedisConnection

--- a/connectors/tcp_pin.py
+++ b/connectors/tcp_pin.py
@@ -277,7 +277,9 @@ def make_pinned_redis_connection_class(
                 return sock
             try:
                 return wrap(sock)
-            except OSError:
+            except Exception:
+                # Match redis-py SSLConnection: close plain sock on any wrap
+                # failure (OSError, RedisError, ssl.SSLError, …) (#1586 Bugbot).
                 sock.close()
                 raise
 

--- a/connectors/url_guard.py
+++ b/connectors/url_guard.py
@@ -43,6 +43,10 @@ resolved IPs from :func:`resolve_and_validate_outbound_url`.
 #1586 (Mongo slice): ``mongodb_connector`` keeps the hostname in the URI for
 TLS ``server_hostname`` and pins DNS via :class:`connectors.tcp_pin.HostResolutionPin`
 (pymongo sync resolves with ``socket.getaddrinfo`` on each pool connect).
+
+#1586 (Redis slice): ``redis_connector`` keeps ``host`` for TLS SNI and pins
+TCP peers via ``make_pinned_redis_connection_class`` (redis-py
+``Connection._connect`` would otherwise re-``getaddrinfo`` the hostname).
 """
 
 from __future__ import annotations

--- a/tests/test_crypto_controls_audit.py
+++ b/tests/test_crypto_controls_audit.py
@@ -436,7 +436,9 @@ def test_redis_connect_honors_tls_and_cert_reqs() -> None:
     fake_redis = MagicMock()
     fake_client = MagicMock()
     fake_redis.Redis.return_value = fake_client
-    # Real ConnectionPool path: patch only redis.Redis factory; pool is built in-module.
+    # Patch Redis factory; when redis package is installed the connector builds a
+    # real ConnectionPool (pin path). Without the nosql extra (some CI cells),
+    # it falls back to Redis(**kwargs) with ssl= True.
     with patch("connectors.redis_connector._REDIS_AVAILABLE", True):
         with patch("connectors.redis_connector.redis", fake_redis):
             with patch(
@@ -446,14 +448,17 @@ def test_redis_connect_honors_tls_and_cert_reqs() -> None:
                 connector.connect()
     assert connector._tls_enabled is True
     assert fake_redis.Redis.called
-    pool = fake_redis.Redis.call_args.kwargs.get("connection_pool")
-    assert pool is not None
-    from redis.connection import SSLConnection
+    kwargs = fake_redis.Redis.call_args.kwargs
+    pool = kwargs.get("connection_pool")
+    if pool is not None:
+        from redis.connection import SSLConnection
 
-    assert issubclass(pool.connection_class, SSLConnection)
-    # Hostname kept for TLS SNI; cert_reqs forwarded into pool connection kwargs.
-    assert pool.connection_kwargs.get("host") == "localhost"
-    assert pool.connection_kwargs.get("ssl_cert_reqs") == "required"
+        assert issubclass(pool.connection_class, SSLConnection)
+        assert pool.connection_kwargs.get("host") == "localhost"
+        assert pool.connection_kwargs.get("ssl_cert_reqs") == "required"
+    else:
+        assert kwargs.get("ssl") is True
+        assert kwargs.get("ssl_cert_reqs") == "required"
 
 
 def test_mongodb_connector_saves_crypto_audit_when_flag_on() -> None:

--- a/tests/test_crypto_controls_audit.py
+++ b/tests/test_crypto_controls_audit.py
@@ -434,14 +434,26 @@ def test_redis_connect_honors_tls_and_cert_reqs() -> None:
     }
     connector = RedisConnector(target, MagicMock(), MagicMock())
     fake_redis = MagicMock()
-    fake_redis.Redis.return_value = MagicMock()
+    fake_client = MagicMock()
+    fake_redis.Redis.return_value = fake_client
+    # Real ConnectionPool path: patch only redis.Redis factory; pool is built in-module.
     with patch("connectors.redis_connector._REDIS_AVAILABLE", True):
         with patch("connectors.redis_connector.redis", fake_redis):
-            connector.connect()
+            with patch(
+                "connectors.url_guard._resolve_host_ips",
+                return_value=[__import__("ipaddress").ip_address("127.0.0.1")],
+            ):
+                connector.connect()
     assert connector._tls_enabled is True
-    kwargs = fake_redis.Redis.call_args.kwargs
-    assert kwargs.get("ssl") is True
-    assert kwargs.get("ssl_cert_reqs") == "required"
+    assert fake_redis.Redis.called
+    pool = fake_redis.Redis.call_args.kwargs.get("connection_pool")
+    assert pool is not None
+    from redis.connection import SSLConnection
+
+    assert issubclass(pool.connection_class, SSLConnection)
+    # Hostname kept for TLS SNI; cert_reqs forwarded into pool connection kwargs.
+    assert pool.connection_kwargs.get("host") == "localhost"
+    assert pool.connection_kwargs.get("ssl_cert_reqs") == "required"
 
 
 def test_mongodb_connector_saves_crypto_audit_when_flag_on() -> None:

--- a/tests/test_redis_connector_sampling.py
+++ b/tests/test_redis_connector_sampling.py
@@ -141,3 +141,115 @@ def test_redis_connect_allows_private_with_opt_in() -> None:
         pass
     finally:
         conn.close()
+
+
+def test_make_pinned_redis_connection_class_dials_only_pin_ips(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1586 — redis connection_class never getaddrinfo(hostname) for TCP peer."""
+    if not _has_module("redis"):
+        pytest.skip("redis not installed")
+    import socket
+
+    from redis.connection import Connection
+
+    from connectors.tcp_pin import make_pinned_redis_connection_class
+
+    host = "redis.example.com"
+    seen_connect: list[tuple[str, int]] = []
+    real_getaddrinfo = socket.getaddrinfo
+
+    def boom_getaddrinfo(name, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if name == host:
+            raise AssertionError(
+                "pinned class must not resolve hostname via getaddrinfo"
+            )
+        return real_getaddrinfo(name, *args, **kwargs)
+
+    monkeypatch.setattr(socket, "getaddrinfo", boom_getaddrinfo)
+
+    class FakeSock:
+        def setsockopt(self, *a: object, **k: object) -> None:
+            return None
+
+        def settimeout(self, *a: object, **k: object) -> None:
+            return None
+
+        def connect(self, address: tuple[object, ...]) -> None:
+            seen_connect.append((str(address[0]), int(address[1])))
+
+        def shutdown(self, *a: object, **k: object) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(socket, "socket", lambda *a, **k: FakeSock())
+
+    cls = make_pinned_redis_connection_class(Connection, ["1.1.1.1"])
+    conn = cls(host=host, port=6379, socket_connect_timeout=1, socket_timeout=1)
+    sock = conn._connect()
+    assert sock is not None
+    assert seen_connect == [("1.1.1.1", 6379)]
+    assert conn.host == host
+
+
+def test_redis_connect_pins_hostname_keeps_host_for_tls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1586 — pool host stays hostname; connection_class is pin subclass."""
+    if not _has_module("redis"):
+        pytest.skip("redis not installed")
+    import ipaddress
+
+    from redis.connection import Connection, SSLConnection
+
+    host = "redis.example.com"
+
+    def fake_resolve(name: str):
+        if name == host:
+            return [
+                ipaddress.ip_address("1.1.1.1"),
+                ipaddress.ip_address("2606:4700:4700::1111"),
+            ]
+        raise OSError(f"unexpected {name}")
+
+    monkeypatch.setattr("connectors.url_guard._resolve_host_ips", fake_resolve)
+
+    captured: dict[str, object] = {}
+
+    class FakeRedis:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            captured["kwargs"] = kwargs
+            pool = kwargs.get("connection_pool")
+            captured["pool"] = pool
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr("connectors.redis_connector.redis.Redis", FakeRedis)
+
+    conn = RedisConnector(
+        {
+            "name": "r",
+            "host": host,
+            "port": 6379,
+            "tls": True,
+            "ssl_cert_reqs": "required",
+            "connect_timeout_seconds": 1,
+            "read_timeout_seconds": 1,
+        },
+        scanner=_mk_scanner(),
+        db_manager=MagicMock(),
+    )
+    conn.connect()
+    try:
+        pool = captured["pool"]
+        assert pool is not None
+        assert pool.connection_kwargs["host"] == host  # type: ignore[index]
+        assert issubclass(pool.connection_class, SSLConnection)  # type: ignore[union-attr]
+        assert pool.connection_class is not SSLConnection  # type: ignore[union-attr]
+        assert pool.connection_class is not Connection  # type: ignore[union-attr]
+        assert pool.connection_kwargs.get("ssl_cert_reqs") == "required"  # type: ignore[union-attr]
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary
- Add `make_pinned_redis_connection_class` — redis-py `connection_class` dials only IPs from `resolve_and_validate_outbound_url`.
- Wire `redis_connector` through `ConnectionPool`; hostname stays for TLS SNI; IP literals skip the pin subclass.
- Tests: pin dials only guard IPs; connect keeps hostname + SSLConnection subclass.

Closes part of #1586 (Redis slice). Next: MySQL/Oracle; mssql → #1588.

## Test plan
- [x] `./scripts/quick-test.sh --path tests/test_redis_connector_sampling.py`
- [x] crypto redis TLS test updated for pool path
- [ ] CI green on this PR