### PR TITLE
fix(security): MSSQL TCP peer pin via URL host rewrite (#1586)

### DIFF
--- a/connectors/sql_connector.py
+++ b/connectors/sql_connector.py
@@ -292,6 +292,8 @@ _SQL_SAFE_QUERY_KEYS_BY_DIALECT: dict[str, frozenset[str]] = {
             "timeout",
             "login timeout",
             "login_timeout",
+            # MS ODBC 18+: TLS name when SERVER= is a pin IP (#1586 slice E).
+            "hostnameincertificate",
         }
     ),
     "oracle": frozenset(
@@ -448,6 +450,63 @@ def _install_mysql_host_resolution_pin(
     return HostResolutionPin(str(host), pin_ips).install()
 
 
+# FreeTDS / ODBC resolve outside Python getaddrinfo — pin by rewriting URL host
+# to a guard-validated IP (#1586 slice E). HostResolutionPin would be a no-op.
+_MSSQL_URL_IP_PIN_DBAPIS = frozenset({"pymssql", "pyodbc"})
+
+
+def _mssql_dbapi_name(drivername: str) -> str:
+    """Return the SQLAlchemy DBAPI suffix for an mssql drivername."""
+    raw = (drivername or "").strip().lower()
+    if "+" in raw:
+        return raw.rsplit("+", 1)[-1]
+    return "pymssql"
+
+
+def _apply_mssql_tcp_peer_pin(url: str, pin_ips: list[str]) -> str:
+    """Rewrite MSSQL URL host to a guard-pinned IP (#1586 slice E).
+
+    ``pymssql`` (FreeTDS ``dbopen``) and ``pyodbc`` resolve TCP peers in native
+    code, so :class:`~connectors.tcp_pin.HostResolutionPin` cannot close the
+    validate→connect rebinding window. Putting the validated IP in the URL
+    authority forces the dial peer to the guard-approved address.
+
+    For ``mssql+pyodbc``, inject ``HostNameInCertificate`` with the original
+    hostname when missing so MS ODBC 18+ can verify TLS against the DNS name
+    while connecting to the pin IP. pymssql/FreeTDS has no equivalent knob;
+    encrypting to an IP may need an IP SAN or ``TrustServerCertificate``.
+
+    Literal IP hosts are unchanged. Unsupported mssql DBAPIs fail-closed.
+    """
+    from sqlalchemy.engine.url import make_url
+
+    from .tcp_pin import is_ip_literal, primary_pin_str
+
+    if not pin_ips:
+        return url
+    u = make_url(url)
+    dbapi = _mssql_dbapi_name(u.drivername or "")
+    if dbapi not in _MSSQL_URL_IP_PIN_DBAPIS:
+        raise ValueError(
+            "TCP peer pin (#1586) for mssql requires pymssql or pyodbc "
+            f"(got {u.drivername!r}). Use mssql+pymssql, mssql+pyodbc, or a "
+            "literal IP host (no DNS rebinding)."
+        )
+    host = u.host
+    if not host:
+        return url
+    host_s = str(host)
+    if is_ip_literal(host_s):
+        return url
+    pin = primary_pin_str(pin_ips)
+    new_u = u.set(host=pin)
+    if dbapi == "pyodbc" and not is_ip_literal(host_s):
+        q = dict(new_u.query)
+        if "hostnameincertificate" not in {str(k).lower() for k in q}:
+            new_u = new_u.update_query_dict({"HostNameInCertificate": host_s})
+    return new_u.render_as_string(hide_password=False)
+
+
 def _connect_args_from_target(target: dict[str, Any]) -> dict[str, Any]:
     """
     Build SQLAlchemy ``connect_args`` from target timeouts (config loader merges global + per-target).
@@ -466,8 +525,10 @@ def _connect_args_from_target(target: dict[str, Any]) -> dict[str, Any]:
         mysql+pymysql /       connect_timeout; DNS pinned via HostResolutionPin (#1586)
         mariadb+pymysql       only — other mysql/mariadb drivers fail-closed on hostname
         sqlite               timeout  (lock wait; read_timeout_seconds)
-        mssql+pymssql        login_timeout, timeout  (#1297; bare ``mssql`` maps here)
-        mssql+pyodbc         timeout only  (pyodbc.connect accepts ``timeout``; not login_timeout)
+        mssql+pymssql        login_timeout, timeout  (#1297; bare ``mssql`` maps here);
+                             TCP pin via URL host→guard IP (#1586 slice E; FreeTDS)
+        mssql+pyodbc         timeout only  (pyodbc.connect accepts ``timeout``; not login_timeout);
+                             TCP pin via URL host→IP + HostNameInCertificate (#1586)
         oracle+oracledb      tcp_connect_timeout  (oracledb; not connect_timeout)
                              TCP pin deferred — thin client resolves in native code
         other                connect_timeout  (best-effort)
@@ -569,6 +630,8 @@ class SQLConnector:
             dns_pin = _install_mysql_host_resolution_pin(
                 url, pin_ips, drivername=drivername
             )
+        if base == "mssql":
+            url = _apply_mssql_tcp_peer_pin(url, pin_ips)
         try:
             self.engine = create_engine(
                 url, pool_pre_ping=True, connect_args=connect_args

--- a/connectors/tcp_pin.py
+++ b/connectors/tcp_pin.py
@@ -5,7 +5,7 @@ approved by :func:`connectors.url_guard.resolve_and_validate_outbound_url`.
 
 This is **not** an HTTP adapter — each connector applies pins with its own
 driver mechanism (libpq ``hostaddr``, redis ``connection_class``,
-pymongo via :class:`HostResolutionPin`, etc.).
+pymongo via :class:`HostResolutionPin`, MSSQL URL host→IP rewrite, etc.).
 """
 
 from __future__ import annotations

--- a/connectors/url_guard.py
+++ b/connectors/url_guard.py
@@ -52,6 +52,12 @@ TCP peers via ``make_pinned_redis_connection_class`` (redis-py
 :class:`~connectors.tcp_pin.HostResolutionPin` (Python ``getaddrinfo``). Native
 MySQL/MariaDB connectors fail-closed on hostname targets; Oracle thin remains
 deferred (native resolve).
+
+#1586 (MSSQL slice E): ``sql_connector`` rewrites the URL hostname to a
+guard-pinned IP for ``mssql+pymssql`` (FreeTDS) and ``mssql+pyodbc`` (plus
+``HostNameInCertificate`` for ODBC 18+ TLS). Native resolve cannot use
+:class:`~connectors.tcp_pin.HostResolutionPin`; other mssql DBAPIs fail-closed
+on hostname targets.
 """
 
 from __future__ import annotations

--- a/tests/pester/SudoersLoadOrder.Tests.ps1
+++ b/tests/pester/SudoersLoadOrder.Tests.ps1
@@ -11,13 +11,16 @@ Describe 'labop-sudoers-load-order-lib (maestro#6)' {
                 [Parameter(Mandatory = $true)][string]$BashSnippet
             )
             $libUnix = ($script:Lib -replace '\\', '/')
-            $scriptBody = @(
+            # Normalize CRLF → LF: pwsh here-strings may embed `r; bash then treats
+            # `path`r` as a missing file (first classify → other; last line often OK).
+            $scriptBody = (@(
                 'set -euo pipefail'
                 ". '$libUnix'"
                 $BashSnippet
-            ) -join "`n"
+            ) -join "`n") -replace "`r`n", "`n" -replace "`r", "`n"
             $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("sudoers-lib-" + [guid]::NewGuid().ToString('n') + '.sh')
-            [System.IO.File]::WriteAllText($tmp, $scriptBody)
+            $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+            [System.IO.File]::WriteAllText($tmp, $scriptBody, $utf8NoBom)
             try {
                 $out = & bash "$tmp" 2>&1
                 return [pscustomobject]@{

--- a/tests/test_maestro_scripts.py
+++ b/tests/test_maestro_scripts.py
@@ -323,7 +323,9 @@ def test_sync_working_tree_uses_explicit_sync_result() -> None:
     )
     assert "$syncOk = $false" in text
     assert "if ($syncOk)" in text
-    assert "if ($LASTEXITCODE -eq 0) {" in text
+    # Capture rsync exit before any later ssh overwrites $LASTEXITCODE (#969 / syncOk).
+    assert "$exitCode = $LASTEXITCODE" in text
+    assert "if ($exitCode -eq 0) {" in text
     assert "Hash check OK" in text
     assert "return [bool]$syncOk" in text
     assert "--exclude='data-boar-*.tar'" in text
@@ -924,6 +926,11 @@ def _run_maestro_build_decision(pwsh: str, personas: list[str], tmp: Path) -> bo
 
     shutil.copyfile(maestro_src, mdir / "Maestro.ps1")
     shutil.copyfile(maestro / "core" / "MaestroPaths.ps1", mdir / "MaestroPaths.ps1")
+    # maestro#21: Maestro.ps1 dotsources Get-MaestroVersion.ps1 before Lab-MaestroCommon.
+    shutil.copyfile(
+        maestro / "core" / "Get-MaestroVersion.ps1",
+        mdir / "Get-MaestroVersion.ps1",
+    )
     marker = mdir / "build_invoked.marker"
     (mdir / "Build-ContainerArtefact.ps1").write_text(
         'Set-Content -LiteralPath "$PSScriptRoot/build_invoked.marker" -Value built\n',
@@ -936,9 +943,17 @@ def _run_maestro_build_decision(pwsh: str, personas: list[str], tmp: Path) -> bo
     )
     (mdir / "Lab-MaestroCommon.ps1").write_text(
         "function Reset-LabOpStatus { param($Node, $RunMarker) }\n"
-        "function Invoke-LabopGateReadiness { param($Node, [switch]$Deep) return $true }\n",
+        "function Invoke-LabopGateReadiness { param($Node, [switch]$Deep) return $true }\n"
+        "function Assert-MaestroBenchParams { param($BenchRunId, $BenchHealthUrl) }\n"
+        "function Assert-MaestroInventoryNodePaths { param($Inventory) }\n",
         encoding="utf-8",
     )
+    (mdir / "Test-MaestroOtelPreflight.ps1").write_text(
+        "# stub for lab-free #950 harness\n",
+        encoding="utf-8",
+    )
+    # Self-integrity warn path reads VERSION under maestro root (= tmp).
+    (tmp / "VERSION").write_text("0.0.0-test\n", encoding="utf-8")
     inv = {"lab_members": [{"hostname": "h1", "user": "u", "personas": personas}]}
     (data_dir / "inventory.json").write_text(json.dumps(inv), encoding="utf-8")
 

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -923,6 +923,189 @@ def test_mysql_family_python_dns_pin_supported() -> None:
     assert _mysql_family_python_dns_pin_supported("mysql") is False
 
 
+def test_apply_mssql_tcp_peer_pin_rewrites_hostname_to_ip() -> None:
+    """#1586 slice E — FreeTDS dials the guard IP; no HostResolutionPin."""
+    from connectors.sql_connector import _apply_mssql_tcp_peer_pin
+
+    out = _apply_mssql_tcp_peer_pin(
+        "mssql+pymssql://u:p@sql.example.com:1433/db",
+        ["1.1.1.1", "2606:4700:4700::1111"],
+    )
+    assert out == "mssql+pymssql://u:p@1.1.1.1:1433/db"
+
+
+def test_apply_mssql_tcp_peer_pin_formats_ipv6() -> None:
+    from connectors.sql_connector import _apply_mssql_tcp_peer_pin
+
+    out = _apply_mssql_tcp_peer_pin(
+        "mssql+pymssql://u:p@sql.example.com:1433/db",
+        ["2606:4700:4700::1111"],
+    )
+    assert out == "mssql+pymssql://u:p@[2606:4700:4700::1111]:1433/db"
+
+
+def test_apply_mssql_tcp_peer_pin_pyodbc_injects_hostname_in_certificate() -> None:
+    from connectors.sql_connector import _apply_mssql_tcp_peer_pin
+    from sqlalchemy.engine.url import make_url
+
+    out = _apply_mssql_tcp_peer_pin(
+        "mssql+pyodbc://u:p@sql.example.com:1433/db"
+        "?driver=ODBC+Driver+18+for+SQL+Server",
+        ["1.1.1.1"],
+    )
+    parsed = make_url(out)
+    assert parsed.host == "1.1.1.1"
+    q = {str(k).lower(): v for k, v in parsed.query.items()}
+    assert q["hostnameincertificate"] == "sql.example.com"
+    assert "driver" in q
+
+
+def test_apply_mssql_tcp_peer_pin_preserves_existing_hostname_in_certificate() -> None:
+    from connectors.sql_connector import _apply_mssql_tcp_peer_pin
+    from sqlalchemy.engine.url import make_url
+
+    out = _apply_mssql_tcp_peer_pin(
+        "mssql+pyodbc://u:p@sql.example.com:1433/db"
+        "?HostNameInCertificate=custom.cert.name",
+        ["1.1.1.1"],
+    )
+    parsed = make_url(out)
+    assert parsed.host == "1.1.1.1"
+    q = {str(k).lower(): v for k, v in parsed.query.items()}
+    assert q["hostnameincertificate"] == "custom.cert.name"
+
+
+def test_apply_mssql_tcp_peer_pin_literal_ip_noop() -> None:
+    from connectors.sql_connector import _apply_mssql_tcp_peer_pin
+
+    url = "mssql+pymssql://u:p@1.1.1.1:1433/db"
+    assert _apply_mssql_tcp_peer_pin(url, ["9.9.9.9"]) == url
+
+
+def test_apply_mssql_tcp_peer_pin_unsupported_dbapi_fails_closed() -> None:
+    from connectors.sql_connector import _apply_mssql_tcp_peer_pin
+
+    with pytest.raises(ValueError, match="#1586|pymssql|pyodbc"):
+        _apply_mssql_tcp_peer_pin(
+            "mssql+adodbapi://u:p@sql.example.com:1433/db",
+            ["1.1.1.1"],
+        )
+
+
+def test_sql_mssql_pymssql_connect_rewrites_url_host_to_pin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1586 — bare mssql → pymssql; create_engine sees pin IP, not hostname."""
+    import socket
+    from urllib.parse import urlsplit
+
+    from connectors import sql_connector
+
+    host = "mssql.example.com"
+
+    def fake_getaddrinfo(name, *args, **kwargs):
+        if name == host:
+            return [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.1.1.1", 0)),
+                (
+                    socket.AF_INET6,
+                    socket.SOCK_STREAM,
+                    6,
+                    "",
+                    ("2606:4700:4700::1111", 0, 0, 0),
+                ),
+            ]
+        raise socket.gaierror(f"unexpected host {name!r}")
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr(
+        "connectors.url_guard.socket.getaddrinfo",
+        fake_getaddrinfo,
+    )
+
+    with (
+        patch.object(sql_connector, "ensure_sql_driver_available"),
+        patch.object(sql_connector, "create_engine") as mock_engine,
+    ):
+        mock_engine.return_value = MagicMock()
+        connector = sql_connector.SQLConnector(
+            {
+                "name": "mssql-pin",
+                "driver": "mssql",
+                "host": host,
+                "port": 1433,
+                "user": "u",
+                "pass": "p",
+                "database": "db",
+            },
+            scanner=MagicMock(),
+            db_manager=MagicMock(),
+        )
+        connector.connect()
+        mock_engine.assert_called_once()
+        (url,) = mock_engine.call_args.args
+        assert urlsplit(url).hostname == "1.1.1.1"
+        assert connector._dns_pin is None
+        connector.close()
+
+
+def test_sql_mssql_pyodbc_connect_pins_ip_and_tls_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1586 — pyodbc: SERVER=pin IP + HostNameInCertificate=hostname."""
+    import socket
+
+    from connectors import sql_connector
+    from sqlalchemy.engine.url import make_url
+
+    host = "mssql-odbc.example.com"
+
+    def fake_getaddrinfo(name, *args, **kwargs):
+        if name == host:
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.1.1.1", 0))]
+        raise socket.gaierror(f"unexpected host {name!r}")
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr(
+        "connectors.url_guard.socket.getaddrinfo",
+        fake_getaddrinfo,
+    )
+
+    with (
+        patch.object(sql_connector, "ensure_sql_driver_available"),
+        patch.object(sql_connector, "create_engine") as mock_engine,
+    ):
+        mock_engine.return_value = MagicMock()
+        connector = sql_connector.SQLConnector(
+            {
+                "name": "mssql-odbc-pin",
+                "driver": "mssql+pyodbc",
+                "host": host,
+                "port": 1433,
+                "user": "u",
+                "pass": "p",
+                "database": "db",
+            },
+            scanner=MagicMock(),
+            db_manager=MagicMock(),
+        )
+        connector.connect()
+        parsed = make_url(mock_engine.call_args.args[0])
+        assert parsed.host == "1.1.1.1"
+        q = {str(k).lower(): v for k, v in parsed.query.items()}
+        assert q["hostnameincertificate"] == host
+        connector.close()
+
+
+def test_sql_guard_allows_mssql_hostnameincertificate_query() -> None:
+    from connectors.sql_connector import _guard_sql_connection_url
+
+    _guard_sql_connection_url(
+        "mssql+pyodbc://x:x@1.1.1.1:1433/db?HostNameInCertificate=sql.example.com",
+        {"name": "ok"},
+    )
+
+
 def test_apply_postgres_hostaddr_pin_formats_ipv6() -> None:
     from connectors.sql_connector import _apply_postgres_hostaddr_pin
 


### PR DESCRIPTION
## Summary
- Close the validate→connect DNS rebinding window for **MSSQL** (#1586 slice E): rewrite the SQLAlchemy URL hostname to the guard-pinned IP for `mssql+pymssql` (FreeTDS) and `mssql+pyodbc`.
- For pyodbc, inject `HostNameInCertificate` with the original hostname (MS ODBC 18+ TLS) when missing; allowlist that query key (#1556).
- Fail-closed for other mssql DBAPIs on hostname targets; literal IP hosts unchanged. Does **not** close mother #1586 (Oracle thin still deferred).

## Test plan
- [x] `./scripts/quick-test.sh --path tests/test_sql_connector.py --keyword "apply_mssql or mssql_pymssql_connect or mssql_pyodbc_connect or hostnameincertificate"`
- [x] Pre-commit hooks on commit
- [x] CI green on this PR
- [x] Optional: lab smoke against real SQL Server with `mssql` / `mssql+pyodbc` hostname target