### PR TITLE
fix(security): MySQL TCP peer pin via HostResolutionPin (#1586)

### DIFF
--- a/connectors/sql_connector.py
+++ b/connectors/sql_connector.py
@@ -394,6 +394,30 @@ def _apply_postgres_hostaddr_pin(
     return out
 
 
+def _install_mysql_host_resolution_pin(
+    url: str,
+    pin_ips: list[str],
+) -> Any:
+    """Pin pymysql DNS for *url* hostname to *pin_ips* (#1586 MySQL slice).
+
+    pymysql uses ``socket.create_connection((host, port))`` and TLS
+    ``server_hostname=self.host``, so we keep the URL hostname and restrict
+    ``getaddrinfo`` via :class:`~connectors.tcp_pin.HostResolutionPin`.
+    Returns the pin object (caller must ``release`` on close) or ``None``
+    when there is nothing to pin (no host / empty pins).
+    """
+    if not pin_ips:
+        return None
+    from sqlalchemy.engine.url import make_url
+
+    from .tcp_pin import HostResolutionPin
+
+    host = make_url(url).host
+    if not host:
+        return None
+    return HostResolutionPin(str(host), pin_ips).install()
+
+
 def _connect_args_from_target(target: dict[str, Any]) -> dict[str, Any]:
     """
     Build SQLAlchemy ``connect_args`` from target timeouts (config loader merges global + per-target).
@@ -409,11 +433,12 @@ def _connect_args_from_target(target: dict[str, Any]) -> dict[str, Any]:
 
         postgresql[+…]       connect_timeout, options=-c statement_timeout=… (ms);
                              ``hostaddr`` is added separately from guard pins (#1586)
-        mysql[+…] / mariadb  connect_timeout
+        mysql[+…] / mariadb  connect_timeout; DNS pinned via HostResolutionPin (#1586)
         sqlite               timeout  (lock wait; read_timeout_seconds)
         mssql+pymssql        login_timeout, timeout  (#1297; bare ``mssql`` maps here)
         mssql+pyodbc         timeout only  (pyodbc.connect accepts ``timeout``; not login_timeout)
         oracle+oracledb      tcp_connect_timeout  (oracledb; not connect_timeout)
+                             TCP pin deferred — thin client resolves in native code
         other                connect_timeout  (best-effort)
     """
     connect_s = int(target.get("connect_timeout_seconds", 25))
@@ -489,6 +514,7 @@ class SQLConnector:
         self.engine = None
         # Compatibility shim: legacy tests/helpers may still patch this attribute.
         self._connection = None
+        self._dns_pin = None
         self._sql_sampling_audit_key: str | None = None
         self._table_row_cache: dict[tuple[str, str], int | None] = {}
         self._sample_statement_timeout_ms = _resolve_sample_statement_timeout_ms(
@@ -507,7 +533,18 @@ class SQLConnector:
         _, base = _resolve_driver(self.config.get("driver"))
         if base == "postgresql":
             connect_args = _apply_postgres_hostaddr_pin(connect_args, pin_ips)
-        self.engine = create_engine(url, pool_pre_ping=True, connect_args=connect_args)
+        dns_pin = None
+        if base in ("mysql", "mariadb"):
+            dns_pin = _install_mysql_host_resolution_pin(url, pin_ips)
+        try:
+            self.engine = create_engine(
+                url, pool_pre_ping=True, connect_args=connect_args
+            )
+        except Exception:
+            if dns_pin is not None:
+                dns_pin.release()
+            raise
+        self._dns_pin = dns_pin
         self._table_row_cache = {}
 
     def close(self) -> None:
@@ -520,6 +557,11 @@ class SQLConnector:
         if self.engine:
             self.engine.dispose()
             self.engine = None
+        # Release after dispose so pool reconnects during teardown still see pins.
+        pin = getattr(self, "_dns_pin", None)
+        if pin is not None:
+            pin.release()
+            self._dns_pin = None
 
     def discover(self) -> list[dict[str, Any]]:
         """Return list of {schema, table, columns: [{name, type}]}. For Oracle, skips system schemas."""

--- a/connectors/sql_connector.py
+++ b/connectors/sql_connector.py
@@ -394,26 +394,56 @@ def _apply_postgres_hostaddr_pin(
     return out
 
 
+def _mysql_family_python_dns_pin_supported(drivername: str) -> bool:
+    """True when the DBAPI resolves TCP peers via Python ``getaddrinfo`` (#1586).
+
+    ``HostResolutionPin`` only intercepts Python ``socket.getaddrinfo``. Drivers
+    such as ``mariadb+mariadbconnector``, ``mysql+mysqldb``, and
+    ``mysql+mysqlconnector`` resolve in native code — installing the pin would
+    be a no-op and falsely suggest peers are pinned for the engine lifetime.
+    """
+    if not drivername or "+" not in drivername:
+        return False
+    return drivername.rsplit("+", 1)[-1].lower() == "pymysql"
+
+
 def _install_mysql_host_resolution_pin(
     url: str,
     pin_ips: list[str],
+    *,
+    drivername: str,
 ) -> Any:
     """Pin pymysql DNS for *url* hostname to *pin_ips* (#1586 MySQL slice).
 
     pymysql uses ``socket.create_connection((host, port))`` and TLS
     ``server_hostname=self.host``, so we keep the URL hostname and restrict
     ``getaddrinfo`` via :class:`~connectors.tcp_pin.HostResolutionPin`.
-    Returns the pin object (caller must ``release`` on close) or ``None``
-    when there is nothing to pin (no host / empty pins).
+
+    Fail-closed for MySQL/MariaDB drivers that resolve outside Python (Security
+    Agent MEDIUM on #1597): raise rather than install a no-op pin. Literal IP
+    hosts need no pin (no DNS rebinding window).
+
+    Returns the pin object (caller must ``release`` on close) or ``None`` when
+    there is nothing to pin.
     """
-    if not pin_ips:
-        return None
     from sqlalchemy.engine.url import make_url
 
-    from .tcp_pin import HostResolutionPin
+    from .tcp_pin import HostResolutionPin, is_ip_literal
 
     host = make_url(url).host
     if not host:
+        return None
+    if is_ip_literal(str(host)):
+        return None
+    if not _mysql_family_python_dns_pin_supported(drivername):
+        raise ValueError(
+            "TCP peer pin (#1586) requires a Python-socket MySQL/MariaDB driver "
+            f"(…+pymysql); got {drivername!r}. Use mysql+pymysql or "
+            "mariadb+pymysql, or a literal IP host (no DNS rebinding). "
+            "Native connectors (mariadbconnector, mysqldb, mysqlconnector) "
+            "resolve outside Python getaddrinfo — same class as Oracle thin."
+        )
+    if not pin_ips:
         return None
     return HostResolutionPin(str(host), pin_ips).install()
 
@@ -433,7 +463,8 @@ def _connect_args_from_target(target: dict[str, Any]) -> dict[str, Any]:
 
         postgresql[+…]       connect_timeout, options=-c statement_timeout=… (ms);
                              ``hostaddr`` is added separately from guard pins (#1586)
-        mysql[+…] / mariadb  connect_timeout; DNS pinned via HostResolutionPin (#1586)
+        mysql+pymysql /       connect_timeout; DNS pinned via HostResolutionPin (#1586)
+        mariadb+pymysql       only — other mysql/mariadb drivers fail-closed on hostname
         sqlite               timeout  (lock wait; read_timeout_seconds)
         mssql+pymssql        login_timeout, timeout  (#1297; bare ``mssql`` maps here)
         mssql+pyodbc         timeout only  (pyodbc.connect accepts ``timeout``; not login_timeout)
@@ -530,12 +561,14 @@ class SQLConnector:
         url = _build_url(self.config)
         pin_ips = _guard_sql_connection_url(url, self.config)
         connect_args = _connect_args_from_target(self.config)
-        _, base = _resolve_driver(self.config.get("driver"))
+        drivername, base = _resolve_driver(self.config.get("driver"))
         if base == "postgresql":
             connect_args = _apply_postgres_hostaddr_pin(connect_args, pin_ips)
         dns_pin = None
         if base in ("mysql", "mariadb"):
-            dns_pin = _install_mysql_host_resolution_pin(url, pin_ips)
+            dns_pin = _install_mysql_host_resolution_pin(
+                url, pin_ips, drivername=drivername
+            )
         try:
             self.engine = create_engine(
                 url, pool_pre_ping=True, connect_args=connect_args

--- a/connectors/tcp_pin.py
+++ b/connectors/tcp_pin.py
@@ -66,6 +66,11 @@ def _is_ip_literal(host: str) -> bool:
         return False
 
 
+def is_ip_literal(host: str) -> bool:
+    """True when *host* is a literal IPv4/IPv6 address (no DNS rebinding window)."""
+    return _is_ip_literal((host or "").strip().rstrip("."))
+
+
 def _synthetic_addrinfo(
     pins: tuple[str, ...],
     port: Any,

--- a/connectors/url_guard.py
+++ b/connectors/url_guard.py
@@ -44,10 +44,10 @@ resolved IPs from :func:`resolve_and_validate_outbound_url`.
 TLS ``server_hostname`` and pins DNS via :class:`connectors.tcp_pin.HostResolutionPin`
 (pymongo sync resolves with ``socket.getaddrinfo`` on each pool connect).
 
-#1586 (MySQL slice): ``sql_connector`` (mysql/mariadb + pymysql) keeps the URL
-hostname for TLS ``server_hostname`` and installs
-:class:`~connectors.tcp_pin.HostResolutionPin` for the engine lifetime
-(pymysql ``socket.create_connection`` → ``getaddrinfo``).
+#1586 (MySQL slice): ``sql_connector`` pins **only** ``…+pymysql`` drivers via
+:class:`~connectors.tcp_pin.HostResolutionPin` (Python ``getaddrinfo``). Native
+MySQL/MariaDB connectors fail-closed on hostname targets; Oracle thin remains
+deferred (native resolve).
 """
 
 from __future__ import annotations

--- a/connectors/url_guard.py
+++ b/connectors/url_guard.py
@@ -43,6 +43,11 @@ resolved IPs from :func:`resolve_and_validate_outbound_url`.
 #1586 (Mongo slice): ``mongodb_connector`` keeps the hostname in the URI for
 TLS ``server_hostname`` and pins DNS via :class:`connectors.tcp_pin.HostResolutionPin`
 (pymongo sync resolves with ``socket.getaddrinfo`` on each pool connect).
+
+#1586 (MySQL slice): ``sql_connector`` (mysql/mariadb + pymysql) keeps the URL
+hostname for TLS ``server_hostname`` and installs
+:class:`~connectors.tcp_pin.HostResolutionPin` for the engine lifetime
+(pymysql ``socket.create_connection`` → ``getaddrinfo``).
 """
 
 from __future__ import annotations

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -789,6 +789,140 @@ def test_sql_mysql_pin_released_when_create_engine_fails(
     assert getattr(connector, "_dns_pin", None) is None
 
 
+def test_sql_mariadb_default_driver_fails_closed_without_python_pin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1586 / #1597 Security: bare mariadb → mariadbconnector must not no-op pin."""
+    import socket
+
+    from connectors import sql_connector
+
+    host = "mariadb.example.com"
+
+    def fake_getaddrinfo(name, *args, **kwargs):
+        if name == host:
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.1.1.1", 0))]
+        raise socket.gaierror(f"unexpected host {name!r}")
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr(
+        "connectors.url_guard.socket.getaddrinfo",
+        fake_getaddrinfo,
+    )
+
+    with patch.object(sql_connector, "ensure_sql_driver_available"):
+        connector = sql_connector.SQLConnector(
+            {
+                "name": "mdb",
+                "driver": "mariadb",
+                "host": host,
+                "port": 3306,
+                "user": "u",
+                "pass": "p",
+                "database": "db",
+            },
+            scanner=MagicMock(),
+            db_manager=MagicMock(),
+        )
+        with pytest.raises(ValueError, match="#1586|pymysql|mariadbconnector"):
+            connector.connect()
+
+
+def test_sql_mysql_mysqldb_fails_closed_without_python_pin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1586 — mysql+mysqldb uses libc resolve; refuse hostname targets."""
+    import socket
+
+    from connectors import sql_connector
+
+    host = "mysql-native.example.com"
+
+    def fake_getaddrinfo(name, *args, **kwargs):
+        if name == host:
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.1.1.1", 0))]
+        raise socket.gaierror(f"unexpected host {name!r}")
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr(
+        "connectors.url_guard.socket.getaddrinfo",
+        fake_getaddrinfo,
+    )
+
+    with patch.object(sql_connector, "ensure_sql_driver_available"):
+        connector = sql_connector.SQLConnector(
+            {
+                "name": "mysqldb",
+                "driver": "mysql+mysqldb",
+                "host": host,
+                "port": 3306,
+                "user": "u",
+                "pass": "p",
+                "database": "db",
+            },
+            scanner=MagicMock(),
+            db_manager=MagicMock(),
+        )
+        with pytest.raises(ValueError, match="#1586|pymysql"):
+            connector.connect()
+
+
+def test_sql_mariadb_pymysql_installs_host_resolution_pin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1586 — explicit mariadb+pymysql is pin-capable like mysql+pymysql."""
+    import socket
+    from urllib.parse import urlsplit
+
+    from connectors import sql_connector
+
+    host = "mariadb-py.example.com"
+
+    def fake_getaddrinfo(name, *args, **kwargs):
+        if name == host:
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.1.1.1", 0))]
+        raise socket.gaierror(f"unexpected host {name!r}")
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr(
+        "connectors.url_guard.socket.getaddrinfo",
+        fake_getaddrinfo,
+    )
+
+    with (
+        patch.object(sql_connector, "ensure_sql_driver_available"),
+        patch.object(sql_connector, "create_engine") as mock_engine,
+    ):
+        mock_engine.return_value = MagicMock()
+        connector = sql_connector.SQLConnector(
+            {
+                "name": "mdb-py",
+                "driver": "mariadb+pymysql",
+                "host": host,
+                "port": 3306,
+                "user": "u",
+                "pass": "p",
+                "database": "db",
+            },
+            scanner=MagicMock(),
+            db_manager=MagicMock(),
+        )
+        connector.connect()
+        assert urlsplit(mock_engine.call_args.args[0]).hostname == host
+        assert connector._dns_pin is not None
+        connector.close()
+
+
+def test_mysql_family_python_dns_pin_supported() -> None:
+    from connectors.sql_connector import _mysql_family_python_dns_pin_supported
+
+    assert _mysql_family_python_dns_pin_supported("mysql+pymysql") is True
+    assert _mysql_family_python_dns_pin_supported("mariadb+pymysql") is True
+    assert _mysql_family_python_dns_pin_supported("mariadb+mariadbconnector") is False
+    assert _mysql_family_python_dns_pin_supported("mysql+mysqldb") is False
+    assert _mysql_family_python_dns_pin_supported("mysql") is False
+
+
 def test_apply_postgres_hostaddr_pin_formats_ipv6() -> None:
     from connectors.sql_connector import _apply_postgres_hostaddr_pin
 

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -678,6 +678,117 @@ def test_sql_postgres_connect_pins_hostaddr_from_guard_dns(
         connector.close()
 
 
+def test_sql_mysql_connect_installs_host_resolution_pin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1586 MySQL: URL hostname kept; getaddrinfo only returns guard pins."""
+    import socket
+    from urllib.parse import urlsplit
+
+    from connectors import sql_connector
+
+    host = "mysql.example.com"
+
+    def fake_getaddrinfo(name, *args, **kwargs):
+        if name == host:
+            return [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.1.1.1", 0)),
+                (
+                    socket.AF_INET6,
+                    socket.SOCK_STREAM,
+                    6,
+                    "",
+                    ("2606:4700:4700::1111", 0, 0, 0),
+                ),
+            ]
+        raise socket.gaierror(f"unexpected host {name!r}")
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr(
+        "connectors.url_guard.socket.getaddrinfo",
+        fake_getaddrinfo,
+    )
+
+    with (
+        patch.object(sql_connector, "ensure_sql_driver_available"),
+        patch.object(sql_connector, "create_engine") as mock_engine,
+    ):
+        mock_engine.return_value = MagicMock()
+        connector = sql_connector.SQLConnector(
+            {
+                "name": "mysql-pin",
+                "driver": "mysql",
+                "host": host,
+                "port": 3306,
+                "user": "u",
+                "pass": "p",
+                "database": "db",
+            },
+            scanner=MagicMock(),
+            db_manager=MagicMock(),
+        )
+        connector.connect()
+        mock_engine.assert_called_once()
+        (url,) = mock_engine.call_args.args
+        assert urlsplit(url).hostname == host
+        peers = {info[4][0] for info in socket.getaddrinfo(host, 3306)}
+        assert peers == {"1.1.1.1", "2606:4700:4700::1111"}
+        assert connector._dns_pin is not None
+        connector.close()
+        assert getattr(connector, "_dns_pin", None) is None
+
+
+def test_sql_mysql_pin_released_when_create_engine_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1586 — failed create_engine must not leave a process-wide DNS pin."""
+    import socket
+
+    import connectors.tcp_pin as tcp_pin
+    from connectors import sql_connector
+    from connectors.tcp_pin import normalize_pin_hostname
+
+    host = "mysql-fail.example.com"
+    key = normalize_pin_hostname(host)
+
+    def fake_getaddrinfo(name, *args, **kwargs):
+        if name == host:
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.1.1.1", 0))]
+        raise socket.gaierror(f"unexpected host {name!r}")
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr(
+        "connectors.url_guard.socket.getaddrinfo",
+        fake_getaddrinfo,
+    )
+
+    with (
+        patch.object(sql_connector, "ensure_sql_driver_available"),
+        patch.object(
+            sql_connector,
+            "create_engine",
+            side_effect=RuntimeError("boom"),
+        ),
+    ):
+        connector = sql_connector.SQLConnector(
+            {
+                "name": "mysql-fail",
+                "driver": "mysql+pymysql",
+                "host": host,
+                "port": 3306,
+                "user": "u",
+                "pass": "p",
+                "database": "db",
+            },
+            scanner=MagicMock(),
+            db_manager=MagicMock(),
+        )
+        with pytest.raises(RuntimeError, match="boom"):
+            connector.connect()
+    assert key not in tcp_pin._HOST_PINS
+    assert getattr(connector, "_dns_pin", None) is None
+
+
 def test_apply_postgres_hostaddr_pin_formats_ipv6() -> None:
     from connectors.sql_connector import _apply_postgres_hostaddr_pin
 


### PR DESCRIPTION
## Summary
- MySQL/MariaDB: install `HostResolutionPin` around `create_engine` (pymysql `create_connection` → `getaddrinfo`; TLS keeps URL hostname).
- Release pin after `engine.dispose()`; release on `create_engine` failure.
- **Oracle deferred:** thin client resolves in native code — Python `socket.getaddrinfo` patch would not cover it; needs IP rewrite + `ssl_server_cert_dn` (or similar) in a later slice.
- mssql still → #1588.

Related: #1586 · Redis pin #1596 (CI fix in flight).

## Test plan
- [x] `pytest tests/test_sql_connector.py -k mysql_connect_installs or mysql_pin_released`
- [ ] CI green